### PR TITLE
ci: add release-please token to fix stalled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,4 @@ jobs:
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options
           release-type: simple
+          token: ${{ secrets.RELEASE_PLEASE_ACCESS_TOKEN }}


### PR DESCRIPTION
This adds the release-please token to the release workflow to fix an issue that occurred in https://github.com/mikavilpas/yazi.nvim/pull/154

Looks like release-please is able to create a release PR, but not able to start workflows using the default `GITHUB_TOKEN`.

- https://github.com/googleapis/release-please-action/issues/818
- https://github.com/marketplace/actions/release-please-action
- https://github.com/peter-evans/create-pull-request/issues/48