### PR TITLE
ci: make integration-tests more robust

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently --kill-others --names 'client,server,cypress' --prefix-colors 'blue,green,yellow' 'vite' 'npm run dev:server' 'npm run cy:open'",
+    "dev": "concurrently --kill-others --names 'client,server,cypress' --prefix-colors 'blue,green,yellow' 'npm run dev:client' 'npm run dev:server' 'npm run cy:open'",
     "dev:client": "vite",
     "dev:server": "tsc-watch --noClear --build --onSuccess 'tsx ./server/server.ts'",
     "cy:open": "cypress open",
-    "cy:run": "concurrently --kill-others --success 'command-cypress' --names 'dev,cypress' --prefix-colors 'blue,green' 'npm run dev' 'wait-on --timeout 60000 http://127.0.0.1:5173 && npx cypress run'",
+    "cy:run:ci": "concurrently --success command-cypress --kill-others --names 'client,server,cypress' --prefix-colors 'blue,green,yellow' 'npm run dev:client' 'npm run dev:server' 'wait-on --timeout 60000 http://127.0.0.1:5173 && npx cypress run'",
     "build": "tsc && vite build",
     "eslint": "eslint --max-warnings=0 .",
     "preview": "vite preview"

--- a/integration-tests/test-environment/test-setup.lua
+++ b/integration-tests/test-environment/test-setup.lua
@@ -35,6 +35,7 @@ vim.opt.rtp:prepend('../../')
 -- This is also a good place to setup other settings (vim.opt)
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
+vim.o.swapfile = false
 
 -- install the following plugins
 ---@type LazySpec

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "install:all": "npm install --workspaces --include-workspace-root",
     "prettier": "prettier --check .",
-    "cy:run": "npm run cy:run --workspace integration-tests",
+    "cy:run": "npm run cy:run:ci --workspace integration-tests",
     "markdownlint": "markdownlint-cli2 README.md"
   },
   "private": true,


### PR DESCRIPTION
Fixes the following issues:
- an extra `cypress open` was launched when running tests in ci. They should have been run headlessly.
- swapfiles were occasionally created in the test environment, which could cause tests to fail. This only happened developing locally.