### PR TITLE
feat: allow yazi_closed_successfully hook to know the last yazi dir

### DIFF
--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -13,10 +13,13 @@
 
 ---@class YaziConfigHooks
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil
----@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig): nil
+---@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig, state: YaziClosedState): nil
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig): nil
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent
+
+---@class YaziClosedState # describes the state of yazi when it was closed; the last known state
+---@field public last_directory Path # the last directory that yazi was in before it was closed
 
 ---@class YaziRenameEvent
 ---@field public type "rename"
@@ -45,6 +48,12 @@
 ---@field public timestamp string
 ---@field public id string
 ---@field public data {urls: string[]}
+
+---@class YaziChangeDirectoryEvent
+---@field public type "cd"
+---@field public timestamp string
+---@field public id string
+---@field public url string
 
 ---@class yazi.AutoCmdEvent # the nvim_create_autocmd() event object copied from the nvim help docs
 ---@field public id number

--- a/tests/yazi/open_dir_spec.lua
+++ b/tests/yazi/open_dir_spec.lua
@@ -25,7 +25,7 @@ describe('when the user set open_for_directories = true', function()
     vim.api.nvim_command('edit /')
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi \'/\' --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
+      'yazi \'/\' --local-events "rename,delete,trash,move,cd" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -42,7 +42,7 @@ describe('opening a file', function()
     })
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi \'/abc/test file-$1.txt\' --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
+      'yazi \'/abc/test file-$1.txt\' --local-events "rename,delete,trash,move,cd" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)
@@ -56,7 +56,7 @@ describe('opening a file', function()
     })
 
     assert.stub(api_mock.termopen).was_called_with(
-      'yazi \'/tmp/\' --local-events "rename,delete,trash,move" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
+      'yazi \'/tmp/\' --local-events "rename,delete,trash,move,cd" --chooser-file "/tmp/yazi_filechosen" > "/tmp/yazi.nvim.events.txt"',
       match.is_table()
     )
   end)
@@ -92,8 +92,10 @@ describe('opening a file', function()
     function()
       local target_file = '/abc/test-file-potato.txt'
       setup_fake_yazi_opens_file(target_file)
-      local spy_hook = spy.new(function(chosen_file)
+      ---@param state YaziClosedState
+      local spy_hook = spy.new(function(chosen_file, _config, state)
         assert.equals('/abc/test-file-potato.txt', chosen_file)
+        assert.equals('/abc', state.last_directory.filename)
       end)
 
       vim.api.nvim_command('edit /abc/test-file.txt')
@@ -110,7 +112,7 @@ describe('opening a file', function()
 
       assert
         .spy(spy_hook)
-        .was_called_with('/abc/test-file-potato.txt', match.is_table())
+        .was_called_with('/abc/test-file-potato.txt', match.is_table(), match.is_table())
     end
   )
 


### PR DESCRIPTION
This PR adds support for custom hook implementations to know what the last directory was when yazi was closed. It can be used to e.g. change the current working directory in neovim.

In the future, I am thinking I can add some mappings that also use this, for example to do a grep (file content search) operation on the selected directory only. More ideas are also welcome 👍🏻 

related: https://github.com/mikavilpas/yazi.nvim/issues/83