### PR TITLE
feat: warn when the yazi version is too old

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -42,7 +42,9 @@ function M.yazi(config, path)
       on_exit = function(_job_id, code, _event)
         M.yazi_loaded = false
         if code ~= 0 then
-          print('yazi exited with code', code)
+          print(
+            "yazi.nvim: had trouble opening yazi. Run ':checkhealth yazi' for more information."
+          )
           return
         end
 

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -27,6 +27,13 @@ return {
       )
     end
 
+    local yazi_help = vim.fn.system('yazi --help')
+    if not yazi_help:find('--local-events', 1, true) then
+      vim.health.warn(
+        'The yazi version does not support --local-events. Please upgrade to the newest version of yazi.'
+      )
+    end
+
     vim.health.ok('yazi')
   end,
 }


### PR DESCRIPTION
Fixes https://github.com/mikavilpas/yazi.nvim/issues/32

Note: I could have added support for a yazi version without --local-events support, but I think it's much better to point the user to upgrade their yazi version instead so that they also get other fixes and features with the new yazi version.