### PR TITLE
Fix deletion not closing open deleted buffers

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -1,3 +1,5 @@
+---@module "plenary"
+
 local window = require('yazi.window')
 local utils = require('yazi.utils')
 local vimfn = require('yazi.vimfn')

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -157,7 +157,10 @@ function M.get_open_buffers()
   local open_buffers = {}
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     local path = vim.api.nvim_buf_get_name(bufnr)
-    if path ~= '' and path ~= nil then
+    local type = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
+
+    local is_ordinary_file = path ~= '' and type == ''
+    if is_ordinary_file then
       local renameable_buffer = RenameableBuffer.new(bufnr, path)
       open_buffers[#open_buffers + 1] = renameable_buffer
     end

--- a/tests/yazi/trash_spec.lua
+++ b/tests/yazi/trash_spec.lua
@@ -22,6 +22,10 @@ describe('process_trash_event', function()
 
     event_handling.process_delete_event(event, {})
 
+    vim.wait(1000, function()
+      return not vim.api.nvim_buf_is_valid(buffer)
+    end)
+
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
 
@@ -38,11 +42,15 @@ describe('process_trash_event', function()
 
     event_handling.process_delete_event(event, {})
 
+    vim.wait(1000, function()
+      return not vim.api.nvim_buf_is_valid(buffer)
+    end)
+
     assert.is_false(vim.api.nvim_buf_is_valid(buffer))
   end)
 
   it("doesn't delete a buffer that doesn't match the trash event", function()
-    local buffer = vim.fn.bufadd('/abc/def')
+    vim.fn.bufadd('/abc/def')
 
     ---@type YaziTrashEvent
     local event = {
@@ -52,13 +60,12 @@ describe('process_trash_event', function()
       data = { urls = { '/abc/ghi' } },
     }
 
-    event_handling.process_delete_event(event, {})
-
-    assert.is_true(vim.api.nvim_buf_is_valid(buffer))
+    local deletions = event_handling.process_delete_event(event, {})
+    assert.are.same({}, deletions)
   end)
 
   it("doesn't delete a buffer that was renamed to in a later event", function()
-    local buffer1 = vim.fn.bufadd('/def/file')
+    vim.fn.bufadd('/def/file')
 
     ---@type YaziTrashEvent
     local delete_event = {
@@ -76,8 +83,8 @@ describe('process_trash_event', function()
       data = { from = '/def/other-file', to = '/def/file' },
     }
 
-    event_handling.process_delete_event(delete_event, { rename_event })
-
-    assert.is_true(vim.api.nvim_buf_is_valid(buffer1))
+    local deletions =
+      event_handling.process_delete_event(delete_event, { rename_event })
+    assert.are.same({}, deletions)
   end)
 end)


### PR DESCRIPTION
# fix: open buffers deleted in yazi were not closed

When a buffer was opened in neovim and being edited, and then yazi
deleted it, the buffer was not closed. I'm not sure what broke it.

The fix is to close the buffer asynchronously. I don't understand why
that fixes the issue, but it does.

`vim.await` is really cool. I found it here:
https://www.reddit.com/r/neovim/comments/1cv5q45/comment/l4s2ya0/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

# perf: processing open buffers only processes normal buffers

Buffers are processed when renaming, deleting, and trashing files in
yazi. Previously all open buffers were processed, but now only normal
buffers are.

This actually doesn't have a big impact on performance. I just wanted to
have a `perf` commit in the history 😄. Perhaps in big projects it might
be noticeable, or if some future feature will require more performance.