### PR TITLE
fix: exiting insert mode with "<esc><esc>"

### DIFF
--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -90,6 +90,15 @@ function YaziFloatingWindow:open_and_display()
     self:add_hacky_mouse_support(yazi_buffer)
   end
 
+  vim.api.nvim_create_autocmd('ModeChanged', {
+    buffer = yazi_buffer,
+    callback = function()
+      -- HACK Sometimes pressing "<esc><esc>" exits insert mode the first time it's pressed.
+      -- Work around this by starting insert mode after the first time the mode changes.
+      vim.cmd('startinsert')
+    end,
+  })
+
   vim.api.nvim_create_autocmd({ 'VimResized' }, {
     buffer = yazi_buffer,
     callback = function()


### PR DESCRIPTION
For me, the following bug was happening:
- I start yazi and see yazi in the floating terminal
- I press `<esc><esc>` (esc twice)
- pressing j does not make yazi move the focus to the next file. Instead the terminal seems to be in normal mode and the cursor moves down.

This only happens once in the neovim session.

It was possible to work around this issue by pressing `i` to seemingly enter insert mode again 😄

This commit works around the issue by always entering insert mode when the mode changes.

This seems like a pretty stupid solution, so let's hope it causes no problems 🤞🏻