### PR TITLE
fix: complex character file name resolution for multiple files

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -30,7 +30,7 @@ function M.yazi(config, path)
   os.remove(config.chosen_file_path)
   local cmd = string.format(
     'yazi "%s" --local-events "rename,delete,trash,move" --chooser-file "%s" > %s',
-    path,
+    vim.fn.fnameescape(path),
     config.chosen_file_path,
     config.events_file_path
   )

--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -2,22 +2,22 @@ local M = {}
 
 ---@param chosen_file string
 function M.open_file(chosen_file)
-  vim.cmd(string.format('edit %s', chosen_file))
+  vim.cmd(string.format('edit %s', vim.fn.fnameescape(chosen_file)))
 end
 
 ---@param chosen_file string
 function M.open_file_in_vertical_split(chosen_file)
-  vim.cmd(string.format('vsplit %s', chosen_file))
+  vim.cmd(string.format('vsplit %s', vim.fn.fnameescape(chosen_file)))
 end
 
 ---@param chosen_file string
 function M.open_file_in_horizontal_split(chosen_file)
-  vim.cmd(string.format('split %s', chosen_file))
+  vim.cmd(string.format('split %s', vim.fn.fnameescape(chosen_file)))
 end
 
 ---@param chosen_file string
 function M.open_file_in_tab(chosen_file)
-  vim.cmd(string.format('tabedit %s', chosen_file))
+  vim.cmd(string.format('tabedit %s', vim.fn.fnameescape(chosen_file)))
 end
 
 ---@param chosen_files string[]

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -197,8 +197,7 @@ function M.on_yazi_exited(prev_win, window, config)
       local chosen_file = chosen_files[1]
       config.hooks.yazi_closed_successfully(chosen_file, config)
       if chosen_file then
-        local path = vim.fn.fnameescape(chosen_file)
-        config.open_file_function(path, config)
+        config.open_file_function(chosen_file, config)
       end
     end
   end

--- a/tests/yazi/open_multiple_files_spec.lua
+++ b/tests/yazi/open_multiple_files_spec.lua
@@ -1,14 +1,22 @@
 describe('the default configuration', function()
+  before_each(function()
+    -- clear all buffers
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
   it('can display multiple files in the quickfix list', function()
     local config = require('yazi.config').default()
-    local chosen_files = { '/abc/test-file.txt', '/abc/test-file2.txt' }
+    -- include problematic characters in the file names to preserve their behaviour
+    local chosen_files = { '/abc/test-$@file.txt', '/abc/test-file2.txt' }
 
     config.hooks.yazi_opened_multiple_files(chosen_files, config)
 
     local quickfix_list = vim.fn.getqflist()
 
     assert.equals(2, #quickfix_list)
-    assert.equals('/abc/test-file.txt', quickfix_list[1].text)
+    assert.equals('/abc/test-$@file.txt', quickfix_list[1].text)
     assert.equals('/abc/test-file2.txt', quickfix_list[2].text)
   end)
 end)

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -34,11 +34,11 @@ describe('opening a file', function()
   end
 
   it('opens yazi with the current file selected', function()
-    vim.api.nvim_command('edit /abc/test-file-1.txt')
+    vim.api.nvim_command('edit ' .. vim.fn.fnameescape('/abc/test-file-$1.txt'))
     plugin.yazi()
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi "/abc/test-file-1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
+      'yazi "/abc/test-file-\\$1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
       match.is_table()
     )
   end)


### PR DESCRIPTION
This also fixes an issue where the currently open file would not get preselected when yazi was opened when the file had complex characters such as '$' in it.

related to #60 #61 