### PR TITLE
fix(lsp): renaming only notified the lsp for the current file

### DIFF
--- a/lua/yazi/lsp/lsp_util.lua
+++ b/lua/yazi/lsp/lsp_util.lua
@@ -2,14 +2,13 @@ local M = {}
 
 -- For nvim 0.9 compatibility
 ---@param lsp_method string
----@param bufnr number
-function M.get_clients(lsp_method, bufnr)
+function M.get_clients(lsp_method)
   -- TODO remove this when we drop support for nvim 0.9
 
   ---@diagnostic disable-next-line: deprecated - but needed for compatibility
-  local clients = vim.lsp.get_active_clients({ bufnr = bufnr })
+  local clients = vim.lsp.get_active_clients()
   return vim.tbl_filter(function(client)
-    return client.supports_method(lsp_method, { bufnr = bufnr })
+    return client.supports_method(lsp_method)
   end, clients)
 end
 

--- a/lua/yazi/lsp/rename.lua
+++ b/lua/yazi/lsp/rename.lua
@@ -8,7 +8,7 @@ local function notify_file_was_renamed(from, to)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles
   local method = 'workspace/willRenameFiles'
 
-  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
+  local clients = lsp_util.get_clients(method)
 
   for _, client in ipairs(clients) do
     local resp = client.request_sync(method, {
@@ -32,7 +32,7 @@ local function notify_rename_complete(from, to)
   -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles
   local method = 'workspace/didRenameFiles'
 
-  local clients = lsp_util.get_clients(method, vim.api.nvim_get_current_buf())
+  local clients = lsp_util.get_clients(method)
 
   for _, client in ipairs(clients) do
     -- NOTE: this returns nothing, so no need to do anything with the response


### PR DESCRIPTION
In projects where there are many types of files, such as readme files (markdown) and code files (let's say, typescript), there was an inconvenience that the currently active lsp servers would not be notified unless they were connected to the current buffer.

That means that if you were editing a markdown file and wanted to rename a typescript file using yazi, the lsp server for typescript would not be notified of the rename.