### PR TITLE
fix(repro): update the repro script to update the dependencies

### DIFF
--- a/documentation/reproducing-issues.md
+++ b/documentation/reproducing-issues.md
@@ -5,7 +5,7 @@ are caused by plugins or configuration. This can also make it very difficult to
 provide a fix. To help us diagnose the issue, please follow these steps:
 
 1. copy [repro.lua](../repro.lua) to a directory on your system
-2. run `nvim -u repro.lua` in that directory
+2. run `nvim -u repro.lua -c "lua require('lazy').update()"` in that directory
    - this will start Neovim with a minimal configuration, completely defined by
      that one file.
 3. try to reproduce the issue


### PR DESCRIPTION
This plugin includes a `repro.lua` file that can be used to start neovim with a minimal, known configuration. This is useful for reproducing issues.

If the reproduction script had been run some time ago, the dependencies might be out of date. This commit updates the script to update the dependencies before starting neovim.