### PR TITLE
fix yazi version checker for healthcheck

### DIFF
--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -21,7 +21,7 @@ return {
     end
 
     local checker = require('vim.version')
-    if not checker.ge(semver, '0.1.5') then
+    if not checker.gt(semver, '0.1.5') then
       return vim.health.warn(
         'yazi version is too old, please upgrade to 0.1.5 or newer'
       )


### PR DESCRIPTION
The vim.version.ge method doesn't exist on nvim 0.9.5.
vim.version.gt does and it seems to do what we want here.