### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -5,7 +5,7 @@ jobs:
     name: runner / linkspector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: selene
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
       - uses: NTBBloodbath/selene-action@v1.0.0
         with:
           # Github secret token
@@ -21,4 +21,4 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: DavidAnson/markdownlint-cli2-action@v15
+      - uses: DavidAnson/markdownlint-cli2-action@v16.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4.1.1
         with:
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: prettier
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.6
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version-file: .nvmrc
       - run: npm ci
@@ -22,7 +22,7 @@ jobs:
     name: stylua
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
             manager: sudo apt-get
             packages: -y ripgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - run: date +%F > todays-date
       - name: Restore from today's cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.0.2
         with:
           path: _neovim
           key:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,37 +13,37 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
 
       - name: Checkout dependency neodev # get neodev and neovim/runtime for builtin types
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
         with:
           repository: "folke/neodev.nvim"
           path: "deps/neodev.nvim"
 
       - name: Checkout dependency plenary
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
         with:
           repository: "nvim-lua/plenary.nvim"
           path: "deps/plenary.nvim"
 
       - name: Checkout neovim for type annotations
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.6
         with:
           repository: "neovim/neovim"
           path: "deps/neovim"
 
-      - uses: leafo/gh-actions-lua@v9 # get luarocks dependencies for their types (eg `PathlibPath`)
+      - uses: leafo/gh-actions-lua@v10.0.0 # get luarocks dependencies for their types (eg `PathlibPath`)
         with:
           luaVersion: "5.1"
-      - uses: leafo/gh-actions-luarocks@v4
+      - uses: leafo/gh-actions-luarocks@v4.3.0
       - name: install dependencies
         run: |
           luarocks init
           luarocks install --only-deps ./*.rockspec
 
       - name: Typecheck the code base
-        uses: mrcjkb/lua-typecheck-action@v0.2.1
+        uses: mrcjkb/lua-typecheck-action@v1.0.0
         with:
           configpath: .github/workflows/.luarc.json
           directories: |

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.6
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[googleapis/release-please-action](https://github.com/googleapis/release-please-action)** published a new release **[v4.1.1](https://github.com/googleapis/release-please-action/releases/tag/v4.1.1)** on 2024-05-14T20:39:29Z
* **[leafo/gh-actions-lua](https://github.com/leafo/gh-actions-lua)** published a new release **[v10.0.0](https://github.com/leafo/gh-actions-lua/releases/tag/v10.0.0)** on 2023-01-31T18:40:04Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
* **[DavidAnson/markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action)** published a new release **[v16.0.0](https://github.com/DavidAnson/markdownlint-cli2-action/releases/tag/v16.0.0)** on 2024-04-08T00:13:44Z
* **[leafo/gh-actions-luarocks](https://github.com/leafo/gh-actions-luarocks)** published a new release **[v4.3.0](https://github.com/leafo/gh-actions-luarocks/releases/tag/v4.3.0)** on 2022-03-25T22:01:46Z
* **[mrcjkb/lua-typecheck-action](https://github.com/mrcjkb/lua-typecheck-action)** published a new release **[v1.0.0](https://github.com/mrcjkb/lua-typecheck-action/releases/tag/v1.0.0)** on 2024-05-31T13:14:06Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
