### PR TITLE
feat: lazy.nvim users no longer need to specify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,37 +48,35 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 ---@type LazySpec
 {
-  { 'nvim-lua/plenary.nvim', lazy = true },
-  {
-    "mikavilpas/yazi.nvim",
-    event = "VeryLazy",
-    keys = {
-      -- 👇 in this section, choose your own keymappings!
-      {
-        "<leader>-",
-        function()
-          require("yazi").yazi()
-        end,
-        desc = "Open the file manager",
-      },
-      {
-        -- Open in the current working directory
-        "<leader>cw",
-        function()
-          require("yazi").yazi(nil, vim.fn.getcwd())
-        end,
-        desc = "Open the file manager in nvim's working directory" ,
-      },
+  "mikavilpas/yazi.nvim",
+  event = "VeryLazy",
+  keys = {
+    -- 👇 in this section, choose your own keymappings!
+    {
+      "<leader>-",
+      function()
+        require("yazi").yazi()
+      end,
+      desc = "Open the file manager",
     },
-    ---@type YaziConfig
-    opts = {
-      -- if you want to open yazi instead of netrw, see below for more info
-      open_for_directories = false,
+    {
+      -- Open in the current working directory
+      "<leader>cw",
+      function()
+        require("yazi").yazi(nil, vim.fn.getcwd())
+      end,
+      desc = "Open the file manager in nvim's working directory" ,
     },
   },
+  ---@type YaziConfig
+  opts = {
+    -- if you want to open yazi instead of netrw, see below for more info
+    open_for_directories = false,
+  },
 }
-
 ```
+
+If you are not using lazy.nvim, see [lazy.lua](./lazy.lua) for what dependencies are required.
 
 ### ⚙️⚙️ Advanced configuration
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 }
 ```
 
-If you are not using lazy.nvim, see [lazy.lua](./lazy.lua) for what dependencies are required.
+If you are not using lazy.nvim, see [lazy.lua](./lazy.lua) for what dependencies
+are required.
 
 ### ⚙️⚙️ Advanced configuration
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently --kill-others --names 'client,server' --prefix-colors 'blue,green' 'vite' 'npm run dev:server'; exit 0",
+    "dev": "concurrently --kill-others --names 'client,server,cypress' --prefix-colors 'blue,green,yellow' 'vite' 'npm run dev:server' 'npm run cy:open'",
     "dev:client": "vite",
     "dev:server": "tsc-watch --noClear --build --onSuccess 'tsx ./server/server.ts'",
     "cy:open": "cypress open",

--- a/integration-tests/test-environment/test-setup.lua
+++ b/integration-tests/test-environment/test-setup.lua
@@ -34,15 +34,16 @@ vim.opt.rtp:prepend('../../')
 -- loading lazy.nvim so that mappings are correct.
 -- This is also a good place to setup other settings (vim.opt)
 vim.g.mapleader = ' '
-vim.g.maplocalleader = '\\'
+vim.g.maplocalleader = ' '
 
 -- install the following plugins
 ---@type LazySpec
 local plugins = {
   {
     'mikavilpas/yazi.nvim',
-    dir = '../../',
     event = 'VeryLazy',
+    -- for tests, always use the code from this repository
+    dir = '../../',
     keys = {
       {
         '<up>',
@@ -57,7 +58,6 @@ local plugins = {
     },
   },
   { 'nvim-telescope/telescope.nvim', lazy = true },
-  { 'nvim-lua/plenary.nvim', lazy = true },
   { 'catppuccin/nvim', name = 'catppuccin', priority = 1000 },
 }
 require('lazy').setup({ spec = plugins })

--- a/lazy.lua
+++ b/lazy.lua
@@ -1,0 +1,17 @@
+-- This file is used to define the dependencies of this plugin when the user is
+-- using lazy.nvim.
+--
+--https://lazy.folke.io/packages#lazy
+
+---@module "lazy"
+---@module "yazi"
+
+---@type LazySpec
+return {
+  { 'nvim-lua/plenary.nvim', lazy = true },
+  {
+    'mikavilpas/yazi.nvim',
+    ---@type YaziConfig
+    opts = {},
+  },
+}


### PR DESCRIPTION
As of lazy.nvim 11, packages can now specify their own dependencies and configuration. This means that users of lazy.nvim no longer need to specify plenary.nvim as a dependency. If any dependencies are added in the future, they will be automatically installed by lazy.nvim.

This is a backwards-compatible change.

<https://lazy.folke.io/news#11x>