### PR TITLE
Request lsp help when renaming and deleting files

### DIFF
--- a/lua/yazi/event_handling.lua
+++ b/lua/yazi/event_handling.lua
@@ -1,5 +1,6 @@
 local utils = require('yazi.utils')
 local plenaryIterators = require('plenary.iterators')
+local lsp_delete = require('yazi.lsp.delete')
 
 local M = {}
 
@@ -24,6 +25,7 @@ function M.process_delete_event(event, remaining_events)
           break
         else
           vim.api.nvim_buf_delete(buffer.bufnr, { force = false })
+          lsp_delete.file_deleted(buffer.path.filename)
         end
       end
     end

--- a/lua/yazi/lsp/delete.lua
+++ b/lua/yazi/lsp/delete.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+---@param path string
+local function notify_file_was_deleted(path)
+  -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willDeleteFiles
+  local method = 'workspace/willDeleteFiles'
+
+  local clients = vim.lsp.get_clients({
+    method = method,
+    bufnr = vim.api.nvim_get_current_buf(),
+  })
+
+  for _, client in ipairs(clients) do
+    local resp = client.request_sync(method, {
+      files = {
+        {
+          uri = vim.uri_from_fname(path),
+        },
+      },
+    }, 1000, 0)
+
+    if resp and resp.result ~= nil then
+      vim.lsp.util.apply_workspace_edit(resp.result, client.offset_encoding)
+    end
+  end
+end
+
+---@param path string
+local function notify_delete_complete(path)
+  -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didDeleteFiles
+  local method = 'workspace/didDeleteFiles'
+
+  local clients = vim.lsp.get_clients({
+    method = method,
+    bufnr = vim.api.nvim_get_current_buf(),
+  })
+
+  for _, client in ipairs(clients) do
+    -- NOTE: this returns nothing, so no need to do anything with the response
+    client.request_sync(method, {
+      files = {
+        {
+          uri = vim.uri_from_fname(path),
+        },
+      },
+    }, 1000, 0)
+  end
+end
+
+-- Send a notification to LSP servers, letting them know that yazi just deleted some files
+---@param path string
+function M.file_deleted(path)
+  notify_file_was_deleted(path)
+  notify_delete_complete(path)
+end
+
+return M

--- a/lua/yazi/lsp/delete.lua
+++ b/lua/yazi/lsp/delete.lua
@@ -1,3 +1,5 @@
+local lsp_util = require('yazi.lsp.lsp_util')
+
 local M = {}
 
 ---@param path string
@@ -5,10 +7,7 @@ local function notify_file_was_deleted(path)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willDeleteFiles
   local method = 'workspace/willDeleteFiles'
 
-  local clients = vim.lsp.get_clients({
-    method = method,
-    bufnr = vim.api.nvim_get_current_buf(),
-  })
+  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
 
   for _, client in ipairs(clients) do
     local resp = client.request_sync(method, {
@@ -30,10 +29,7 @@ local function notify_delete_complete(path)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didDeleteFiles
   local method = 'workspace/didDeleteFiles'
 
-  local clients = vim.lsp.get_clients({
-    method = method,
-    bufnr = vim.api.nvim_get_current_buf(),
-  })
+  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
 
   for _, client in ipairs(clients) do
     -- NOTE: this returns nothing, so no need to do anything with the response

--- a/lua/yazi/lsp/lsp_util.lua
+++ b/lua/yazi/lsp/lsp_util.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+-- For nvim 0.9 compatibility
+---@param lsp_method string
+---@param bufnr number
+function M.get_clients(lsp_method, bufnr)
+  -- TODO remove this when we drop support for nvim 0.9
+
+  ---@diagnostic disable-next-line: deprecated - but needed for compatibility
+  local clients = vim.lsp.get_active_clients({ bufnr = bufnr })
+  return vim.tbl_filter(function(client)
+    return client.supports_method(lsp_method, { bufnr = bufnr })
+  end, clients)
+end
+
+return M

--- a/lua/yazi/lsp/rename.lua
+++ b/lua/yazi/lsp/rename.lua
@@ -1,0 +1,60 @@
+local M = {}
+
+---@param from string
+---@param to string
+local function notify_file_was_renamed(from, to)
+  -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
+  local method = 'workspace/willRenameFiles'
+
+  local clients = vim.lsp.get_clients({
+    method = method,
+    bufnr = vim.api.nvim_get_current_buf(),
+  })
+
+  for _, client in ipairs(clients) do
+    local resp = client.request_sync(method, {
+      files = {
+        {
+          oldUri = vim.uri_from_fname(from),
+          newUri = vim.uri_from_fname(to),
+        },
+      },
+    }, 1000, 0)
+
+    if resp and resp.result ~= nil then
+      vim.lsp.util.apply_workspace_edit(resp.result, client.offset_encoding)
+    end
+  end
+end
+
+---@param from string
+---@param to string
+local function notify_rename_complete(from, to)
+  -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles
+  local method = 'workspace/didRenameFiles'
+
+  local clients = vim.lsp.get_clients({
+    method = method,
+    bufnr = vim.api.nvim_get_current_buf(),
+  })
+
+  for _, client in ipairs(clients) do
+    -- NOTE: this returns nothing, so no need to do anything with the response
+    client.request_sync(method, {
+      files = {
+        oldUri = vim.uri_from_fname(from),
+        newUri = vim.uri_from_fname(to),
+      },
+    }, 1000, 0)
+  end
+end
+
+-- Send a notification to LSP servers, letting them know that yazi just renamed some files
+---@param from string
+---@param to string
+function M.file_renamed(from, to)
+  notify_file_was_renamed(from, to)
+  notify_rename_complete(from, to)
+end
+
+return M

--- a/lua/yazi/lsp/rename.lua
+++ b/lua/yazi/lsp/rename.lua
@@ -1,3 +1,5 @@
+local lsp_util = require('yazi.lsp.lsp_util')
+
 local M = {}
 
 ---@param from string
@@ -6,10 +8,7 @@ local function notify_file_was_renamed(from, to)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
   local method = 'workspace/willRenameFiles'
 
-  local clients = vim.lsp.get_clients({
-    method = method,
-    bufnr = vim.api.nvim_get_current_buf(),
-  })
+  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
 
   for _, client in ipairs(clients) do
     local resp = client.request_sync(method, {
@@ -33,10 +32,7 @@ local function notify_rename_complete(from, to)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles
   local method = 'workspace/didRenameFiles'
 
-  local clients = vim.lsp.get_clients({
-    method = method,
-    bufnr = vim.api.nvim_get_current_buf(),
-  })
+  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
 
   for _, client in ipairs(clients) do
     -- NOTE: this returns nothing, so no need to do anything with the response

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -1,5 +1,6 @@
 local fn = vim.fn
 local RenameableBuffer = require('yazi.renameable_buffer')
+local lsp_rename = require('yazi.lsp.rename')
 
 local M = {}
 
@@ -172,6 +173,8 @@ function M.rename_or_close_buffer(instruction)
   else
     vim.api.nvim_buf_set_name(instruction.bufnr, instruction.path.filename)
   end
+
+  lsp_rename.file_renamed(instruction.original_path, instruction.path.filename)
 end
 
 ---@param prev_win integer

--- a/tests/yazi/lsp_delete_spec.lua
+++ b/tests/yazi/lsp_delete_spec.lua
@@ -1,0 +1,14 @@
+local luassert = require('luassert')
+local lsp_delete = require('yazi.lsp.delete')
+
+describe('renaming files with LSP support', function()
+  -- It's pretty hard to test this as it would require a running LSP server.
+  -- There are some examples of this, e.g.
+  -- https://github.com/pmizio/typescript-tools.nvim/blob/master/tests/editor_spec.lua
+  --
+  -- Maybe more testing could be added later.
+  it('does nothing if no LSP is running', function()
+    local result = lsp_delete.file_deleted('test-file.txt')
+    luassert.is_nil(result)
+  end)
+end)

--- a/tests/yazi/lsp_rename_spec.lua
+++ b/tests/yazi/lsp_rename_spec.lua
@@ -1,0 +1,14 @@
+local luassert = require('luassert')
+local lsp_rename = require('yazi.lsp.rename')
+
+describe('renaming files with LSP support', function()
+  -- It's pretty hard to test this as it would require a running LSP server.
+  -- There are some examples of this, e.g.
+  -- https://github.com/pmizio/typescript-tools.nvim/blob/master/tests/editor_spec.lua
+  --
+  -- Maybe more testing could be added later.
+  it('does nothing if no LSP is running', function()
+    local result = lsp_rename.file_renamed('test-file.txt', 'test-file2.txt')
+    luassert.is_nil(result)
+  end)
+end)


### PR DESCRIPTION
feat(lsp): apply changes to related files when a file is renamed

Previously the language server could easily get out of sync when a file
was renamed in yazi. The language server would e.g. have import
statements that referenced the old file name.

This feature only applies when a language server is running and the
server has support for renaming. What now happens is:

- neovim is open and a language server is running
- neovim opens yazi
- yazi renames (or moves) a file that's part of the current workspace
- yazi is closed
- neovim sends a request to the language server to rename the file
- the language server responds with a list of changes to other files
- neovim applies those changes to the other files but doesn't save
  changes automatically (at least not for me)

I tested this in a typescript project as well as two rust projects.
Everything worked nicely.

---

the same thing for the delete operation, except I don't know how to test that at this time.