### PR TITLE
fix!: remap default horizontal split c-s -> c-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
 These are the default keybindings that are available when yazi is open:
 
 - `<c-v>`: open the selected file in a vertical split
-- `<c-s>`: open the selected file in a horizontal split
+- `<c-x>`: open the selected file in a horizontal split
 - `<c-t>`: open the selected file in a new tab
 
 Notice that these are also the defaults for telescope.

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -34,7 +34,7 @@ function M.default_set_keymappings_function(yazi_buffer, config)
     M.select_current_file_and_close_yazi()
   end, { buffer = yazi_buffer })
 
-  vim.keymap.set({ 't' }, '<c-s>', function()
+  vim.keymap.set({ 't' }, '<c-x>', function()
     config.open_file_function = openers.open_file_in_horizontal_split
     config.hooks.yazi_opened_multiple_files = function(chosen_files)
       for _, chosen_file in ipairs(chosen_files) do


### PR DESCRIPTION
This is done to avoid overriding an existing yazi keybinding ("search none", which cancels the ongoing search)

Fixes https://github.com/mikavilpas/yazi.nvim/issues/31