### PR TITLE
feat!: require yazi version 0.2.5 (previously required 0.2.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           # Install yazi
           test -d _yazi || {
             mkdir -p _yazi
-            wget "https://github.com/sxyazi/yazi/releases/download/v0.2.4/yazi-x86_64-unknown-linux-gnu.zip" --output-document yazi.zip
+            wget "https://github.com/sxyazi/yazi/releases/download/v0.2.5/yazi-x86_64-unknown-linux-gnu.zip" --output-document yazi.zip
             unzip yazi.zip -d _yazi
           }
           echo "Current _yazi/ contents"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ open yazi in a floating window in Neovim.
 First, make sure you have the requirements:
 
 - Neovim 0.9.x or later
-- yazi 0.2.4 or later. For the best experience, use a version released after
-  2024-04-06 that includes [this](https://github.com/sxyazi/yazi/pull/880)
-  change
+- yazi [0.2.5](https://github.com/sxyazi/yazi/releases/tag/v0.2.5) or later
 
 > You can run `:checkhealth yazi` to see if compatible versions are installed
 > and working.

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -21,9 +21,9 @@ return {
     end
 
     local checker = require('vim.version')
-    if not checker.gt(semver, '0.2.3') then
+    if not checker.gt(semver, '0.2.4') then
       return vim.health.warn(
-        'yazi version is too old, please upgrade to 0.2.4 or newer'
+        'yazi version is too old, please upgrade to 0.2.5 or newer'
       )
     end
 


### PR DESCRIPTION
The check is not enforced, so using 0.2.4 should still work. However, the latest version of yazi is supported right now.