### PR TITLE
feat: can open a directory from the command line

### DIFF
--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -44,3 +44,12 @@
 ---@field public timestamp string
 ---@field public id string
 ---@field public data {urls: string[]}
+
+---@class yazi.AutoCmdEvent # the nvim_create_autocmd() event object copied from the nvim help docs
+---@field public id number
+---@field public event string
+---@field public group number | nil
+---@field public match string
+---@field public buf number
+---@field public file string
+---@field public data any


### PR DESCRIPTION
When starting neovim from the command line, yazi would not open. E.g. `nvim .` would not open yazi. This commit adds the ability to open yazi from the command line.

This might also be supported in other plugins the user may have. I had to disable the functionality in `neo-tree.nvim` to get this to work.

```lua
{
  "nvim-neo-tree/neo-tree.nvim",
  opts = {
    filesystem = {
      hijack_netrw_behavior = "disabled",
    },
  },
}
```

See:
https://github.com/mikavilpas/dotfiles/commit/3b5bc69917ee7e808eef0fc9734693d0141ea474#diff-8be1bcf06549d609352b9b2f97e7ceb027155091fe4067d0e9e70e1dee85ed04R36

Fixes #55 