### PR TITLE
fix: don't close a removed file if renamed to later

### DIFF
--- a/tests/yazi/delete_spec.lua
+++ b/tests/yazi/delete_spec.lua
@@ -20,7 +20,7 @@ describe('process_delete_event', function()
       data = { urls = { '/abc/def' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
@@ -36,7 +36,7 @@ describe('process_delete_event', function()
       data = { urls = { '/abc' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
@@ -52,8 +52,32 @@ describe('process_delete_event', function()
       data = { urls = { '/abc/ghi' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_true(vim.api.nvim_buf_is_valid(buffer))
+  end)
+
+  it("doesn't delete a buffer that was renamed to in a later event", function()
+    local buffer1 = vim.fn.bufadd('/def/file')
+
+    ---@type YaziDeleteEvent
+    local delete_event = {
+      type = 'delete',
+      timestamp = '1712766606832135',
+      id = '1712766606832135',
+      data = { urls = { '/def/file' } },
+    }
+
+    ---@type YaziRenameEvent
+    local rename_event = {
+      type = 'rename',
+      timestamp = '1712766606832135',
+      id = '1712766606832135',
+      data = { from = '/def/other-file', to = '/def/file' },
+    }
+
+    event_handling.process_delete_event(delete_event, { rename_event })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(buffer1))
   end)
 end)

--- a/tests/yazi/trash_spec.lua
+++ b/tests/yazi/trash_spec.lua
@@ -20,7 +20,7 @@ describe('process_trash_event', function()
       data = { urls = { '/abc/def' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
@@ -36,7 +36,7 @@ describe('process_trash_event', function()
       data = { urls = { '/abc' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
@@ -52,8 +52,32 @@ describe('process_trash_event', function()
       data = { urls = { '/abc/ghi' } },
     }
 
-    event_handling.process_delete_event(event)
+    event_handling.process_delete_event(event, {})
 
     assert.is_true(vim.api.nvim_buf_is_valid(buffer))
+  end)
+
+  it("doesn't delete a buffer that was renamed to in a later event", function()
+    local buffer1 = vim.fn.bufadd('/def/file')
+
+    ---@type YaziTrashEvent
+    local delete_event = {
+      type = 'trash',
+      timestamp = '1712766606832135',
+      id = '1712766606832135',
+      data = { urls = { '/def/file' } },
+    }
+
+    ---@type YaziRenameEvent
+    local rename_event = {
+      type = 'rename',
+      timestamp = '1712766606832135',
+      id = '1712766606832135',
+      data = { from = '/def/other-file', to = '/def/file' },
+    }
+
+    event_handling.process_delete_event(delete_event, { rename_event })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(buffer1))
   end)
 end)


### PR DESCRIPTION
sometimes I find myself renaming a file to a new name, and then
renaming it back to the original name. This causes the file to be
closed and then opened again, which is not necessary. This commit
fixes this issue by checking if the file is already open before
closing it.