### PR TITLE
Fix successive renames not being handled

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -71,7 +71,7 @@ function M.yazi(path)
           utils.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
 
         for _, event in ipairs(renames) do
-          vim.api.nvim_buf_set_name(event.buffer, event.to)
+          vim.api.nvim_buf_set_name(event.bufnr, event.path.filename)
         end
       end,
     })

--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -1,0 +1,71 @@
+local plenary_path = require('plenary.path')
+local plenary_iterators = require('plenary.iterators')
+
+local function remove_trailing_slash(path)
+  if path:sub(-1) == '/' then
+    return path:sub(1, -2)
+  end
+
+  return path
+end
+
+---@class RenameableBuffer
+---@field bufnr number
+---@field original_path string
+---@field path Path
+local RenameableBuffer = {}
+RenameableBuffer.__index = RenameableBuffer
+
+---@param bufnr number
+---@param path string the original path of the buffer
+function RenameableBuffer.new(bufnr, path)
+  local self = setmetatable({}, RenameableBuffer)
+
+  path = remove_trailing_slash(path)
+
+  self.bufnr = bufnr
+  self.original_path = path
+  self.path = plenary_path:new(path)
+
+  return self
+end
+
+---@param path string can be a parent directory or an exact file path
+---@return boolean
+function RenameableBuffer:matches_exactly(path)
+  path = remove_trailing_slash(path)
+  return self.path.filename == path
+end
+
+---@param path string
+function RenameableBuffer:matches_parent(path)
+  path = remove_trailing_slash(path)
+  local found = plenary_iterators
+    .iter(self.path:parents())
+    :find(function(parent_path)
+      return path == parent_path
+    end)
+
+  return found ~= nil
+end
+
+---@param path string
+---@return nil
+function RenameableBuffer:rename(path)
+  path = remove_trailing_slash(path)
+  self.path = plenary_path:new(path)
+end
+
+---@param parent_from string the parent directory that was renamed
+---@param parent_to string the new parent directory
+---@return nil
+function RenameableBuffer:rename_parent(parent_from, parent_to)
+  local common = self.path.filename:sub(1, #parent_from)
+  local rest = self.path.filename:sub(#common + 1, -1)
+
+  local new_path = parent_to .. rest
+
+  self.path = plenary_path:new(new_path)
+end
+
+return RenameableBuffer

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -10,7 +10,3 @@
 ---@class YaziEventDataRename
 ---@field public from string
 ---@field public to string
-
----@class YaziBufferRenameInstruction
----@field buffer integer the existing buffer number that needs renaming
----@field to string the new file name that the buffer should point to

--- a/tests/yazi/example_spec.lua
+++ b/tests/yazi/example_spec.lua
@@ -19,11 +19,11 @@ describe('opening a file', function()
   end)
 
   it('opens yazi with the current file selected', function()
-    vim.api.nvim_command('edit /tmp/test-file.txt')
+    vim.api.nvim_command('edit /abc/test-file.txt')
     plugin.yazi()
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi "/tmp/test-file.txt" --local-events "rename" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
+      'yazi "/abc/test-file.txt" --local-events "rename" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
       match.is_table()
     )
   end)
@@ -41,11 +41,11 @@ describe('opening a file', function()
 
   describe("when a file is selected in yazi's chooser", function()
     -- yazi writes the selected file to this file for us to read
-    local target_file = '/tmp/test-file.txt'
+    local target_file = '/abc/test-file.txt'
 
     before_each(function()
       -- have to start editing a valid file, otherwise the plugin will ignore the callback
-      vim.cmd('edit /tmp/a.txt')
+      vim.cmd('edit /abc/a.txt')
 
       local termopen = spy.on(api_mock, 'termopen')
       termopen.callback = function(_, callback)

--- a/tests/yazi/renameable_buffer_spec.lua
+++ b/tests/yazi/renameable_buffer_spec.lua
@@ -1,0 +1,50 @@
+local RenameableBuffer = require('yazi.renameable_buffer')
+local assert = require('luassert')
+
+describe('the RenameableBuffer class', function()
+  it('matches a parent directory', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    local result = rename:matches_parent('/my-tmp/')
+    assert.is_true(result)
+  end)
+
+  it('matches a parent directory with a trailing slash', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    local result = rename:matches_parent('/my-tmp')
+    assert.is_true(result)
+  end)
+
+  it('matches an exact file path', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    local result = rename:matches_exactly('/my-tmp/file1')
+    assert.is_true(result)
+  end)
+
+  it('does not match a different parent directory', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    assert.is_false(rename:matches_exactly('/my-tmp2'))
+  end)
+
+  it('does not match a different file path', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    assert.is_false(rename:matches_exactly('/my-tmp/file2'))
+  end)
+
+  it('renames a file', function()
+    local rename = RenameableBuffer.new(1, '/my-tmp/file1')
+    rename:rename('/my-tmp/file2')
+    assert.are.equal('/my-tmp/file2', rename.path.filename)
+
+    -- does not change the original path
+    assert.are.equal('/my-tmp/file1', rename.original_path)
+  end)
+
+  it("renames the buffer's parent directory", function()
+    local buffer = RenameableBuffer.new(1, '/my-tmp/file1')
+    buffer:rename_parent('/my-tmp', '/my-tmp2')
+    assert.are.equal('/my-tmp2/file1', buffer.path.filename)
+
+    -- does not change the original path
+    assert.are.equal('/my-tmp/file1', buffer.original_path)
+  end)
+end)


### PR DESCRIPTION
In the previous implementation, renaming a file multiple times in yazi did not sync properly to nvim.

This is now fixed.