### PR TITLE
fix: opening many files with custom keymappings causing an error

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -8,7 +8,6 @@ local M = {}
 
 M.yazi_loaded = false
 
---- :Yazi entry point
 ---@param config? YaziConfig?
 ---@param path? string
 ---@diagnostic disable-next-line: redefined-local
@@ -18,7 +17,8 @@ function M.yazi(config, path)
     return
   end
 
-  config = vim.tbl_deep_extend('force', M.config, config or {})
+  config =
+    vim.tbl_deep_extend('force', configModule.default(), M.config, config or {})
 
   path = utils.selected_file_path(path)
 
@@ -65,7 +65,8 @@ M.config = configModule.default()
 
 ---@param opts YaziConfig?
 function M.setup(opts)
-  M.config = vim.tbl_deep_extend('force', M.config, opts or {})
+  M.config =
+    vim.tbl_deep_extend('force', configModule.default(), M.config, opts or {})
 
   if M.config.open_for_directories == true then
     local yazi_augroup = vim.api.nvim_create_augroup('yazi', { clear = true })


### PR DESCRIPTION
The error was tricky to reproduce. Here's what happened:
- open yazi
- select multiple files with space or c-a
- pressing enter will send them to the quickfix list
- alternatively, pressing e.g. c-v can open them in vertical splits
- the next time you opened yazi, the keymappings were not properly reset, causing opening many files with enter not to be sent to the quickfix list, but to be opened in vertical splits

The error was caused by the fact that the config was modified in the keymappings, but not properly reset on the next opening of yazi.