### PR TITLE
fix: symlinked files cannot be highlighted when hovered

### DIFF
--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -35,8 +35,10 @@ end
 ---@param path string can be a parent directory or an exact file path
 ---@return boolean
 function RenameableBuffer:matches_exactly(path)
-  path = remove_trailing_slash(path)
-  return self.path.filename == path
+  local path_a = vim.uv.fs_realpath(path) or path
+  local path_b = vim.uv.fs_realpath(self.path.filename) or self.path.filename
+
+  return path_a == path_b
 end
 
 ---@param path string

--- a/spec/yazi/renameable_buffer_spec.lua
+++ b/spec/yazi/renameable_buffer_spec.lua
@@ -49,7 +49,7 @@ describe('the RenameableBuffer class', function()
     return file_path
   end
 
-  it('#focus matches when the file is a symlink', function()
+  it('matches when the file is a symlink', function()
     local file1_path = create_temp_file('_file1')
     local file2_path = vim.fn.tempname() .. '_file2'
 


### PR DESCRIPTION
I experienced this issue when hovering over my yazi.nvim lazy.nvim spec. It's symlinked to the actual file in the lazy.nvim repository.

These are the same file:

```sh
/Users/mikavilpas/dotfiles/.config/nvim/lua/plugins/my-file-manager.lua
/Users/mikavilpas/.config/nvim/lua/plugins/my-file-manager.lua
```

This commit fixes the issue by resolving the real path of the file before
comparing it to the path of the buffer.

Closes https://github.com/mikavilpas/yazi.nvim/issues/195