### PR TITLE
fix(lsp): only notifying lsp of renames for open buffers

### DIFF
--- a/lua/yazi/event_handling.lua
+++ b/lua/yazi/event_handling.lua
@@ -1,6 +1,7 @@
 local utils = require('yazi.utils')
 local plenaryIterators = require('plenary.iterators')
 local lsp_delete = require('yazi.lsp.delete')
+local lsp_rename = require('yazi.lsp.rename')
 
 local M = {}
 
@@ -63,6 +64,8 @@ function M.process_events_emitted_from_yazi(events)
   for i, event in ipairs(events) do
     if event.type == 'rename' then
       ---@cast event YaziRenameEvent
+      lsp_rename.file_renamed(event.data.from, event.data.to)
+
       local rename_instructions =
         M.get_buffers_that_need_renaming_after_yazi_exited(event.data)
       for _, instruction in ipairs(rename_instructions) do
@@ -71,6 +74,8 @@ function M.process_events_emitted_from_yazi(events)
     elseif event.type == 'move' then
       ---@cast event YaziMoveEvent
       for _, item in ipairs(event.data.items) do
+        lsp_rename.file_renamed(item.from, item.to)
+
         local rename_instructions =
           M.get_buffers_that_need_renaming_after_yazi_exited(item)
         for _, instruction in ipairs(rename_instructions) do

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -1,6 +1,5 @@
 local fn = vim.fn
 local RenameableBuffer = require('yazi.renameable_buffer')
-local lsp_rename = require('yazi.lsp.rename')
 
 local M = {}
 
@@ -173,8 +172,6 @@ function M.rename_or_close_buffer(instruction)
   else
     vim.api.nvim_buf_set_name(instruction.bufnr, instruction.path.filename)
   end
-
-  lsp_rename.file_renamed(instruction.original_path, instruction.path.filename)
 end
 
 ---@param prev_win integer


### PR DESCRIPTION
This fixes an error in the following case:

- in a directory containing many files, have only one file open in neovim (with other files in the directory not open)
- open yazi
- rename the directory containing the files

At this point, the LSP server would receive a notification of the rename only for the file that was open in neovim, and not for the other files in the directory. This would cause the LSP server to only apply changes related to the one open file.