### PR TITLE
Fix Windows spaces issue

### DIFF
--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -14,7 +14,7 @@ return {
 
     -- parse the version
 
-    local semver = raw_version:match('^[Yy]azi (%w+%.%w+%.%w+)')
+    local semver = raw_version:match('[Yy]azi (%w+%.%w+%.%w+)')
 
     if semver == nil then
       vim.health.warn('yazi --version looks unexpected, saw ' .. raw_version)

--- a/lua/yazi/utils/path.lua
+++ b/lua/yazi/utils/path.lua
@@ -22,6 +22,9 @@ local M = {}
 M.escape_path_for_cmd = function(path)
   local escaped_path = vim.fn.fnameescape(path)
   if M.is_windows then
+    -- Replace forward slash spaces with just spaces.
+    escaped_path = escaped_path:gsub('\\ ', ' ')
+
     -- on windows, some punctuation preceeded by a `\` needs to have a second
     -- `\` added to preserve the path separator. this is a naive replacement and
     -- definitely not bullet proof. if we start finding issues with opening files


### PR DESCRIPTION
This just replaces `\ ` (backslash followed by space) with ` ` (space), which solves #67. What was causing the issue was that `fnameescape` added the backslashes in front of the existing spaces, so Windows got confused.

It also changes the function that checks for the Yazi version, because Yazi added a CSI sequence in sxyazi/yazi@4c35f26e in front (which is what was leading to the weird characters at the start).