### PR TITLE
fix: open file results in one empty buffer

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -26,6 +26,7 @@ function M.yazi(config, input_path)
   local path = utils.selected_file_path(input_path)
 
   local prev_win = vim.api.nvim_get_current_win()
+  local prev_buf = vim.api.nvim_get_current_buf()
 
   config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
   config.events_file_path = config.events_file_path or vim.fn.tempname()
@@ -67,7 +68,7 @@ function M.yazi(config, input_path)
             last_directory = path
           end
         end
-        utils.on_yazi_exited(prev_win, win, config, {
+        utils.on_yazi_exited(prev_win, prev_buf, win, config, {
           last_directory = event_info.last_directory or path:parent(),
         })
       end,

--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -1,7 +1,20 @@
 local M = {}
 
+local function delete_empty_path_buffers()
+  local buffers = vim.api.nvim_list_bufs()
+  if #buffers == 2 then
+    for _, buf in ipairs(buffers) do
+      local file_path = vim.api.nvim_buf_get_name(buf)
+      if file_path == '' then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+  end
+end
+
 ---@param chosen_file string
 function M.open_file(chosen_file)
+  delete_empty_path_buffers()
   vim.cmd(string.format('edit %s', vim.fn.fnameescape(chosen_file)))
 end
 

--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -1,20 +1,7 @@
 local M = {}
 
-local function delete_empty_path_buffers()
-  local buffers = vim.api.nvim_list_bufs()
-  if #buffers == 2 then
-    for _, buf in ipairs(buffers) do
-      local file_path = vim.api.nvim_buf_get_name(buf)
-      if file_path == '' then
-        vim.api.nvim_buf_delete(buf, { force = true })
-      end
-    end
-  end
-end
-
 ---@param chosen_file string
 function M.open_file(chosen_file)
-  delete_empty_path_buffers()
   vim.cmd(string.format('edit %s', vim.fn.fnameescape(chosen_file)))
 end
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -195,15 +195,20 @@ function M.rename_or_close_buffer(instruction)
 end
 
 ---@param prev_win integer
+---@param prev_buf integer
 ---@param window YaziFloatingWindow
 ---@param config YaziConfig
 ---@param state YaziClosedState
-function M.on_yazi_exited(prev_win, window, config, state)
+function M.on_yazi_exited(prev_win, prev_buf, window, config, state)
   vim.cmd('silent! :checktime')
 
   -- open the file that was chosen
   if not vim.api.nvim_win_is_valid(prev_win) then
     return
+  end
+
+  if vim.api.nvim_buf_is_valid(prev_buf) then
+    vim.api.nvim_set_current_buf(prev_buf)
   end
 
   window:close()


### PR DESCRIPTION
I am using AstroNvim and encountered an issue that will result in one empty buffer.
background:
AstroNvim uses alpha.nvim as a greeting.
reproduce procedure:
1. use astronvim
2. add yazi.nvim with below config
``` lua
---@type LazySpec
return {
  "mikavilpas/yazi.nvim",
  event = "VeryLazy",
  keys = {
    -- 👇 in this section, choose your own keymappings!
    {
      "<leader>-",
      function() require("yazi").yazi() end,
      desc = "Open the file manager",
    },
    {
      -- Open in the current working directory
      "<leader>+",
      function() require("yazi").yazi(nil, vim.fn.getcwd()) end,
      desc = "Open the file manager in nvim's working directory",
    },
  },
  ---@type YaziConfig
  opts = {
    -- open_for_directories = true,
    log_level = vim.log.levels.INFO,
  },
}
```
3. open neovim , leader- to open yazi,select a file to open
4. will look like below ,an Untitled buffer is created.
<img width="942" alt="image" src="https://github.com/mikavilpas/yazi.nvim/assets/59443488/69914258-7dbf-4635-bc54-4a3555814890">

I added a temporary solution to fix it which is ugly because I did not find why this happened. If you'd like to help, I'd like to pr further.
My solution is to find the buffer with no actual path. If the path is empty , then delete the buffer.

minimum repro lua with astronvim `nvim -u repro.lua` to use
```lua
-- save as repro.lua
-- run with nvim -u repro.lua
-- DO NOT change the paths
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs({ "config", "data", "state", "runtime", "cache" }) do
  vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  -- stylua: ignore
  vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable",
    lazypath })
end
vim.opt.rtp:prepend(vim.env.LAZY or lazypath)

-- install plugins
local plugins = {
  { "AstroNvim/AstroNvim", import = "astronvim.plugins" },
  {
    "mikavilpas/yazi.nvim",
    event = "VeryLazy",
    keys = {
      -- 👇 in this section, choose your own keymappings!
      {
        "<leader>-",
        function()
          require("yazi").yazi()
        end,
        desc = "Open the file manager",
      },
      {
        -- Open in the current working directory
        "<leader>+",
        function()
          require("yazi").yazi(nil, vim.fn.getcwd())
        end,
        desc = "Open the file manager in nvim's working directory",
      },
    },
    ---@type YaziConfig
    opts = {
      -- open_for_directories = true,
      log_level = vim.log.levels.INFO,
    },
  },

  -- add any other plugins/customizations here
}
require("lazy").setup(plugins, {
  root = root .. "/plugins",
})

-- add anything else here (autocommands, vim.filetype, etc.)

```