### PR TITLE
Remove curly braces in lazy.nvim instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
       function()
         require("yazi").yazi()
       end,
-      { desc = "Open the file manager" },
+      desc = "Open the file manager",
     },
   },
   ---@type YaziConfig


### PR DESCRIPTION
The curly braces surrounding `desc` in the instructions to install using `lazy.nvim` should be removed.