### PR TITLE
fix(plugins): fix failure on repeated installation

### DIFF
--- a/tests/yazi/plugin_spec.lua
+++ b/tests/yazi/plugin_spec.lua
@@ -47,10 +47,7 @@ describe('installing a plugin', function()
         name = 'test-plugin-2',
       }, { yazi_dir = yazi_dir })
 
-      assert.is_equal(
-        result.error,
-        'yazi plugin/flavor directory does not exist'
-      )
+      assert.is_equal(result.error, 'source directory does not exist')
       assert.is_equal(result.from, plugin_dir)
     end)
   end)
@@ -72,6 +69,21 @@ describe('installing a plugin', function()
         vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'flavors', 'test-flavor'))
 
       assert.are.same(flavor_dir, symlink)
+    end)
+  end)
+
+  describe('symlink', function()
+    it("doesn't complain if the symlink already exists", function()
+      local source = vim.fs.joinpath(base_dir, 'source-dir')
+      local target = vim.fs.joinpath(base_dir, 'target-dir')
+
+      vim.fn.mkdir(source)
+
+      local result = plugin.symlink({ name = 'source', dir = source }, target)
+      assert.are.same(result.error, nil)
+
+      local result2 = plugin.symlink({ name = 'source', dir = source }, target)
+      assert.are.same(result2.error, nil)
     end)
   end)
 end)


### PR DESCRIPTION
When a plugin or flavor is first installed and later updated, the link to the plugin or flavor's directory is already in place. This caused an error when the plugin or flavor was installed again (updated). The error did not actually do anything disruptive, but it was annoying.

Now, reinstalling checks if the symlink is already in place and does nothing if it is.