### PR TITLE
fix: remove extra debug logging

### DIFF
--- a/lua/yazi/log.lua
+++ b/lua/yazi/log.lua
@@ -58,7 +58,6 @@ end
 
 ---@param message string
 function Log:debug(message)
-  vim.notify(vim.inspect({ self.level }))
   if
     self.level
     and self.level ~= log_levels.OFF


### PR DESCRIPTION
I left this in accidentally, and it logged a confusing message every time.

some discussion can be found in
https://github.com/mikavilpas/yazi.nvim/commit/8f251defe31ce7b3e623b499e08a7c558d79bfdb