### PR TITLE
refactor: remove hacky workaround for <esc><esc> in insert mode

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -1,3 +1,5 @@
+---@module "plenary.path"
+
 local openers = require('yazi.openers')
 local keybinding_helpers = require('yazi.keybinding_helpers')
 
@@ -42,6 +44,11 @@ function M.default_set_keymappings_function(yazi_buffer, config)
   vim.keymap.set({ 't' }, '<c-v>', function()
     keybinding_helpers.open_file_in_vertical_split(config)
   end, { buffer = yazi_buffer })
+  vim.keymap.set('t', '<esc>', '<esc>', { buffer = yazi_buffer })
+
+  -- LazyVim sets <esc><esc> to forcibly enter normal mode. This has been
+  -- confusing for some users. Let's disable it when using yazi.nvim only.
+  vim.keymap.set({ 't' }, '<esc><esc>', '<Nop>', { buffer = yazi_buffer })
 
   vim.keymap.set({ 't' }, '<c-x>', function()
     keybinding_helpers.open_file_in_horizontal_split(config)

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -90,15 +90,6 @@ function YaziFloatingWindow:open_and_display()
     self:add_hacky_mouse_support(yazi_buffer)
   end
 
-  vim.api.nvim_create_autocmd('ModeChanged', {
-    buffer = yazi_buffer,
-    callback = function()
-      -- HACK Sometimes pressing "<esc><esc>" exits insert mode the first time it's pressed.
-      -- Work around this by starting insert mode after the first time the mode changes.
-      vim.cmd('startinsert')
-    end,
-  })
-
   vim.api.nvim_create_autocmd({ 'VimResized' }, {
     buffer = yazi_buffer,
     callback = function()


### PR DESCRIPTION
This PR is for testing an idea that came up in #126 