### PR TITLE
refactor(renaming): rename one file at a time, not all at once

### DIFF
--- a/lua/yazi/renaming.lua
+++ b/lua/yazi/renaming.lua
@@ -2,9 +2,9 @@ local RenameableBuffer = require('yazi.renameable_buffer')
 
 local M = {}
 
----@param rename_events YaziEventDataRename[]
+---@param rename_event YaziEventDataRename
 ---@return RenameableBuffer[] "instructions for renaming the buffers (command pattern)"
-function M.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
+function M.get_buffers_that_need_renaming_after_yazi_exited(rename_event)
   ---@type RenameableBuffer[]
   local open_buffers = {}
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
@@ -18,15 +18,14 @@ function M.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
   ---@type table<integer, RenameableBuffer>
   local renamed_buffers = {}
 
-  for _, event in ipairs(rename_events) do
-    for _, buffer in ipairs(open_buffers) do
-      if buffer:matches_exactly(event.from) then
-        buffer:rename(event.to)
-        renamed_buffers[buffer.bufnr] = buffer
-      elseif buffer:matches_parent(event.from) then
-        buffer:rename_parent(event.from, event.to)
-        renamed_buffers[buffer.bufnr] = buffer
-      end
+  local event = rename_event
+  for _, buffer in ipairs(open_buffers) do
+    if buffer:matches_exactly(event.from) then
+      buffer:rename(event.to)
+      renamed_buffers[buffer.bufnr] = buffer
+    elseif buffer:matches_parent(event.from) then
+      buffer:rename_parent(event.from, event.to)
+      renamed_buffers[buffer.bufnr] = buffer
     end
   end
 

--- a/tests/yazi/rename_spec.lua
+++ b/tests/yazi/rename_spec.lua
@@ -10,52 +10,40 @@ describe('get_buffers_that_need_renaming_after_yazi_exited', function()
   end)
 
   it('can detect renames to files whose names match exactly', function()
-    ---@type YaziEventDataRename[]
-    local rename_events = {
-      {
-        from = '/my-tmp/file1',
-        to = '/my-tmp/file2',
-      },
-      {
-        from = '/my-tmp/file_A',
-        to = '/my-tmp/file_B',
-      },
+    ---@type YaziEventDataRename
+    local rename_event = {
+      from = '/my-tmp/file1',
+      to = '/my-tmp/file2',
     }
 
-    -- simulate the buffers being opened
+    -- simulate buffers being opened
     vim.fn.bufadd('/my-tmp/file1')
     vim.fn.bufadd('/my-tmp/file_A')
 
     local rename_instructions =
-      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
+      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_event)
 
-    assert.is_equal(vim.tbl_count(rename_instructions), 2)
+    assert.is_equal(vim.tbl_count(rename_instructions), 1)
 
     local result1 = rename_instructions[1]
     assert.is_equal('/my-tmp/file2', result1.path.filename)
     assert.is_number(result1.bufnr)
-
-    local result2 = rename_instructions[2]
-    assert.is_equal('/my-tmp/file_B', result2.path.filename)
-    assert.is_number(result2.bufnr)
   end)
 
   it(
     'can detect renames to buffers open in a directory that was renamed',
     function()
-      ---@type YaziEventDataRename[]
-      local rename_events = {
-        {
-          from = '/my-tmp/dir1',
-          to = '/my-tmp/dir2',
-        },
+      ---@type YaziEventDataRename
+      local rename_event = {
+        from = '/my-tmp/dir1',
+        to = '/my-tmp/dir2',
       }
 
       -- simulate the buffer being opened
       vim.fn.bufadd('/my-tmp/dir1/file')
 
       local rename_instructions =
-        renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
+        renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_event)
 
       assert.is_equal(vim.tbl_count(rename_instructions), 1)
       local result = rename_instructions[1]
@@ -64,70 +52,18 @@ describe('get_buffers_that_need_renaming_after_yazi_exited', function()
   )
 
   it("doesn't rename a buffer that was not renamed in yazi", function()
-    ---@type YaziEventDataRename[]
-    local rename_events = {
-      {
-        from = '/my-tmp/not-opened-file',
-        to = '/my-tmp/not-opened-file-renamed',
-      },
+    ---@type YaziEventDataRename
+    local rename_event = {
+      from = '/my-tmp/not-opened-file',
+      to = '/my-tmp/not-opened-file-renamed',
     }
 
     -- simulate the buffer being opened
     vim.fn.bufadd('/my-tmp/dir1/file')
 
     local rename_instructions =
-      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
+      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_event)
 
     assert.is_equal(vim.tbl_count(rename_instructions), 0)
-  end)
-
-  it('can rename the same file multiple times', function()
-    ---@type YaziEventDataRename[]
-    local rename_events = {
-      {
-        from = '/my-tmp/file1',
-        to = '/my-tmp/file2',
-      },
-      {
-        from = '/my-tmp/file2',
-        to = '/my-tmp/file3',
-      },
-    }
-
-    -- simulate the buffers being opened
-    vim.fn.bufadd('/my-tmp/file1')
-
-    local rename_instructions =
-      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
-
-    assert.is_equal(vim.tbl_count(rename_instructions), 1)
-
-    local result = rename_instructions[1]
-    assert.is_equal('/my-tmp/file3', result.path.filename)
-    assert.is_number(result.bufnr)
-  end)
-
-  it('can rename the same directory multiple times', function()
-    ---@type YaziEventDataRename[]
-    local rename_events = {
-      {
-        from = '/my-tmp/dir1',
-        to = '/my-tmp/dir2',
-      },
-      {
-        from = '/my-tmp/dir2',
-        to = '/my-tmp/dir3',
-      },
-    }
-
-    -- simulate the buffer being opened
-    vim.fn.bufadd('/my-tmp/dir1/file')
-
-    local rename_instructions =
-      renaming.get_buffers_that_need_renaming_after_yazi_exited(rename_events)
-
-    assert.is_equal(vim.tbl_count(rename_instructions), 1)
-    local result = rename_instructions[1]
-    assert.is_equal('/my-tmp/dir3/file', result.path.filename)
   end)
 end)


### PR DESCRIPTION
This is preparation for the next step, which is to process many types of items from yazi, not just rename events.