### PR TITLE
refactor: use unique temp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,6 @@ You can optionally configure yazi.nvim by setting any of the options below.
     -- the transparency of the yazi floating window (0-100). See :h winblend
     yazi_floating_window_winblend = 0,
 
-    -- the path to a temporary file that will be created by yazi to store the
-    -- chosen file path. This is used internally but you might want to change
-    -- it if there are issues accessing the default path.
-    chosen_file_path = '/tmp/yazi_filechosen',
-
     -- what Neovim should do a when a file was opened (selected) in yazi.
     -- Defaults to simply opening the file.
     open_file_function = function(chosen_file, config) end,

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ open yazi in a floating window in Neovim.
 ## ✨ Features
 
 - Open yazi in a floating window
-- Files can be opened in the current buffer, a vertical split, a horizontal
-  split, or a new tab
+- Files can be selected in yazi and opened in the current buffer, a vertical
+  split, a horizontal split, or a new tab
 - If multiple files are selected, they can be sent to the quickfix list
 - (optionally) open yazi instead of netrw for directories
 - Files that are renamed, moved, or deleted in yazi are kept in sync with open

--- a/README.md
+++ b/README.md
@@ -101,10 +101,6 @@ You can optionally configure yazi.nvim by setting any of the options below.
     -- it if there are issues accessing the default path.
     chosen_file_path = '/tmp/yazi_filechosen',
 
-    -- the path to a temporary file that will be created by yazi to store
-    -- events
-    events_file_path = '/tmp/yazi.nvim.events.txt',
-
     -- what Neovim should do a when a file was opened (selected) in yazi.
     -- Defaults to simply opening the file.
     open_file_function = function(chosen_file, config) end,

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -24,6 +24,7 @@ function M.yazi(config, path)
 
   local prev_win = vim.api.nvim_get_current_win()
 
+  config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
   config.events_file_path = config.events_file_path or vim.fn.tempname()
 
   local win = window.YaziFloatingWindow.new(config)

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -24,6 +24,8 @@ function M.yazi(config, path)
 
   local prev_win = vim.api.nvim_get_current_win()
 
+  config.events_file_path = config.events_file_path or vim.fn.tempname()
+
   local win = window.YaziFloatingWindow.new(config)
   win:open_and_display()
 

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -6,7 +6,6 @@ function M.default()
   ---@type YaziConfig
   return {
     open_for_directories = false,
-    chosen_file_path = '/tmp/yazi_filechosen',
     enable_mouse_support = false,
     open_file_function = openers.open_file,
     set_keymappings_function = M.default_set_keymappings_function,

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -7,7 +7,6 @@ function M.default()
   return {
     open_for_directories = false,
     chosen_file_path = '/tmp/yazi_filechosen',
-    events_file_path = '/tmp/yazi.nvim.events.txt',
     enable_mouse_support = false,
     open_file_function = openers.open_file,
     set_keymappings_function = M.default_set_keymappings_function,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -1,7 +1,7 @@
 ---@class YaziConfig
 ---@field public open_for_directories? boolean
 ---@field public chosen_file_path? string "the path to a temporary file that will be created by yazi to store the chosen file path"
----@field public events_file_path? string "the path to a temporary file that will be created by yazi to store events"
+---@field public events_file_path? string "the path to a temporary file that will be created by yazi to store events. A random path will be used by default"
 ---@field public enable_mouse_support? boolean
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig): nil "a function that will be called when a file is chosen in yazi"
 ---@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig): nil "the function that will set the keymappings for the yazi floating window. It will be called after the floating window is created."

--- a/tests/yazi/open_dir_spec.lua
+++ b/tests/yazi/open_dir_spec.lua
@@ -9,7 +9,10 @@ local plugin = require('yazi')
 describe('when the user set open_for_directories = true', function()
   before_each(function()
     ---@diagnostic disable-next-line: missing-fields
-    plugin.setup({ open_for_directories = true })
+    plugin.setup({
+      open_for_directories = true,
+      events_file_path = '/tmp/yazi.nvim.events.txt',
+    })
   end)
 
   after_each(function()

--- a/tests/yazi/open_dir_spec.lua
+++ b/tests/yazi/open_dir_spec.lua
@@ -11,6 +11,7 @@ describe('when the user set open_for_directories = true', function()
     ---@diagnostic disable-next-line: missing-fields
     plugin.setup({
       open_for_directories = true,
+      chosen_file_path = '/tmp/yazi_filechosen',
       events_file_path = '/tmp/yazi.nvim.events.txt',
     })
   end)

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -35,7 +35,7 @@ describe('opening a file', function()
 
   it('opens yazi with the current file selected', function()
     vim.api.nvim_command('edit ' .. vim.fn.fnameescape('/abc/test-file-$1.txt'))
-    plugin.yazi()
+    plugin.yazi({ events_file_path = '/tmp/yazi.nvim.events.txt' })
 
     assert.stub(api_mock.termopen).was_called_with(
       'yazi "/abc/test-file-\\$1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
@@ -46,7 +46,7 @@ describe('opening a file', function()
   it('opens yazi with the current directory selected', function()
     vim.api.nvim_command('edit /tmp/')
 
-    plugin.yazi()
+    plugin.yazi({ events_file_path = '/tmp/yazi.nvim.events.txt' })
 
     assert.stub(api_mock.termopen).was_called_with(
       'yazi "/tmp/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -35,7 +35,10 @@ describe('opening a file', function()
 
   it('opens yazi with the current file selected', function()
     vim.api.nvim_command('edit ' .. vim.fn.fnameescape('/abc/test-file-$1.txt'))
-    plugin.yazi({ events_file_path = '/tmp/yazi.nvim.events.txt' })
+    plugin.yazi({
+      chosen_file_path = '/tmp/yazi_filechosen',
+      events_file_path = '/tmp/yazi.nvim.events.txt',
+    })
 
     assert.stub(api_mock.termopen).was_called_with(
       'yazi "/abc/test-file-\\$1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
@@ -46,7 +49,10 @@ describe('opening a file', function()
   it('opens yazi with the current directory selected', function()
     vim.api.nvim_command('edit /tmp/')
 
-    plugin.yazi({ events_file_path = '/tmp/yazi.nvim.events.txt' })
+    plugin.yazi({
+      chosen_file_path = '/tmp/yazi_filechosen',
+      events_file_path = '/tmp/yazi.nvim.events.txt',
+    })
 
     assert.stub(api_mock.termopen).was_called_with(
       'yazi "/tmp/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
@@ -58,7 +64,10 @@ describe('opening a file', function()
     it('opens the file that the user selected in yazi', function()
       local target_file = '/abc/test-file.txt'
       setup_fake_yazi_opens_file(target_file)
-      plugin.yazi({ set_keymappings_function = function() end })
+      plugin.yazi({
+        chosen_file_path = '/tmp/yazi_filechosen',
+        set_keymappings_function = function() end,
+      })
 
       assert.equals(target_file, vim.fn.expand('%'))
     end)
@@ -68,7 +77,10 @@ describe('opening a file', function()
       local target_file = 'routes/posts.$postId/route.tsx'
       setup_fake_yazi_opens_file(target_file)
 
-      plugin.yazi({ set_keymappings_function = function() end })
+      plugin.yazi({
+        chosen_file_path = '/tmp/yazi_filechosen',
+        set_keymappings_function = function() end,
+      })
 
       assert.equals(target_file, vim.fn.expand('%'))
     end)
@@ -86,6 +98,7 @@ describe('opening a file', function()
       vim.api.nvim_command('edit /abc/test-file.txt')
 
       plugin.yazi({
+        chosen_file_path = '/tmp/yazi_filechosen',
         set_keymappings_function = function() end,
         ---@diagnostic disable-next-line: missing-fields
         hooks = {
@@ -127,6 +140,7 @@ describe('opening a file', function()
     vim.api.nvim_command('edit ' .. target_file)
 
     plugin.yazi({
+      chosen_file_path = '/tmp/yazi_filechosen',
       set_keymappings_function = function() end,
       ---@diagnostic disable-next-line: assign-type-mismatch
       open_file_function = spy_open_file_function,


### PR DESCRIPTION
This mainly helps with developing the plugin by preventing conflicts of multiple parallel yazi.nvim instances.

The file paths can still be configured but I removed them from the readme because most users don't have to.