### PR TITLE
feat: show multiple selected files in the quickfix list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Using lazy.nvim:
 
       -- when yazi was successfully closed
       yazi_closed_successfully = function(chosen_file) end,
+
+      -- when yazi opened multiple files. The default is to send them to the
+      -- quickfix list, but if you want to change that, you can define it here
+      yazi_opened_multiple_files = function(chosen_files) end,
     },
 
     -- the floating window scaling factor. 1 means 100%, 0.9 means 90%, etc.
@@ -85,5 +89,6 @@ So far I have done some maintenance work and added a bunch of features:
 - feat: health check for yazi
 - feat: files that are renamed, moved, deleted, or trashed in yazi are kept in sync with open buffers (this requires a version of yazi that includes [this](https://github.com/sxyazi/yazi/pull/880) change from 2024-04-06)
 - feat: allow customizing the method of opening the selected file in neovim
+- feat: can send multiple opened files to the quickfix list
 
 If you'd like to collaborate, contact me via GitHub issues.

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -53,10 +53,16 @@ function M.yazi(config, path)
           if
             code == 0 and utils.file_exists(config.chosen_file_path) == true
           then
-            local chosen_file = vim.fn.readfile(config.chosen_file_path)[1]
-            config.hooks.yazi_closed_successfully(chosen_file)
-            if chosen_file then
-              config.open_file_function(chosen_file)
+            local chosen_files = vim.fn.readfile(config.chosen_file_path)
+
+            if #chosen_files > 1 then
+              config.hooks.yazi_opened_multiple_files(chosen_files)
+            else
+              local chosen_file = chosen_files[1]
+              config.hooks.yazi_closed_successfully(chosen_file)
+              if chosen_file then
+                config.open_file_function(chosen_file)
+              end
             end
           end
 

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -15,6 +15,22 @@ function M.default()
       yazi_opened = function(_preselected_path) end,
       ---@diagnostic disable-next-line: unused-local
       yazi_closed_successfully = function(_chosen_file) end,
+      yazi_opened_multiple_files = function(chosen_files)
+        -- show the items it the quickfix list
+        vim.fn.setqflist({}, 'r', {
+          title = 'Yazi',
+          items = vim.tbl_map(function(file)
+            return {
+              filename = file,
+              lnum = 1,
+              text = file,
+            }
+          end, chosen_files),
+        })
+
+        -- open the quickfix window
+        vim.cmd('copen')
+      end,
     },
 
     floating_window_scaling_factor = 0.9,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -10,6 +10,7 @@
 ---@class YaziConfigHooks
 ---@field public yazi_opened? fun(preselected_path: string | nil): nil
 ---@field public yazi_closed_successfully? fun(chosen_file: string | nil): nil
+---@field public yazi_opened_multiple_files? fun(chosen_files: string[]): nil
 
 ---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent
 

--- a/tests/yazi/open_multiple_files_spec.lua
+++ b/tests/yazi/open_multiple_files_spec.lua
@@ -1,0 +1,14 @@
+describe('the default configuration', function()
+  it('can display multiple files in the quickfix list', function()
+    local config = require('yazi.config').default()
+    local chosen_files = { '/abc/test-file.txt', '/abc/test-file2.txt' }
+
+    config.hooks.yazi_opened_multiple_files(chosen_files)
+
+    local quickfix_list = vim.fn.getqflist()
+
+    assert.equals(2, #quickfix_list)
+    assert.equals('/abc/test-file.txt', quickfix_list[1].text)
+    assert.equals('/abc/test-file2.txt', quickfix_list[2].text)
+  end)
+end)


### PR DESCRIPTION
In yazi, it's possible to open one file or multiple files. Now, if a single file is opened, there is no change in behavior. However, if multiple files are opened, the quickfix list will show all the files that are opened.