### PR TITLE
Allow installing yazi plugins from a plugin monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Yazi is highly customizable. It features its own plugin and event system,
 themes, and keybindings. This section lists some of the plugins and themes that
 I like.
 
-- <https://github.com/DreamMaoMao/keyjump.yazi> allows jumping to a line by
-  typing a hint character, much like
+- <https://github.com/redbeardymcgee/yazi-plugins/tree/main/keyjump.yazi> allows
+  jumping to a line by typing a hint character, much like
   [hop.nvim](https://github.com/smoka7/hop.nvim)
 - <https://github.com/Rolv-Apneseth/starship.yazi> is a port of the
   [starship prompt](https://starship.rs) to yazi. It allows reusing the prompt
@@ -207,11 +207,6 @@ I like.
   [this discussion](https://github.com/sxyazi/yazi/discussions/818) or
   [my config](https://github.com/mikavilpas/dotfiles/commit/bb07515f69d219fd3435d222fcb2d80d27a25025#diff-973b37f40e024ca0f7e62f2569efce24ad550d0352adc8449168ac950af9eaf5R8)
   for an example of using it
-
-## 🍴 About my fork
-
-I forked this from <https://github.com/DreamMaoMao/yazi.nvim> for my own use,
-and also because I wanted to learn Neovim plugin development.
 
 ## Contributing
 

--- a/documentation/plugin-manager.md
+++ b/documentation/plugin-manager.md
@@ -6,12 +6,12 @@ allows you to fully manage your yazi and neovim plugins from inside neovim.
 ## Getting started
 
 In this example, we will install the yazi plugin
-[DreamMaoMao/keyjump.yazi](https://github.com/DreamMaoMao/keyjump.yazi), which
-adds a "jump-to-line" feature to yazi. We will also install a _flavor_ which
-applies a color scheme to yazi.
+[starship.yazi](https://github.com/Rolv-Apneseth/starship.yazi), which adds
+support for the [starship](https://starship.rs/) shell prompt to yazi. We will
+also install a _flavor_ which applies a color scheme to yazi.
 
 In your yazi.nvim configuration, add a new lazy.nvim plugin specification for
-`DreamMaoMao/keyjump.yazi`:
+`Rolv-Apneseth/starship.yazi`:
 
 ```lua
 -- this file is: /Users/mikavilpas/.config/nvim/lua/plugins/my-file-manager.lua
@@ -29,8 +29,7 @@ return {
     },
   },
   {
-    -- example: include a plugin
-    "DreamMaoMao/keyjump.yazi",
+    "Rolv-Apneseth/starship.yazi",
     lazy = true,
     build = function(plugin)
       require("yazi.plugin").build_plugin(plugin)
@@ -53,9 +52,9 @@ Next, run `:Lazy` in neovim to install the plugin and flavor.
 
 Finally, make changes in your yazi configuration:
 
-- add a keybinding to your `~/.config/yazi/keymap.toml` according to the
-  [instructions](https://github.com/DreamMaoMao/keyjump.yazi?tab=readme-ov-file#usage)
-  provided by the plugin author.
+- (for plugins requiring keybindings) add a keybinding to your
+  `~/.config/yazi/keymap.toml` according to the instructions provided by the
+  plugin author.
 - include the flavor in your `~/.config/yazi/theme.toml` according to the
   [instructions](https://github.com/BennyOe/onedark.yazi?tab=readme-ov-file#%EF%B8%8F-usage)
   provided by the flavor author.
@@ -123,12 +122,16 @@ plugin manager.
 ---@type LazyPlugin[]
 return {
   {
-    -- a yazi plugin which like flash.nvim in neovim,allow use key char to Precise selection
-    -- https://github.com/DreamMaoMao/keyjump.yazi
-    "DreamMaoMao/keyjump.yazi",
+    -- example: a yazi plugin monorepo which provides multiple plugins for
+    -- yazi. To use it, you need to specify the sub_dir for the plugin you want
+    -- to install.
+    "redbeardymcgee/yazi-plugins",
     lazy = true,
     build = function(plugin)
-      require("yazi.plugin").build_plugin(plugin)
+      -- This is a plugin like flash.nvim in neovim - it allows you to jump to
+      -- a line by typing the first few characters of the line.
+      -- https://github.com/redbeardymcgee/yazi-plugins
+      require("yazi.plugin").build_plugin(plugin, { sub_dir = "keyjump.yazi" })
     end,
   },
   {

--- a/lua/yazi/plugin.lua
+++ b/lua/yazi/plugin.lua
@@ -21,6 +21,10 @@ local M = {}
 ---   build = function(plugin)
 ---     -- this will be called by lazy.nvim after the plugin was updated
 ---     require("yazi.plugin").build_plugin(plugin)
+---
+---     -- if your plugin is not found at the root of the repository, you can
+---     -- specify a subdirectory like this:
+---     require("yazi.plugin").build_plugin({ sub_dir = "my-plugin.yazi" })
 ---   end,
 --- }
 --- ```
@@ -28,7 +32,7 @@ local M = {}
 --- For more information, see the yazi.nvim documentation.
 ---
 ---@param plugin YaziLazyNvimSpec
----@param options? { yazi_dir: string }
+---@param options? { yazi_dir: string, sub_dir?: string }
 function M.build_plugin(plugin, options)
   local yazi_dir = options and options.yazi_dir
     or vim.fn.expand('~/.config/yazi')
@@ -39,11 +43,19 @@ function M.build_plugin(plugin, options)
 
   local to = vim.fs.normalize(vim.fs.joinpath(yazi_plugins_dir, plugin.name))
 
+  if options and options.sub_dir then
+    plugin = {
+      name = plugin.name,
+      dir = vim.fs.joinpath(plugin.dir, options.sub_dir),
+    }
+    to = vim.fs.normalize(vim.fs.joinpath(yazi_plugins_dir, options.sub_dir))
+  end
+
   return M.symlink(plugin, to)
 end
 
 ---@param flavor YaziLazyNvimSpec
----@param options? { yazi_dir: string }
+---@param options? { yazi_dir: string, sub_dir?: string }
 function M.build_flavor(flavor, options)
   local yazi_dir = options and options.yazi_dir
     or vim.fn.expand('~/.config/yazi')
@@ -53,6 +65,14 @@ function M.build_flavor(flavor, options)
   vim.fn.mkdir(yazi_flavors_dir, 'p')
 
   local to = vim.fs.normalize(vim.fs.joinpath(yazi_flavors_dir, flavor.name))
+
+  if options and options.sub_dir then
+    flavor = {
+      name = flavor.name,
+      dir = vim.fs.joinpath(flavor.dir, options.sub_dir),
+    }
+    to = vim.fs.normalize(vim.fs.joinpath(yazi_flavors_dir, options.sub_dir))
+  end
 
   return M.symlink(flavor, to)
 end

--- a/spec/yazi/plugin_spec.lua
+++ b/spec/yazi/plugin_spec.lua
@@ -53,6 +53,28 @@ describe('installing a plugin', function()
       assert.is_equal(result.error, 'source directory does not exist')
       assert.is_equal(result.from, plugin_dir)
     end)
+
+    it('can install a plugin from a monorepo subdirectory', function()
+      local plugin_monorepo_dir = vim.fs.joinpath(base_dir, 'yazi-plugins')
+      local plugin_dir = vim.fs.joinpath(plugin_monorepo_dir, 'keyjump.yazi')
+      local yazi_dir = vim.fs.joinpath(base_dir, 'fake-yazi-dir')
+
+      vim.fn.mkdir(plugin_monorepo_dir)
+      vim.fn.mkdir(plugin_dir)
+      vim.fn.mkdir(yazi_dir)
+      vim.fn.mkdir(vim.fs.joinpath(yazi_dir, 'plugins'))
+
+      plugin.build_plugin({
+        dir = plugin_monorepo_dir,
+        name = 'yazi-plugins',
+      }, { yazi_dir = yazi_dir, sub_dir = 'keyjump.yazi' })
+
+      -- verify that the plugin was symlinked
+      local symlink =
+        vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'plugins', 'keyjump.yazi'))
+
+      assert.are.same(plugin_dir, symlink)
+    end)
   end)
 
   describe('installing a flavor', function()
@@ -70,6 +92,29 @@ describe('installing a plugin', function()
 
       local symlink =
         vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'flavors', 'test-flavor'))
+
+      assert.are.same(flavor_dir, symlink)
+    end)
+
+    it('can install a flavor from a monorepo subdirectory', function()
+      local flavor_monorepo_dir = vim.fs.joinpath(base_dir, 'yazi-flavors')
+      local flavor_dir = vim.fs.joinpath(flavor_monorepo_dir, 'flavor123.yazi')
+      local yazi_dir = vim.fs.joinpath(base_dir, 'fake-yazi-dir')
+
+      vim.fn.mkdir(flavor_monorepo_dir)
+      vim.fn.mkdir(flavor_dir)
+      vim.fn.mkdir(yazi_dir)
+      vim.fn.mkdir(vim.fs.joinpath(yazi_dir, 'flavors'))
+
+      plugin.build_flavor({
+        dir = flavor_monorepo_dir,
+        name = 'yazi-flavors',
+      }, { yazi_dir = yazi_dir, sub_dir = 'flavor123.yazi' })
+
+      -- verify that the flavor was symlinked
+      local symlink = vim.uv.fs_readlink(
+        vim.fs.joinpath(yazi_dir, 'flavors', 'flavor123.yazi')
+      )
 
       assert.are.same(flavor_dir, symlink)
     end)


### PR DESCRIPTION
Some plugins are not found at the root of the repository, but in a
subdirectory. This change allows specifying a subdirectory when
installing a plugin.

It corresponds to using `#` in the plugin URL when installing plugins
without yazi.nvim with the `ya pack` command.

```sh
ya pack -a redbeardymcgee/yazi-plugins#keyjump
```

Is the same as:

```lua
---@type LazySpec
{
  "redbeardymcgee/yazi-plugins",
  lazy = true,
  build = function(plugin)
    require("yazi.plugin").build_plugin(plugin, { sub_dir = "keyjump.yazi" })
  end,
},
```