### PR TITLE
ci: check that there are no #focus tags left over in the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ init:
 
 lint:
 	selene ./lua/ ./spec/
+	@if grep -r -e "#focus" --include \*.lua .; then \
+			echo "\n"; \
+			echo "Error: ${COLOR_GREEN}#focus${COLOR_RESET} tags found in the codebase.\n"; \
+			echo "Please remove them to prevent issues with not accidentally running all tests."; \
+			exit 1; \
+	fi
+
 
 test:
 	luarocks test --local

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -48,7 +48,7 @@ describe('opening a file', function()
     )
   end)
 
-  it('#focus opens yazi with the current directory selected', function()
+  it('opens yazi with the current directory selected', function()
     vim.api.nvim_command('edit /tmp/')
 
     plugin.yazi({


### PR DESCRIPTION
This might cause trouble for developers who want to run focused tests. Better to avoid it.