### PR TITLE
fix: use explicit buffer id to ensure the behavior of 'winleave' auto…

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -24,7 +24,8 @@ function M.yazi(config, path)
 
   local prev_win = vim.api.nvim_get_current_win()
 
-  local win, _, yazi_buffer = window.open_floating_window(config)
+  local win = window.YaziFloatingWindow.new(config)
+  win:open_and_display()
 
   os.remove(config.chosen_file_path)
   local cmd = string.format(
@@ -45,15 +46,15 @@ function M.yazi(config, path)
           return
         end
 
-        utils.on_yazi_exited(prev_win, win, yazi_buffer, config)
+        utils.on_yazi_exited(prev_win, win, config)
 
         local events = utils.read_events_file(config.events_file_path)
         event_handling.process_events_emitted_from_yazi(events)
       end,
     })
 
-    config.hooks.yazi_opened(path, yazi_buffer, config)
-    config.set_keymappings_function(yazi_buffer, config)
+    config.hooks.yazi_opened(path, win.content_buffer, config)
+    config.set_keymappings_function(win.content_buffer, config)
   end
   vim.schedule(function()
     vim.cmd('startinsert')

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -175,15 +175,9 @@ function M.rename_or_close_buffer(instruction)
 end
 
 ---@param prev_win integer
----@param floating_window_id integer
----@param floating_window_buffer integer
+---@param window YaziFloatingWindow
 ---@param config YaziConfig
-function M.on_yazi_exited(
-  prev_win,
-  floating_window_id,
-  floating_window_buffer,
-  config
-)
+function M.on_yazi_exited(prev_win, window, config)
   vim.cmd('silent! :checktime')
 
   -- open the file that was chosen
@@ -191,9 +185,7 @@ function M.on_yazi_exited(
     return
   end
 
-  if vim.api.nvim_win_is_valid(floating_window_id) then
-    vim.api.nvim_win_close(floating_window_id, true)
-  end
+  window:close()
 
   vim.api.nvim_set_current_win(prev_win)
   if M.file_exists(config.chosen_file_path) == true then
@@ -208,13 +200,6 @@ function M.on_yazi_exited(
         config.open_file_function(chosen_file, config)
       end
     end
-  end
-
-  if
-    vim.api.nvim_buf_is_valid(floating_window_buffer)
-    and vim.api.nvim_buf_is_loaded(floating_window_buffer)
-  then
-    vim.api.nvim_buf_delete(floating_window_buffer, { force = true })
   end
 end
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -191,7 +191,10 @@ function M.on_yazi_exited(
     return
   end
 
-  vim.api.nvim_win_close(floating_window_id, true)
+  if vim.api.nvim_win_is_valid(floating_window_id) then
+    vim.api.nvim_win_close(floating_window_id, true)
+  end
+
   vim.api.nvim_set_current_win(prev_win)
   if M.file_exists(config.chosen_file_path) == true then
     local chosen_files = vim.fn.readfile(config.chosen_file_path)

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -96,10 +96,12 @@ function YaziFloatingWindow:open_and_display()
   vim.cmd('setlocal winhl=NormalFloat:YaziFloat')
   vim.cmd('set winblend=' .. self.config.yazi_floating_window_winblend)
 
-  -- use autocommand to ensure that the border_buffer closes at the same time as the main buffer
-  vim.cmd("autocmd WinLeave <buffer> silent! execute 'hide'")
-  local cmd = [[autocmd WinLeave <buffer> silent! execute 'silent bdelete! %s']]
-  vim.cmd(cmd:format(border_buffer))
+  vim.api.nvim_create_autocmd('WinLeave', {
+    buffer = yazi_buffer,
+    callback = function()
+      self:close()
+    end,
+  })
 
   self.win = win
   self.border_window = border_window

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -1,5 +1,113 @@
 local M = {}
 
+---@class YaziFloatingWindow
+---@field win integer floating_window_id
+---@field border_window integer
+---@field content_buffer integer
+---@field config YaziConfig
+local YaziFloatingWindow = {}
+YaziFloatingWindow.__index = YaziFloatingWindow
+
+M.YaziFloatingWindow = YaziFloatingWindow
+
+---@param config YaziConfig
+function YaziFloatingWindow.new(config)
+  local self = setmetatable({}, YaziFloatingWindow)
+
+  self.config = config
+
+  return self
+end
+
+function YaziFloatingWindow:close()
+  if
+    vim.api.nvim_buf_is_valid(self.content_buffer)
+    and vim.api.nvim_buf_is_loaded(self.content_buffer)
+  then
+    vim.api.nvim_buf_delete(self.content_buffer, { force = true })
+  end
+
+  if vim.api.nvim_win_is_valid(self.win) then
+    vim.api.nvim_win_close(self.win, true)
+  end
+
+  if vim.api.nvim_win_is_valid(self.border_window) then
+    vim.api.nvim_win_close(self.border_window, true)
+  end
+end
+
+function YaziFloatingWindow:open_and_display()
+  local height = math.ceil(
+    vim.o.lines * self.config.floating_window_scaling_factor
+  ) - 1
+  local width =
+    math.ceil(vim.o.columns * self.config.floating_window_scaling_factor)
+
+  local row = math.ceil(vim.o.lines - height) / 2
+  local col = math.ceil(vim.o.columns - width) / 2
+
+  local border_opts = {
+    style = 'minimal',
+    relative = 'editor',
+    row = row - 1,
+    col = col - 1,
+    width = width + 2,
+    height = height + 2,
+  }
+
+  local opts = {
+    style = 'minimal',
+    relative = 'editor',
+    row = row,
+    col = col,
+    width = width,
+    height = height,
+  }
+
+  local topleft, top, topright, right, botright, bot, botleft, left =
+    '╭', '─', '╮', '│', '╯', '─', '╰', '│'
+
+  local border_lines = { topleft .. string.rep(top, width) .. topright }
+  local middle_line = left .. string.rep(' ', width) .. right
+  for _ = 1, height do
+    table.insert(border_lines, middle_line)
+  end
+  table.insert(border_lines, botleft .. string.rep(bot, width) .. botright)
+
+  -- create a unlisted scratch buffer for the border
+  local border_buffer = vim.api.nvim_create_buf(false, true)
+
+  -- set border_lines in the border buffer from start 0 to end -1 and strict_indexing false
+  vim.api.nvim_buf_set_lines(border_buffer, 0, -1, true, border_lines)
+  -- create border window
+  local border_window = vim.api.nvim_open_win(border_buffer, true, border_opts)
+  vim.api.nvim_set_hl(0, 'YaziBorder', { link = 'Normal', default = true })
+  vim.cmd('set winhl=NormalFloat:YaziBorder')
+
+  local yazi_buffer = vim.api.nvim_create_buf(false, true)
+  -- create file window, enter the window, and use the options defined in opts
+  local win = vim.api.nvim_open_win(yazi_buffer, true, opts)
+
+  vim.bo[yazi_buffer].filetype = 'yazi'
+
+  vim.cmd('setlocal bufhidden=hide')
+  vim.cmd('setlocal nocursorcolumn')
+  vim.api.nvim_set_hl(0, 'YaziFloat', { link = 'Normal', default = true })
+  vim.cmd('setlocal winhl=NormalFloat:YaziFloat')
+  vim.cmd('set winblend=' .. self.config.yazi_floating_window_winblend)
+
+  -- use autocommand to ensure that the border_buffer closes at the same time as the main buffer
+  vim.cmd("autocmd WinLeave <buffer> silent! execute 'hide'")
+  local cmd = [[autocmd WinLeave <buffer> silent! execute 'silent bdelete! %s']]
+  vim.cmd(cmd:format(border_buffer))
+
+  self.win = win
+  self.border_window = border_window
+  self.content_buffer = yazi_buffer
+
+  return self
+end
+
 --- open a floating window with nice borders
 ---@param config YaziConfig
 ---@return integer, integer, integer
@@ -63,9 +171,8 @@ function M.open_floating_window(config)
 
   -- use autocommand to ensure that the border_buffer closes at the same time as the main buffer
   vim.cmd("autocmd WinLeave <buffer> silent! execute 'hide'")
-  local cmd =
-    [[autocmd WinLeave <buffer=%d> silent! execute 'silent bdelete! %d']]
-  vim.cmd(cmd:format(border_buffer, border_buffer))
+  local cmd = [[autocmd WinLeave <buffer> silent! execute 'silent bdelete! %s']]
+  vim.cmd(cmd:format(border_buffer))
 
   return win, border_window, yazi_buffer
 end

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -63,8 +63,9 @@ function M.open_floating_window(config)
 
   -- use autocommand to ensure that the border_buffer closes at the same time as the main buffer
   vim.cmd("autocmd WinLeave <buffer> silent! execute 'hide'")
-  local cmd = [[autocmd WinLeave <buffer> silent! execute 'silent bdelete! %s']]
-  vim.cmd(cmd:format(border_buffer))
+  local cmd =
+    [[autocmd WinLeave <buffer=%d> silent! execute 'silent bdelete! %d']]
+  vim.cmd(cmd:format(border_buffer, border_buffer))
 
   return win, border_window, yazi_buffer
 end


### PR DESCRIPTION
mainly fixes #36 

in my case, there are two problems i met: 
* the first one is when i call open method the first time, after i choosen the file, the border window won't close, a screenshot is attached below; 
* and the second one is the the same as the issue i created, the border window is closed unexpectedly before we call nvim_win_close. i am not sure why this is happening, but add a check to avoid it.

![图片](https://github.com/mikavilpas/yazi.nvim/assets/9302617/2485a418-3e71-4fc3-8c64-85ef2451052f)
