### PR TITLE
feat!: add default colors for hover highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
     -- https://github.com/mikavilpas/yazi.nvim/pull/180
     highlight_groups = {
       -- NOTE: this only works if `use_ya_for_events_reading` is enabled, etc.
-      hovered_buffer_background = nil,
+      hovered_buffer = nil,
     },
 
     -- the floating window scaling factor. 1 means 100%, 0.9 means 90%, etc.

--- a/integration-tests/client/testEnvironmentTypes.ts
+++ b/integration-tests/client/testEnvironmentTypes.ts
@@ -12,6 +12,7 @@ export type StartNeovimServerArguments = {
 export type StartupScriptModification =
   | "modify_yazi_config_to_use_ya_as_event_reader.lua"
   | "modify_yazi_config_and_add_hovered_buffer_background.lua"
+  | "use_light_neovim_colorscheme.lua"
 
 declare global {
   interface Window {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/express": "4.17.21",
     "@types/node": "20.14.10",
+    "@types/tinycolor2": "1.4.6",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "7.16.0",
     "@typescript-eslint/parser": "7.16.0",
@@ -28,6 +29,7 @@
     "eslint-plugin-no-only-tests": "3.1.0",
     "express": "4.19.2",
     "prettier-plugin-organize-imports": "4.0.0",
+    "tinycolor2": "1.6.0",
     "tsc-watch": "6.2.0",
     "typescript": "5.5.3",
     "vite": "^5.3.1"

--- a/integration-tests/server/server.ts
+++ b/integration-tests/server/server.ts
@@ -64,6 +64,15 @@ io.on("connection", function connection(socket) {
               args.push("-c", `lua dofile('${file}')`)
               break
             }
+            case "use_light_neovim_colorscheme.lua": {
+              const file = path.join(
+                testDirectory,
+                "config-modifications",
+                "use_light_neovim_colorscheme.lua",
+              )
+              args.push("-c", `lua dofile('${file}')`)
+              break
+            }
             default:
               modification satisfies never
               throw new Error(

--- a/integration-tests/test-environment/config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua
+++ b/integration-tests/test-environment/config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua
@@ -4,7 +4,7 @@ require('yazi').setup(
   ---@type YaziConfig
   {
     highlight_groups = {
-      hovered_buffer_background = { bg = '#494d64' },
+      hovered_buffer = { bg = '#494d64' },
     },
   }
 )

--- a/integration-tests/test-environment/config-modifications/use_light_neovim_colorscheme.lua
+++ b/integration-tests/test-environment/config-modifications/use_light_neovim_colorscheme.lua
@@ -1,0 +1,3 @@
+-- Catppuccin defines a custom command to correctly switch the colorscheme
+-- https://github.com/catppuccin/nvim
+vim.cmd('Catppuccin latte')

--- a/lazy.lua
+++ b/lazy.lua
@@ -9,6 +9,7 @@
 ---@type LazySpec
 return {
   { 'nvim-lua/plenary.nvim', lazy = true },
+  { 'akinsho/bufferline.nvim', lazy = true },
   {
     'mikavilpas/yazi.nvim',
     ---@type YaziConfig

--- a/lua/yazi/buffer_highlighting/disposable_highlight.lua
+++ b/lua/yazi/buffer_highlighting/disposable_highlight.lua
@@ -6,6 +6,25 @@ local Log = require('yazi.log')
 local DisposableHighlight = {}
 DisposableHighlight.__index = DisposableHighlight
 
+local function create_hover_color_from_theme()
+  -- the user has not defined a custom highlight color, so let's create one
+  -- for them
+  local colors = require('bufferline.colors')
+  local hex = colors.get_color
+
+  local bg = hex({ name = 'Normal', attribute = 'bg' })
+
+  if bg == nil then
+    return
+  end
+
+  if colors.color_is_bright(bg) then
+    return { bg = colors.shade_color(bg, -20), force = true }
+  else
+    return { bg = colors.shade_color(bg, 60), force = true }
+  end
+end
+
 ---@param window_id integer
 ---@param highlight_config YaziConfigHighlightGroups
 function DisposableHighlight.new(window_id, highlight_config)
@@ -13,15 +32,25 @@ function DisposableHighlight.new(window_id, highlight_config)
   self.window_id = window_id
   self.old_winhighlight = vim.wo.winhighlight
 
-  vim.api.nvim_set_hl(
-    0,
-    'YaziBufferHoveredBackground',
-    highlight_config.hovered_buffer_background
-  )
+  -- `force = true` overrides the existing highlight group - so that the user
+  -- can see the correct color if they switch colorschemes without restarting
+  if highlight_config.hovered_buffer ~= nil then
+    vim.api.nvim_set_hl(0, 'YaziBufferHovered', highlight_config.hovered_buffer)
+  else
+    local color = create_hover_color_from_theme()
+    if color == nil then
+      Log:debug(
+        'Could not find a background color for a hovered_buffer, not highlighting'
+      )
+
+      return
+    end
+    vim.api.nvim_set_hl(0, 'YaziBufferHovered', color)
+  end
 
   vim.api.nvim_set_option_value(
     'winhighlight',
-    'Normal:YaziBufferHoveredBackground',
+    'Normal:YaziBufferHovered',
     { win = window_id }
   )
 
@@ -29,14 +58,14 @@ function DisposableHighlight.new(window_id, highlight_config)
 end
 
 function DisposableHighlight:dispose()
-  Log:debug(
-    string.format(
-      'Disposing of the DisposableHighlight for window_id %s',
-      self.window_id
-    )
-  )
-  -- Revert winhighlight to its old value
   if vim.api.nvim_win_is_valid(self.window_id) then
+    -- Revert winhighlight to its old value
+    Log:debug(
+      string.format(
+        'Disposing of the DisposableHighlight for window_id %s',
+        self.window_id
+      )
+    )
     vim.api.nvim_set_option_value('winhighlight', self.old_winhighlight, {
       win = self.window_id,
     })

--- a/lua/yazi/buffer_highlighting/highlight_hovered_buffer.lua
+++ b/lua/yazi/buffer_highlighting/highlight_hovered_buffer.lua
@@ -19,27 +19,21 @@ function M.clear_highlights()
 end
 
 ---@param url string
----@param highlight_config YaziConfigHighlightGroups | nil
+---@param highlight_config YaziConfigHighlightGroups
 function M.highlight_hovered_buffer(url, highlight_config)
-  if
-    highlight_config == nil
-    or highlight_config.hovered_buffer_background == nil
-  then
-    Log:debug('no color to highlight_hovered_buffer with, not highlighting')
-    return
-  end
+  assert(highlight_config, 'highlight_config is required')
 
   local visible_open_buffers = utils.get_visible_open_buffers()
   for _, buffer in ipairs(visible_open_buffers) do
     if buffer.renameable_buffer:matches_exactly(url) then
-      Log:debug(
-        'highlighting buffer '
-          .. buffer.renameable_buffer.bufnr
-          .. ' in window '
-          .. buffer.window_id
-      )
       local hl = window_highlights[buffer.window_id]
       if hl == nil then
+        Log:debug(
+          'highlighting buffer '
+            .. buffer.renameable_buffer.bufnr
+            .. ' in window '
+            .. buffer.window_id
+        )
         hl = DisposableHighlight.new(buffer.window_id, highlight_config)
         window_highlights[buffer.window_id] = hl
       end

--- a/lua/yazi/buffer_highlighting/highlight_hovered_buffer.lua
+++ b/lua/yazi/buffer_highlighting/highlight_hovered_buffer.lua
@@ -26,16 +26,17 @@ function M.highlight_hovered_buffer(url, highlight_config)
   local visible_open_buffers = utils.get_visible_open_buffers()
   for _, buffer in ipairs(visible_open_buffers) do
     if buffer.renameable_buffer:matches_exactly(url) then
-      local hl = window_highlights[buffer.window_id]
-      if hl == nil then
+      local existing_hl = window_highlights[buffer.window_id]
+      if existing_hl == nil then
         Log:debug(
           'highlighting buffer '
             .. buffer.renameable_buffer.bufnr
             .. ' in window '
             .. buffer.window_id
         )
-        hl = DisposableHighlight.new(buffer.window_id, highlight_config)
-        window_highlights[buffer.window_id] = hl
+
+        window_highlights[buffer.window_id] =
+          DisposableHighlight.new(buffer.window_id, highlight_config)
       end
     else
       -- only one file can be hovered at a time, so let's clear

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -22,7 +22,7 @@ function M.default()
     },
 
     highlight_groups = {
-      hovered_buffer_background = nil,
+      hovered_buffer = nil,
     },
 
     integrations = {

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -42,6 +42,8 @@ return {
     vim.health.info('yazi.nvim log file is at ' .. logfile_location)
     vim.health.info('    hint: use `gf` to open the file path under the cursor')
 
+    -- TODO validate that the highlight_config is present in the configuration
+
     if require('yazi').config.use_ya_for_events_reading == true then
       if vim.fn.executable('ya') ~= 1 then
         vim.health.error(

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -27,7 +27,7 @@
 ---@field public grep_in_directory? fun(directory: string): nil "a function that will be called when the user wants to grep in a directory"
 
 ---@class (exact) YaziConfigHighlightGroups # Defines the highlight groups that will be used in yazi
----@field public hovered_buffer_background? vim.api.keyset.highlight # the color of the background of buffer that is hovered over
+---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 
 ---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@types/express": "4.17.21",
         "@types/node": "20.14.10",
+        "@types/tinycolor2": "1.4.6",
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "7.16.0",
         "@typescript-eslint/parser": "7.16.0",
@@ -47,9 +48,10 @@
         "eslint-plugin-no-only-tests": "3.1.0",
         "express": "4.19.2",
         "prettier-plugin-organize-imports": "4.0.0",
+        "tinycolor2": "1.6.0",
         "tsc-watch": "6.2.0",
         "typescript": "5.5.3",
-        "vite": "^5.3.3"
+        "vite": "^5.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1362,6 +1364,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
       "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg=="
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+      "dev": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -7311,6 +7319,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.2.3",

--- a/yazi.nvim-scm-1.rockspec
+++ b/yazi.nvim-scm-1.rockspec
@@ -9,6 +9,10 @@ dependencies = {
   -- Add runtime dependencies here
   -- e.g. "plenary.nvim",
   'plenary.nvim',
+
+  -- https://github.com/akinsho/bufferline.nvim
+  -- https://luarocks.org/modules/neorocks/bufferline.nvim
+  'bufferline.nvim',
 }
 test_dependencies = {
   'nlua',


### PR DESCRIPTION
# Hover highlighting is now enabled by default

(Hover highlighting is a feature currently requiring opt-in that was added in #180)

This works with the latest yazi when `use_ya_for_events_reading = true` is specified. To learn more about enabling this, see <https://github.com/mikavilpas/yazi.nvim/pull/152>

This will be the default behaviour when yazi 0.3 is released.

# Hover highlighting colors no longer require manual configuration

> Dark mode
>
> (neovim: catppuccin macchiato, yazi: catppuccin macchiato)

https://github.com/user-attachments/assets/f4c94fc0-8e8a-41b5-94ee-4ecef201b6e2

> Light mode
>
> (neovim: catppuccin latte, yazi: catppuccin macchiato)
>
> Just focus on the background color of the hovered buffer as I couldn't be bothered to change my yazi theme 😅

https://github.com/user-attachments/assets/6f634d67-3a64-4b53-a097-46b49849b40e

This change adds default colors for the hover highlighting feature. The logic supports both light and dark colorschemes:

- for dark colorschemes, the hovered buffer will be lighter in color
- for light colorschemes, it will be darker

The logic is borrowed from the `bufferline.nvim` plugin, which has a lot of users and is well-maintained. This also adds a dependency to bufferline.nvim, but as an optimization only its color utility functions are used as late as possible, and even they are only used when the user hasn't specified a custom highlight color.

# ⚠️ BREAKING CHANGE:

The optional `hovered_buffer_background` key in the `YaziConfigHighlightGroups` has been renamed to `hovered_buffer`. This change was made to better reflect the purpose of the key.

To migrate, run this 🙂

```vim
:%s/hovered_buffer_background/hovered_buffer/gc
```