### PR TITLE
fix: opening "nvim dir/" may focus wrong window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ scripts/lazy.nvim/
 /luarocks
 /lua_modules
 /.luarocks
-/lua

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -128,7 +128,10 @@ function M.setup(opts)
     -- When opening neovim with "nvim ." or "nvim <directory>", the current
     -- buffer is already open at this point. If we have already opened a
     -- directory, display yazi instead.
-    open_yazi_in_directory(vim.fn.expand('%:p'), vim.api.nvim_get_current_buf())
+    open_yazi_in_directory(
+      vim.b.netrw_curdir or vim.fn.expand('%:p'),
+      vim.api.nvim_get_current_buf()
+    )
   end
 end
 


### PR DESCRIPTION
Yazi.nvim has a feature where you can specify `open_for_directories = true` to automatically open yazi when opening a directory in Neovim.

In some cases, opening a directory when starting Neovim from the command line would show yazi, but the window under yazi was selected. Yazi was supposed to have been focused instead.

This was due to the default netrw file manager not having a file name for the buffer that was opened. I don't know why this only happened in some cases.

Fixes https://github.com/mikavilpas/yazi.nvim/issues/58