### PR TITLE
docs: add notice about branch name change causing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # 🎲 A Neovim Plugin for [yazi](https://github.com/sxyazi/yazi.git)
 
+> [!TIP]
+>
+> 2024-07: Some users are experiencing issues updating with lazy.nvim, and have
+> reported uninstalling and reinstalling the plugin seems to work. More
+> information can be found in
+> [#198](https://github.com/mikavilpas/yazi.nvim/pull/198).
+
 <a href="https://dotfyle.com/plugins/mikavilpas/yazi.nvim">
   <img src="https://dotfyle.com/plugins/mikavilpas/yazi.nvim/shield?style=flat-square" alt="shield image for plugin usage" /> </a>
 


### PR DESCRIPTION
I think this is happening because I changed the name of the default branch `master` -> `main`. Lazy.nvim seems to complain by default if the branch disappears.

This seems to be the same issue, and provides a workaround for it:
https://github.com/folke/lazy.nvim/issues/1052#issuecomment-1738770214

So: uninstalling and reinstalling resolves the issue. I added a notice about this to the README.md file.