### PR TITLE
feat: <c-s> closes yazi and starts telescope.nvim's live_grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 > You don't have to set any of these options. The defaults are fine for most
 > users.
+>
+> For advanced configuration, it's recommended to have your Lua language server
+> set up so that you can type check your configuration and avoid errors.
 
 You can optionally configure yazi.nvim by setting any of the options below.
 
@@ -123,7 +126,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
 
       -- when yazi opened multiple files. The default is to send them to the
       -- quickfix list, but if you want to change that, you can define it here
-      yazi_opened_multiple_files = function(chosen_files, config) end,
+      yazi_opened_multiple_files = function(chosen_files, config, state) end,
     },
   },
 }

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ You can optionally configure yazi.nvim by setting any of the options below.
       -- quickfix list, but if you want to change that, you can define it here
       yazi_opened_multiple_files = function(chosen_files, config, state) end,
     },
+
+    integrations = {
+      --- What should be done when the user wants to grep in a directory
+      ---@param directory string
+      grep_in_directory = function(directory)
+        -- the default implementation uses telescope if available, otherwise nothing
+      end,
+    },
   },
 }
 ```
@@ -139,6 +147,9 @@ These are the default keybindings that are available when yazi is open:
 - `<c-v>`: open the selected file in a vertical split
 - `<c-x>`: open the selected file in a horizontal split
 - `<c-t>`: open the selected file in a new tab
+- `<c-s>`: close the current yazi directory using
+  [telescope](https://github.com/nvim-telescope/telescope.nvim)'s `live_grep`.
+  If telescope is not available, nothing happens. You can customize this
 
 Notice that these are also the defaults for telescope.
 

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,5 +1,5 @@
 {
-  "nvim-treesitter": { "branch": "master", "commit": "208d504421e4ac53f4230a34cd4b831e8e76cb69" },
-  "plenary.nvim": { "branch": "master", "commit": "8aad4396840be7fc42896e3011751b7609ca4119" },
-  "tokyonight.nvim": { "branch": "main", "commit": "9bf9ec53d5e87b025e2404069b71e7ebdc3a13e5" }
+  "nvim-treesitter": { "branch": "master", "commit": "6d56c5f404d3b116bab167bc03993cfb0a83f8aa" },
+  "plenary.nvim": { "branch": "master", "commit": "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683" },
+  "tokyonight.nvim": { "branch": "main", "commit": "b9b494fa7f7bbf2fe0747b47fa290fb7a4eddcc7" }
 }

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -1,4 +1,5 @@
 local openers = require('yazi.openers')
+local keybinding_helpers = require('yazi.keybinding_helpers')
 
 local M = {}
 
@@ -29,61 +30,16 @@ end
 ---@param config YaziConfig
 function M.default_set_keymappings_function(yazi_buffer, config)
   vim.keymap.set({ 't' }, '<c-v>', function()
-    M.open_file_in_vertical_split(config)
+    keybinding_helpers.open_file_in_vertical_split(config)
   end, { buffer = yazi_buffer })
 
   vim.keymap.set({ 't' }, '<c-x>', function()
-    M.open_file_in_horizontal_split(config)
+    keybinding_helpers.open_file_in_horizontal_split(config)
   end, { buffer = yazi_buffer })
 
   vim.keymap.set({ 't' }, '<c-t>', function()
-    M.open_file_in_tab(config)
+    keybinding_helpers.open_file_in_tab(config)
   end, { buffer = yazi_buffer })
-end
-
--- This is a utility function that can be used in the set_keymappings_function
--- You can also use it in your own keymappings function
-function M.select_current_file_and_close_yazi()
-  -- select the current file in yazi and close it (enter is the default
-  -- keybinding for selecting a file)
-  vim.api.nvim_feedkeys(
-    vim.api.nvim_replace_termcodes('<enter>', true, false, true),
-    'n',
-    true
-  )
-end
-
----@param config YaziConfig
-function M.open_file_in_vertical_split(config)
-  config.open_file_function = openers.open_file_in_vertical_split
-  config.hooks.yazi_opened_multiple_files = function(chosen_files)
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config)
-    end
-  end
-  M.select_current_file_and_close_yazi()
-end
-
----@param config YaziConfig
-function M.open_file_in_horizontal_split(config)
-  config.open_file_function = openers.open_file_in_horizontal_split
-  config.hooks.yazi_opened_multiple_files = function(chosen_files)
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config)
-    end
-  end
-  M.select_current_file_and_close_yazi()
-end
-
----@param config YaziConfig
-function M.open_file_in_tab(config)
-  config.open_file_function = openers.open_file_in_tab
-  config.hooks.yazi_opened_multiple_files = function(chosen_files)
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config)
-    end
-  end
-  M.select_current_file_and_close_yazi()
 end
 
 return M

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -1,0 +1,57 @@
+local openers = require('yazi.openers')
+
+--- Hacky actions that can be used when yazi is open. They typically select the
+--- current file and execute some useful operation on the selected file.
+---@class YaziOpenerActions
+local YaziOpenerActions = {}
+
+---@param config YaziConfig
+function YaziOpenerActions.open_file_in_vertical_split(config)
+  config.open_file_function = openers.open_file_in_vertical_split
+  config.hooks.yazi_opened_multiple_files = function(
+    chosen_files,
+    _config,
+    state
+  )
+    for _, chosen_file in ipairs(chosen_files) do
+      config.open_file_function(chosen_file, config, state)
+    end
+  end
+  YaziOpenerActions.select_current_file_and_close_yazi()
+end
+
+---@param config YaziConfig
+function YaziOpenerActions.open_file_in_horizontal_split(config)
+  config.open_file_function = openers.open_file_in_horizontal_split
+  config.hooks.yazi_opened_multiple_files = function(chosen_files)
+    for _, chosen_file in ipairs(chosen_files) do
+      config.open_file_function(chosen_file, config)
+    end
+  end
+  YaziOpenerActions.select_current_file_and_close_yazi()
+end
+
+---@param config YaziConfig
+function YaziOpenerActions.open_file_in_tab(config)
+  config.open_file_function = openers.open_file_in_tab
+  config.hooks.yazi_opened_multiple_files = function(chosen_files)
+    for _, chosen_file in ipairs(chosen_files) do
+      config.open_file_function(chosen_file, config)
+    end
+  end
+  YaziOpenerActions.select_current_file_and_close_yazi()
+end
+
+-- This is a utility function that can be used in the set_keymappings_function
+-- You can also use it in your own keymappings function
+function YaziOpenerActions.select_current_file_and_close_yazi()
+  -- select the current file in yazi and close it (enter is the default
+  -- keybinding for selecting a file)
+  vim.api.nvim_feedkeys(
+    vim.api.nvim_replace_termcodes('<enter>', true, false, true),
+    'n',
+    true
+  )
+end
+
+return YaziOpenerActions

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -7,46 +7,51 @@ local YaziOpenerActions = {}
 
 ---@param config YaziConfig
 function YaziOpenerActions.open_file_in_vertical_split(config)
-  config.open_file_function = openers.open_file_in_vertical_split
-  config.hooks.yazi_opened_multiple_files = function(
-    chosen_files,
-    _config,
-    state
-  )
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config, state)
-    end
-  end
-  YaziOpenerActions.select_current_file_and_close_yazi()
+  YaziOpenerActions.select_current_file_and_close_yazi(config, {
+    on_file_opened = openers.open_file_in_vertical_split,
+  })
 end
 
 ---@param config YaziConfig
 function YaziOpenerActions.open_file_in_horizontal_split(config)
-  config.open_file_function = openers.open_file_in_horizontal_split
-  config.hooks.yazi_opened_multiple_files = function(chosen_files)
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config)
-    end
-  end
-  YaziOpenerActions.select_current_file_and_close_yazi()
+  YaziOpenerActions.select_current_file_and_close_yazi(config, {
+    on_file_opened = openers.open_file_in_horizontal_split,
+  })
 end
 
 ---@param config YaziConfig
 function YaziOpenerActions.open_file_in_tab(config)
-  config.open_file_function = openers.open_file_in_tab
-  config.hooks.yazi_opened_multiple_files = function(chosen_files)
-    for _, chosen_file in ipairs(chosen_files) do
-      config.open_file_function(chosen_file, config)
-    end
-  end
-  YaziOpenerActions.select_current_file_and_close_yazi()
+  YaziOpenerActions.select_current_file_and_close_yazi(config, {
+    on_file_opened = openers.open_file_in_tab,
+  })
 end
+
+--
+--
+--
+--
+---@class YaziOpenerActionsCallbacks
+---@field on_file_opened fun(chosen_file: string, config: YaziConfig, state: YaziClosedState):nil
+---@field on_multiple_files_opened? fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState):nil
 
 -- This is a utility function that can be used in the set_keymappings_function
 -- You can also use it in your own keymappings function
-function YaziOpenerActions.select_current_file_and_close_yazi()
-  -- select the current file in yazi and close it (enter is the default
-  -- keybinding for selecting a file)
+---@param config YaziConfig
+---@param callbacks YaziOpenerActionsCallbacks
+function YaziOpenerActions.select_current_file_and_close_yazi(config, callbacks)
+  config.open_file_function = callbacks.on_file_opened
+
+  if callbacks.on_multiple_files_opened == nil then
+    ---@diagnostic disable-next-line: redefined-local
+    callbacks.on_multiple_files_opened = function(chosen_files, config, state)
+      for _, chosen_file in ipairs(chosen_files) do
+        config.open_file_function(chosen_file, config, state)
+      end
+    end
+  end
+
+  config.hooks.yazi_opened_multiple_files = callbacks.on_multiple_files_opened
+
   vim.api.nvim_feedkeys(
     vim.api.nvim_replace_termcodes('<enter>', true, false, true),
     'n',

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -42,10 +42,9 @@ function YaziOpenerActions.select_current_file_and_close_yazi(config, callbacks)
   config.open_file_function = callbacks.on_file_opened
 
   if callbacks.on_multiple_files_opened == nil then
-    ---@diagnostic disable-next-line: redefined-local
-    callbacks.on_multiple_files_opened = function(chosen_files, config, state)
+    callbacks.on_multiple_files_opened = function(chosen_files, cfg, state)
       for _, chosen_file in ipairs(chosen_files) do
-        config.open_file_function(chosen_file, config, state)
+        cfg.open_file_function(chosen_file, cfg, state)
       end
     end
   end

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -1,9 +1,11 @@
+-- TODO all config properties are optional when given, but mandatory inside the plugin
+
 ---@class YaziConfig
 ---@field public open_for_directories? boolean
 ---@field public chosen_file_path? string "the path to a temporary file that will be created by yazi to store the chosen file path"
 ---@field public events_file_path? string "the path to a temporary file that will be created by yazi to store events. A random path will be used by default"
 ---@field public enable_mouse_support? boolean
----@field public open_file_function? fun(chosen_file: string, config: YaziConfig): nil "a function that will be called when a file is chosen in yazi"
+---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
 ---@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig): nil "the function that will set the keymappings for the yazi floating window. It will be called after the floating window is created."
 ---@field public hooks? YaziConfigHooks
 ---@field public floating_window_scaling_factor? float "the scaling factor for the floating window. 1 means 100%, 0.9 means 90%, etc."
@@ -14,7 +16,7 @@
 ---@class YaziConfigHooks
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil
 ---@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig, state: YaziClosedState): nil
----@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig): nil
+---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
 
 ---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent
 

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -8,6 +8,7 @@
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
 ---@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig): nil "the function that will set the keymappings for the yazi floating window. It will be called after the floating window is created."
 ---@field public hooks? YaziConfigHooks
+---@field public integrations? YaziConfigIntegrations
 ---@field public floating_window_scaling_factor? float "the scaling factor for the floating window. 1 means 100%, 0.9 means 90%, etc."
 ---@field public yazi_floating_window_winblend? float "the transparency of the yazi floating window (0-100). See :h winblend"
 ---@field public yazi_floating_window_border? any "the type of border to use. See nvim_open_win() for the values your neovim version supports"
@@ -17,6 +18,9 @@
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil
 ---@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig, state: YaziClosedState): nil
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
+
+---@class YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
+---@field public grep_in_directory? fun(directory: string): nil "a function that will be called when the user wants to grep in a directory"
 
 ---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -210,12 +210,12 @@ function M.on_yazi_exited(prev_win, window, config, state)
     local chosen_files = vim.fn.readfile(config.chosen_file_path)
 
     if #chosen_files > 1 then
-      config.hooks.yazi_opened_multiple_files(chosen_files, config)
+      config.hooks.yazi_opened_multiple_files(chosen_files, config, state)
     else
       local chosen_file = chosen_files[1]
       config.hooks.yazi_closed_successfully(chosen_file, config, state)
       if chosen_file then
-        config.open_file_function(chosen_file, config)
+        config.open_file_function(chosen_file, config, state)
       end
     end
   else

--- a/tests/yazi/yazi_spec.lua
+++ b/tests/yazi/yazi_spec.lua
@@ -151,7 +151,7 @@ describe('opening a file', function()
 
     assert
       .spy(spy_open_file_function)
-      .was_called_with(target_file, match.is_table())
+      .was_called_with(target_file, match.is_table(), match.is_table())
   end)
 end)
 
@@ -188,6 +188,6 @@ describe('opening multiple files', function()
     assert.spy(spy_open_multiple_files).was_called_with({
       target_file_1,
       target_file_2,
-    }, match.is_table())
+    }, match.is_table(), match.is_table())
   end)
 end)


### PR DESCRIPTION
feat: <c-s> closes yazi and starts telescope.nvim's live_grep

The live_grep is constrained to the last directory yazi was in (that is,
the current yazi directory when entering this key combination).

This can be used to comfortably explore parts of the current project (on
the directory level) in an ad hoc fashion.

The search action can be configured in the user's configuration in case
they want to use some other method of searching (even another plugin
entirely), or customize it, or disable it completely.