### PR TITLE
feat(plugin): overwrite existing symlinks when installing plugins

### DIFF
--- a/lua/yazi/plugin.lua
+++ b/lua/yazi/plugin.lua
@@ -85,23 +85,13 @@ end
 function M.symlink(spec, to)
   -- Check if the symlink already exists, which will happen on repeated calls
   local existing_stat = vim.uv.fs_lstat(to)
-  if
-    existing_stat
-    and existing_stat.type == 'link'
-    and vim.uv.fs_readlink(to) == spec.dir
-  then
-    ---@type YaziSpecInstallationResultSuccess
-    local result = {
-      message = 'yazi.nvim: already installed ' .. spec.name,
-      from = spec.dir,
-      to = to,
-    }
-    -- don't notify about this as it's a common case
-    return result
+  if existing_stat and existing_stat.type == 'link' then
+    -- try to remove the symlink as we will soon create a new one
+    vim.uv.fs_unlink(to)
   end
 
-  local dir = vim.uv.fs_stat(spec.dir)
-  if dir == nil or dir.type ~= 'directory' then
+  local source_directory = vim.uv.fs_stat(spec.dir)
+  if source_directory == nil or source_directory.type ~= 'directory' then
     ---@type YaziSpecInstallationResultFailure
     local result = {
       error = 'source directory does not exist',

--- a/spec/yazi/plugin_spec.lua
+++ b/spec/yazi/plugin_spec.lua
@@ -40,6 +40,33 @@ describe('installing a plugin', function()
       assert.are.same(plugin_dir, symlink)
     end)
 
+    it('overwrites any existing symlink', function()
+      -- most of the time this is what the user wants anyway
+      local plugin_dir = vim.fs.joinpath(base_dir, 'test-plugin')
+      local yazi_dir = vim.fs.joinpath(base_dir, 'fake-yazi-dir')
+
+      vim.fn.mkdir(plugin_dir)
+      vim.fn.mkdir(yazi_dir)
+      vim.fn.mkdir(vim.fs.joinpath(yazi_dir, 'plugins'))
+
+      -- create a symlink to a different directory
+      vim.uv.fs_symlink(
+        '/different/directory',
+        vim.fs.joinpath(yazi_dir, 'plugins', 'test-plugin')
+      )
+
+      plugin.build_plugin({
+        dir = plugin_dir,
+        name = 'test-plugin',
+      }, { yazi_dir = yazi_dir })
+
+      -- verify that the plugin was symlinked
+      local symlink =
+        vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'plugins', 'test-plugin'))
+
+      assert.are.same(plugin_dir, symlink)
+    end)
+
     it('warns the user if the plugin directory does not exist', function()
       local plugin_dir = vim.fs.joinpath(base_dir, 'test-plugin')
       local yazi_dir = vim.fs.joinpath(base_dir, 'fake-yazi-dir')


### PR DESCRIPTION
This happened to me when this plugin was moved to a different hosting provider:

- https://github.com/DreamMaoMao/keyjump.yazi
- https://gitee.com/DreamMaoMao/keyjump.yazi

After I changed my lazy.nvim spec to this, I got an error because the symlink already existed:

```lua
{
  name = "keyjump.yazi",
  url = "https://gitee.com/DreamMaoMao/keyjump.yazi.git",
  lazy = true,
  build = function(plugin)
    require("yazi.plugin").build_plugin(plugin)
  end,
},
```

This change makes it so that the symlink is removed before creating a new one. Realistically, this is what the user wants most of the time anyway.