### PR TITLE
fix: not being able to open yazi for directories

### DIFF
--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -71,13 +71,6 @@ function YaziFloatingWindow:open_and_display()
   vim.cmd('setlocal winhl=NormalFloat:YaziFloat')
   vim.cmd('set winblend=' .. self.config.yazi_floating_window_winblend)
 
-  vim.api.nvim_create_autocmd({ 'WinLeave', 'TermLeave' }, {
-    buffer = yazi_buffer,
-    callback = function()
-      self:close()
-    end,
-  })
-
   if self.config.enable_mouse_support == true then
     self:add_hacky_mouse_support(yazi_buffer)
   end


### PR DESCRIPTION
...from a yazi session. It seemed to close the window twice, which caused some issues (not sure why).

Looks like this was accidentally broken when I added experimental support for scrolling in
https://github.com/mikavilpas/yazi.nvim/issues/49

Should be fixed now.