### PR TITLE
fix: crash without newest yazi

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -32,12 +32,13 @@ end
 
 ---@param path Path
 ---@param yazi_id string
+---@diagnostic disable-next-line: unused-local
+-- selene: allow(unused_variable)
 function YaProcess:get_yazi_command(path, yazi_id)
   return string.format(
-    'yazi %s --chooser-file "%s" --client-id "%s"',
+    'yazi %s --chooser-file "%s"',
     vim.fn.shellescape(path.filename),
-    self.config.chosen_file_path,
-    yazi_id
+    self.config.chosen_file_path
   )
 end
 


### PR DESCRIPTION
There was a bug in opting in to the feature from 8114817 (feat: add targeted communication with the yazi instance (opt-in) (#225)). Even if you had not set `use_yazi_client_id_flag = true` in your config, the newest yazi was still required.

This commit fixes that bug by removing the passing of the `yazi_id` (roll forward style). Later changes can still utilize the feature and build on top of this.