### PR TITLE
fix: not being able to disable writing DEBUG logs

### DIFF
--- a/lua/yazi/log.lua
+++ b/lua/yazi/log.lua
@@ -58,7 +58,12 @@ end
 
 ---@param message string
 function Log:debug(message)
-  if self.level and self.level >= log_levels.DEBUG then
+  vim.notify(vim.inspect({ self.level }))
+  if
+    self.level
+    and self.level ~= log_levels.OFF
+    and self.level <= log_levels.DEBUG
+  then
     self:write_message('DEBUG', message)
   end
 end


### PR DESCRIPTION
This bug caused useless log lines to be written to the log file. If you
want to delete your log file, you can find it with `:checkhealth yazi`