### PR TITLE
Try to fix windows path issue

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -3,6 +3,7 @@ local utils = require('yazi.utils')
 local vimfn = require('yazi.vimfn')
 local configModule = require('yazi.config')
 local event_handling = require('yazi.event_handling')
+local Log = require('yazi.log')
 
 local M = {}
 
@@ -39,7 +40,8 @@ function M.yazi(config, path)
   )
 
   if M.yazi_loaded == false then
-    -- ensure that the buffer is closed on exit
+    Log:debug(string.format('Opening yazi with the command: (%s)', cmd))
+
     local job_id = vimfn.termopen(cmd, {
       ---@diagnostic disable-next-line: unused-local
       on_exit = function(_job_id, code, _event)
@@ -75,6 +77,8 @@ M.config = configModule.default()
 function M.setup(opts)
   M.config =
     vim.tbl_deep_extend('force', configModule.default(), M.config, opts or {})
+
+  Log.level = M.config.log_level
 
   if M.config.open_for_directories == true then
     ---@param file string

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -3,6 +3,7 @@ local utils = require('yazi.utils')
 local vimfn = require('yazi.vimfn')
 local configModule = require('yazi.config')
 local event_handling = require('yazi.event_handling')
+local path_utils = require('yazi.utils.path')
 local Log = require('yazi.log')
 
 local M = {}
@@ -34,7 +35,7 @@ function M.yazi(config, path)
   os.remove(config.chosen_file_path)
   local cmd = string.format(
     'yazi "%s" --local-events "rename,delete,trash,move" --chooser-file "%s" > %s',
-    vim.fn.fnameescape(path),
+    path_utils.escape_path_for_cmd(path),
     config.chosen_file_path,
     config.events_file_path
   )

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -34,7 +34,7 @@ function M.yazi(config, path)
 
   os.remove(config.chosen_file_path)
   local cmd = string.format(
-    'yazi "%s" --local-events "rename,delete,trash,move" --chooser-file "%s" > %s',
+    'yazi "%s" --local-events "rename,delete,trash,move" --chooser-file "%s" > "%s"',
     path_utils.escape_path_for_cmd(path),
     config.chosen_file_path,
     config.events_file_path

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -5,6 +5,7 @@ local M = {}
 function M.default()
   ---@type YaziConfig
   return {
+    log_level = vim.log.levels.OFF,
     open_for_directories = false,
     enable_mouse_support = false,
     open_file_function = openers.open_file,

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -34,6 +34,10 @@ return {
       )
     end
 
+    local logfile_location = require('yazi.log'):get_logfile_path()
+    vim.health.info('yazi.nvim log file is at ' .. logfile_location)
+    vim.health.info('    hint: use `gf` to open the file path under the cursor')
+
     vim.health.ok('yazi')
   end,
 }

--- a/lua/yazi/log.lua
+++ b/lua/yazi/log.lua
@@ -1,0 +1,66 @@
+local plenary_path = require('plenary.path')
+
+---@class (exact) yazi.Log
+---@field level yazi.LogLevel
+---@field path string
+local Log = {}
+
+--- The log levels are the same as for vim.log.levels
+---@enum yazi.LogLevel
+local log_levels = {
+  TRACE = 0,
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4,
+  OFF = 5,
+}
+
+---@type yazi.LogLevel
+Log.level = log_levels.OFF
+
+---@return string
+function Log:get_logfile_path()
+  local ok, stdpath = pcall(vim.fn.stdpath, 'log')
+  if not ok then
+    stdpath = vim.fn.stdpath('cache')
+  end
+  return plenary_path:new(stdpath, 'yazi.log'):absolute()
+end
+
+Log.path = Log:get_logfile_path()
+
+---@type file*? # the file handle for the log file
+local file = nil
+
+---@param level string
+---@param message string
+function Log:write_message(level, message)
+  -- initialize if needed
+  if not file then
+    local logfile, err = io.open(self.path, 'a+')
+    file = logfile
+
+    if not file then
+      local err_msg =
+        string.format('yazi.nvim: Failed to open log file at "%s"', err)
+      vim.notify(err_msg, vim.log.levels.ERROR)
+    end
+  end
+
+  if file ~= nil then
+    local timestamp = os.date('%Y-%m-%d %H:%M:%S')
+    local msg = string.format('[%s] %s %s', timestamp, level, message)
+    file:write(msg .. '\n')
+    file:flush()
+  end
+end
+
+---@param message string
+function Log:debug(message)
+  if self.level and self.level >= log_levels.DEBUG then
+    self:write_message('DEBUG', message)
+  end
+end
+
+return Log

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -9,6 +9,7 @@
 ---@field public floating_window_scaling_factor? float "the scaling factor for the floating window. 1 means 100%, 0.9 means 90%, etc."
 ---@field public yazi_floating_window_winblend? float "the transparency of the yazi floating window (0-100). See :h winblend"
 ---@field public yazi_floating_window_border? any "the type of border to use. See nvim_open_win() for the values your neovim version supports"
+---@field public log_level? yazi.LogLevel
 
 ---@class YaziConfigHooks
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil

--- a/lua/yazi/utils/path.lua
+++ b/lua/yazi/utils/path.lua
@@ -1,0 +1,49 @@
+-- NOTE: This file contains code that was copied from
+-- https://github.com/nvim-neo-tree/neo-tree.nvim/blob/main/lua/neo-tree/utils/init.lua#L1033-L1066
+-- as it seems neovim doesn't provide a built-in function for this.
+--
+local M = {}
+
+---Escapes a path primarily relying on `vim.fn.fnameescape`. This function should
+---only be used when preparing a path to be used in a vim command, such as `:e`.
+---
+---For Windows systems, this function handles punctuation characters that will
+---be escaped, but may appear at the beginning of a path segment. For example,
+---the path `C:\foo\(bar)\baz.txt` (where foo, (bar), and baz.txt are segments)
+---will remain unchanged when escaped by `fnaemescape` on a Windows system.
+---However, if that string is used to edit a file with `:e`, `:b`, etc., the open
+---parenthesis will be treated as an escaped character and the path separator will
+---be lost.
+---
+---For more details, see issue #889 when this function was introduced, and further
+---discussions in #1264 and #1352.
+---@param path string
+---@return string
+M.escape_path_for_cmd = function(path)
+  local escaped_path = vim.fn.fnameescape(path)
+  if M.is_windows then
+    -- on windows, some punctuation preceeded by a `\` needs to have a second
+    -- `\` added to preserve the path separator. this is a naive replacement and
+    -- definitely not bullet proof. if we start finding issues with opening files
+    -- or changing directories, look here first. #1382 was the first regression
+    -- from the implementation that used lua's %p to match punctuation, which
+    -- did not quite work. the following characters were tested on windows to
+    -- be known to require an extra escape character.
+    for _, c in ipairs({ '&', '(', ')', ';', '^', '`' }) do
+      -- lua doesn't seem to have a problem with an unnecessary `%` escape
+      -- (e.g., `%;`), so we can use it to ensure we match the punctuation
+      -- for the ones that do (e.g., `%(` and `%^`)
+      escaped_path = escaped_path:gsub('\\%' .. c, '\\%1')
+    end
+  end
+  return escaped_path
+end
+
+---The file system path separator for the current platform.
+M.path_separator = '/'
+M.is_windows = vim.fn.has('win32') == 1 or vim.fn.has('win32unix') == 1
+if M.is_windows == true then
+  M.path_separator = '\\'
+end
+
+return M

--- a/tests/yazi/open_dir_spec.lua
+++ b/tests/yazi/open_dir_spec.lua
@@ -25,7 +25,7 @@ describe('when the user set open_for_directories = true', function()
     vim.api.nvim_command('edit /')
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi "/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
+      'yazi "/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -41,7 +41,7 @@ describe('opening a file', function()
     })
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi "/abc/test-file-\\$1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
+      'yazi "/abc/test-file-\\$1.txt" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)
@@ -55,7 +55,7 @@ describe('opening a file', function()
     })
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi "/tmp/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > /tmp/yazi.nvim.events.txt',
+      'yazi "/tmp/" --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)


### PR DESCRIPTION
Related to #67 but this might not be a perfect solution right away

# Debug logging

feat(log): add possibility for debug logging to diagnose issues

The log can be enabled by specifying it in the yazi.nvim config:

```lua
-- ... other config options here
---@type YaziConfig
opts = {
  log_level = vim.log.levels.DEBUG,
},
```

Only DEBUG level is supported for now.

You can find out the location of the log file by running the following command:

```vim
:checkhealth yazi
```