### PR TITLE
feat: pressing `tab` in yazi jumps to dir of next open split

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ open yazi in a floating window in Neovim.
 - 🆕 Plugin manager for Yazi plugins and flavors
   ([documentation](./documentation/plugin-manager.md)). Please provide your
   feedback!
+- Features available if you are using a development version of yazi (see
+  [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md)):
+  - Highlight the currently hovered yazi file in Neovim
+  - Restart the last yazi session with a keybinding
+  - `<tab>` makes yazi jump to the directory of the next open split
 
 For previewing images with yazi, see Yazi's documentation related to Neovim
 [here](https://yazi-rs.github.io/docs/image-preview/#neovim).

--- a/integration-tests/client/testEnvironmentTypes.ts
+++ b/integration-tests/client/testEnvironmentTypes.ts
@@ -1,6 +1,12 @@
+export type MultipleFiles = {
+  openInVerticalSplits: File[]
+}
+
+type File = TestDirectoryFile | "."
+
 /** The arguments given from the tests to send to the server */
 export type StartNeovimArguments = {
-  filename?: TestDirectoryFile | "."
+  filename?: File | MultipleFiles
   startupScriptModifications?: StartupScriptModification[]
 }
 
@@ -57,9 +63,10 @@ export type TestDirectory = {
     ["test.lua"]: FileEntry
     ["file.txt"]: FileEntry
     ["modify_yazi_config_to_use_ya_as_event_reader.lua"]: FileEntry
-    ["subdirectory/sub.txt"]: FileEntry
+    ["subdirectory/subdirectory-file.txt"]: FileEntry
+    ["other-subdirectory/other-sub-file.txt"]: FileEntry
     ["routes/posts.$postId/route.tsx"]: FileEntry
-    ["routes/posts.$postId/adjacent-file.tsx"]: FileEntry
+    ["routes/posts.$postId/adjacent-file.txt"]: FileEntry
   }
 }
 

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -82,9 +82,14 @@ export default defineConfig({
                   stem: "file",
                   extension: ".txt",
                 },
-                "subdirectory/sub.txt": {
-                  name: "sub.txt",
-                  stem: "sub",
+                "subdirectory/subdirectory-file.txt": {
+                  name: "subdirectory-file.txt",
+                  stem: "subdirectory-file",
+                  extension: ".txt",
+                },
+                ["other-subdirectory/other-sub-file.txt"]: {
+                  name: "other-sub-file.txt",
+                  stem: "other-sub-file",
                   extension: ".txt",
                 },
                 "modify_yazi_config_to_use_ya_as_event_reader.lua": {
@@ -92,10 +97,10 @@ export default defineConfig({
                   stem: "modify_yazi_config_to_use_ya_as_event_reader",
                   extension: ".lua",
                 },
-                "routes/posts.$postId/adjacent-file.tsx": {
-                  name: "adjacent-file.tsx",
+                "routes/posts.$postId/adjacent-file.txt": {
+                  name: "adjacent-file.txt",
                   stem: "adjacent-file",
-                  extension: ".tsx",
+                  extension: ".txt",
                 },
                 "routes/posts.$postId/route.tsx": {
                   name: "route.tsx",
@@ -110,6 +115,7 @@ export default defineConfig({
             execSync(`cp ./test-environment/file.txt ${dir}/`)
             execSync(`cp ./test-environment/test-setup.lua ${dir}/test.lua`)
             execSync(`cp -r ./test-environment/subdirectory ${dir}/`)
+            execSync(`cp -r ./test-environment/other-subdirectory ${dir}/`)
             execSync(`cp -r ./test-environment/config-modifications/ ${dir}/`)
             execSync(`cp -r ./test-environment/routes ${dir}/`)
             console.log(`Created test directory at ${dir}`)

--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
@@ -85,7 +85,7 @@ describe("opening files", () => {
 
       // close yazi just to be sure the file preview is not found instead
       cy.get(
-        dir.contents["routes/posts.$postId/adjacent-file.tsx"].name,
+        dir.contents["routes/posts.$postId/adjacent-file.txt"].name,
       ).should("not.exist")
 
       // the file contents should now be visible

--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
@@ -55,10 +55,17 @@ describe("opening files", () => {
   it("can send file names to the quickfix list", () => {
     cy.startNeovim().then((dir) => {
       cy.typeIntoTerminal("{upArrow}")
-      cy.typeIntoTerminal("{control+a}{enter}")
+
+      // wait for yazi to open
+      cy.contains(dir.contents["test.lua"].name)
+
+      // select the initial file, the cursor moves one line down to the next file
+      cy.typeIntoTerminal(" ")
+      // also select the next file because multiple files have to be selected
+      cy.typeIntoTerminal(" ")
+      cy.typeIntoTerminal("{enter}")
 
       // items in the quickfix list should now be visible
-      cy.contains(`${dir.contents["file.txt"].name}||`)
       cy.contains(`${dir.contents["initial-file.txt"].name}||`)
     })
   })

--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/reading-events.cy.ts
@@ -17,11 +17,11 @@ describe("reading events", () => {
     // telescope should now be visible. Let's search for the contents of the
     // file, which we know beforehand
     cy.contains("Grep in")
-    cy.typeIntoTerminal("Hello")
+    cy.typeIntoTerminal("This")
 
     // we should see text indicating the search is limited to the current
     // directory
-    cy.contains("Hello from the subdirectory! 👋")
+    cy.contains("This is other-sub-file.txt")
   })
 })
 

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
@@ -1,0 +1,119 @@
+import { isHovered, isNotHovered } from "./hover-utils"
+import { startNeovimWithYa } from "./startNeovimWithYa"
+
+// NOTE: cypress doesn't support the tab key, but control+i seems to work fine
+// https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
+
+// TODO make this more robust once we can jump to a file, not just a
+// directory - could test with directories that have multiple files
+
+describe("'cd' to another buffer's directory", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:5173")
+  })
+
+  it("can highlight the buffer when hovered", () => {
+    const view = {
+      leftFile: { text: "This is other-sub-file.txt" },
+      centerFile: { text: "this file is adjacent-file.txt" },
+      rightFile: { text: "ello from the subdirectory!" },
+    } as const
+
+    startNeovimWithYa({
+      filename: {
+        openInVerticalSplits: [
+          "subdirectory/subdirectory-file.txt",
+          "routes/posts.$postId/adjacent-file.txt",
+          "other-subdirectory/other-sub-file.txt",
+        ],
+      },
+      startupScriptModifications: [
+        "modify_yazi_config_and_add_hovered_buffer_background.lua",
+      ],
+    }).then(() => {
+      // sanity check to make sure the files are open
+      cy.contains(view.leftFile.text)
+      cy.contains(view.centerFile.text)
+      cy.contains(view.rightFile.text)
+
+      // before doing anything, both files should be unhovered (have the
+      // default background color)
+      isNotHovered(view.leftFile.text)
+      isNotHovered(view.centerFile.text)
+      isNotHovered(view.rightFile.text)
+
+      // start yazi
+      cy.typeIntoTerminal("{upArrow}")
+
+      // Switch to the other buffers' directories in yazi. This should make
+      // yazi send a hover event for the new, highlighted file.
+      //
+      // Since each directory only has one file, it should be highlighted :)
+      cy.typeIntoTerminal("{control+i}")
+      isNotHovered(view.leftFile.text)
+      isHovered(view.centerFile.text)
+      isNotHovered(view.rightFile.text)
+
+      cy.typeIntoTerminal("{control+i}")
+      isHovered(view.leftFile.text)
+      isNotHovered(view.centerFile.text)
+      isNotHovered(view.rightFile.text)
+
+      cy.typeIntoTerminal("{control+i}")
+      isNotHovered(view.leftFile.text)
+      isNotHovered(view.centerFile.text)
+      isHovered(view.rightFile.text)
+
+      // tab once more to make sure it wraps around
+      cy.typeIntoTerminal("{control+i}")
+      isNotHovered(view.leftFile.text)
+      isHovered(view.centerFile.text)
+      isNotHovered(view.rightFile.text)
+    })
+  })
+
+  it("skips highlighting splits for the same file", () => {
+    const view = {
+      leftAndCenterFile: { text: "ello from the subdirectory!" },
+      rightFile: { text: "This is other-sub-file.txt" },
+    } as const
+
+    startNeovimWithYa({
+      filename: {
+        openInVerticalSplits: [
+          // open the same file in two splits
+          "subdirectory/subdirectory-file.txt",
+          "subdirectory/subdirectory-file.txt",
+          "other-subdirectory/other-sub-file.txt",
+        ],
+      },
+      startupScriptModifications: [
+        "modify_yazi_config_and_add_hovered_buffer_background.lua",
+      ],
+    }).then(() => {
+      isNotHovered(view.leftAndCenterFile.text)
+      isNotHovered(view.rightFile.text)
+
+      // start yazi
+      cy.typeIntoTerminal("{upArrow}")
+
+      cy.typeIntoTerminal("{control+i}")
+
+      // the right file should be highlighted
+      isNotHovered(view.leftAndCenterFile.text)
+      isHovered(view.rightFile.text)
+
+      // tab again to make sure it wraps around. It should highlight both splits
+      cy.typeIntoTerminal("{control+i}")
+      isHovered(view.leftAndCenterFile.text)
+      isNotHovered(view.rightFile.text)
+
+      // tab again. Since the left and center file are the same, it should
+      // skip the center file and highlight the right file
+
+      cy.typeIntoTerminal("{control+i}")
+      isNotHovered(view.leftAndCenterFile.text)
+      isHovered(view.rightFile.text)
+    })
+  })
+})

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/hover-highlights.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/hover-highlights.cy.ts
@@ -1,29 +1,22 @@
-import { flavors } from "@catppuccin/palette"
 import * as tinycolor2 from "tinycolor2"
+import {
+  darkBackgroundColors,
+  isHovered,
+  isNotHovered,
+  lightBackgroundColors,
+} from "./hover-utils"
 import { startNeovimWithYa } from "./startNeovimWithYa"
-
-const darkTheme = flavors.macchiato.colors
-const lightTheme = flavors.latte.colors
-
-function rgbify(color: (typeof darkTheme)["surface0"]["rgb"]) {
-  return `rgb(${color.r.toString()}, ${color.g.toString()}, ${color.b.toString()})`
-}
 
 describe("highlighting the buffer with 'hover' events", () => {
   beforeEach(() => {
     cy.visit("http://localhost:5173")
   })
 
-  const darkBackgroundColors = {
-    normal: rgbify(darkTheme.base.rgb),
-    hovered: rgbify(darkTheme.surface1.rgb),
-  }
-
   // NOTE: when opening the file, the cursor is placed at the beginning of
   // the file. This causes the web terminal to render multiple elements for the
   // same text, and this can cause issues when matching colors, as in the DOM
-  // there are multiple colors. Work around this by matching a substring of the
-  // text instead of the whole text.
+  // there really are multiple colors present. Work around this by matching a
+  // substring of the text instead of the whole text.
 
   /** HACK in CI, there can be timing issues where the first hover event is
    * lost. Right now we work around this by selecting another file first, then
@@ -44,9 +37,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      cy.contains("If you see this text, Neovim is ready!")
-        .children()
-        .should("have.css", "background-color", darkBackgroundColors.normal)
+      isNotHovered("f you see this text, Neovim is ready!")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -57,23 +48,15 @@ describe("highlighting the buffer with 'hover' events", () => {
 
       // yazi is shown and adjacent files should be visible now
       //
-      // the current file (initial-file.txt) is highlighted by default when
+      // the current file is highlighted by default when
       // opening yazi. This should have sent the 'hover' event and caused the
       // Neovim window to be shown with a different background color
-      cy.contains("If you see this text, Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.hovered,
-      )
+      isHovered("If you see this text, Neovim is ready!")
 
       // close yazi - the highlight should be removed and we should see the
       // same color as before
       cy.typeIntoTerminal("q")
-      cy.contains("Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.normal,
-      )
+      isNotHovered("f you see this text, Neovim is ready!")
     })
   })
 
@@ -84,11 +67,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      cy.contains("Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.normal,
-      )
+      isNotHovered("f you see this text, Neovim is ready!")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -100,23 +79,15 @@ describe("highlighting the buffer with 'hover' events", () => {
         dir.contents["initial-file.txt"].name,
       )
 
-      // the current file (initial-file.txt) is highlighted by default when
+      // the current file is highlighted by default when
       // opening yazi. This should have sent the 'hover' event and caused the
       // Neovim window to be shown with a different background color
-      cy.contains("Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.hovered,
-      )
+      isHovered("If you see this text, Neovim is ready!")
 
       // hover another file - the highlight should be removed
       cy.typeIntoTerminal(`/^${dir.contents["test.lua"].name}{enter}`)
 
-      cy.contains("Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.normal,
-      )
+      isNotHovered("If you see this text, Neovim is ready!")
     })
   })
 
@@ -127,9 +98,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      cy.contains("If you see this text, Neovim is ready!")
-        .children()
-        .should("have.css", "background-color", darkBackgroundColors.normal)
+      isNotHovered("f you see this text, Neovim is ready!")
 
       const testFile = dir.contents["test.lua"].name
       // open an adjacent file and wait for it to be displayed
@@ -142,26 +111,14 @@ describe("highlighting the buffer with 'hover' events", () => {
       cy.typeIntoTerminal("{upArrow}")
 
       hoverAnotherFileToEnsureHoverEventIsReceivedInCI(testFile)
-      cy.contains("how to initialize the test environment").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.hovered,
-      )
+      isHovered("how to initialize the test environment")
 
       // select the other file - the highlight should move to it
       cy.typeIntoTerminal(`/^${dir.contents["initial-file.txt"].name}{enter}`, {
         delay: 1,
       })
-      cy.contains("how to initialize the test environment").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.normal,
-      )
-      cy.contains("If you see this text, Neovim is ready!").should(
-        "have.css",
-        "background-color",
-        darkBackgroundColors.hovered,
-      )
+      isNotHovered("how to initialize the test environment")
+      isHovered("If you see this text, Neovim is ready!")
     })
   })
 
@@ -173,9 +130,7 @@ describe("highlighting the buffer with 'hover' events", () => {
     it("for a dark colorscheme, hovers appear lighter in color", () => {
       startNeovimWithYa({ startupScriptModifications: [] }).then((dir) => {
         // wait until text on the start screen is visible
-        cy.contains("If you see this text, Neovim is ready!")
-          .children()
-          .should("have.css", "background-color", darkBackgroundColors.normal)
+        isNotHovered("f you see this text, Neovim is ready!")
 
         // start yazi
         cy.typeIntoTerminal("{upArrow}")
@@ -202,10 +157,6 @@ describe("highlighting the buffer with 'hover' events", () => {
     })
 
     it("for a light colorscheme", () => {
-      const lightBackgroundColors = {
-        normal: rgbify(lightTheme.base.rgb),
-      }
-
       startNeovimWithYa({
         startupScriptModifications: ["use_light_neovim_colorscheme.lua"],
       }).then((dir) => {

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/hover-utils.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/hover-utils.ts
@@ -1,0 +1,38 @@
+import { flavors } from "@catppuccin/palette"
+
+const darkTheme = flavors.macchiato.colors
+const lightTheme = flavors.latte.colors
+
+function rgbify(color: (typeof darkTheme)["surface0"]["rgb"]) {
+  return `rgb(${color.r.toString()}, ${color.g.toString()}, ${color.b.toString()})`
+}
+
+export const darkBackgroundColors = {
+  normal: rgbify(darkTheme.base.rgb),
+  // NOTE: this abstraction is super leaky. It assumes
+  // config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua
+  // is being used
+  hovered: rgbify(darkTheme.surface1.rgb),
+}
+
+export const lightBackgroundColors = {
+  normal: rgbify(lightTheme.base.rgb),
+}
+
+// only works for the dark colorscheme for now
+export function isHovered(text: string): void {
+  cy.contains(text).should(
+    "have.css",
+    "background-color",
+    darkBackgroundColors.hovered,
+  )
+}
+
+// only works for the dark colorscheme for now
+export function isNotHovered(text: string): void {
+  cy.contains(text).should(
+    "have.css",
+    "background-color",
+    darkBackgroundColors.normal,
+  )
+}

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
@@ -57,10 +57,17 @@ describe("opening files", () => {
   it("can send file names to the quickfix list", () => {
     startNeovimWithYa().then((dir) => {
       cy.typeIntoTerminal("{upArrow}")
-      cy.typeIntoTerminal("{control+a}{enter}")
+
+      // wait for yazi to open
+      cy.contains(dir.contents["test.lua"].name)
+
+      // select the initial file, the cursor moves one line down to the next file
+      cy.typeIntoTerminal(" ")
+      // also select the next file because multiple files have to be selected
+      cy.typeIntoTerminal(" ")
+      cy.typeIntoTerminal("{enter}")
 
       // items in the quickfix list should now be visible
-      cy.contains(`${dir.contents["file.txt"].name}||`)
       cy.contains(`${dir.contents["initial-file.txt"].name}||`)
     })
   })

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
@@ -148,7 +148,7 @@ describe("opening files", () => {
 
       // close yazi just to be sure the file preview is not found instead
       cy.get(
-        dir.contents["routes/posts.$postId/adjacent-file.tsx"].name,
+        dir.contents["routes/posts.$postId/adjacent-file.txt"].name,
       ).should("not.exist")
 
       // the file contents should now be visible

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -22,11 +22,11 @@ describe("reading events", () => {
     // telescope should now be visible. Let's search for the contents of the
     // file, which we know beforehand
     cy.contains("Grep in")
-    cy.typeIntoTerminal("Hello")
+    cy.typeIntoTerminal("This")
 
     // we should see text indicating the search is limited to the current
     // directory
-    cy.contains("Hello from the subdirectory! 👋")
+    cy.contains("This is other-sub-file.txt")
   })
 
   it("can read 'trash' events and close an open buffer when its file was trashed", () => {

--- a/integration-tests/server/server.ts
+++ b/integration-tests/server/server.ts
@@ -82,8 +82,18 @@ io.on("connection", function connection(socket) {
         }
       }
       if (startArgs.filename) {
-        const file = path.join(startArgs.directory, startArgs.filename)
-        args.push(file)
+        if (typeof startArgs.filename === "string") {
+          const file = path.join(startArgs.directory, startArgs.filename)
+          args.push(file)
+        } else if (startArgs.filename.openInVerticalSplits.length > 0) {
+          // `-O[N]` Open N vertical windows (default: one per file)
+          args.push("-O")
+
+          for (const file of startArgs.filename.openInVerticalSplits) {
+            const filePath = path.join(startArgs.directory, file)
+            args.push(filePath)
+          }
+        }
       }
 
       const app = TerminalApplication.start({

--- a/integration-tests/test-environment/other-subdirectory/other-sub-file.txt
+++ b/integration-tests/test-environment/other-subdirectory/other-sub-file.txt
@@ -1,0 +1,1 @@
+This is other-sub-file.txt

--- a/integration-tests/test-environment/routes/posts.$postId/adjacent-file.txt
+++ b/integration-tests/test-environment/routes/posts.$postId/adjacent-file.txt
@@ -1,0 +1,1 @@
+this file is adjacent-file.txt

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -94,7 +94,11 @@ function M.yazi(config, input_path)
   )
 
   config.hooks.yazi_opened(path.filename, win.content_buffer, config)
-  config.set_keymappings_function(win.content_buffer, config)
+
+  config.set_keymappings_function(win.content_buffer, config, {
+    api = yazi_process.api,
+    input_path = path,
+  })
 
   win.on_resized = function(event)
     vim.fn.jobresize(

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -47,7 +47,8 @@ end
 --- this function as the basis.
 ---@param yazi_buffer integer
 ---@param config YaziConfig
-function M.default_set_keymappings_function(yazi_buffer, config)
+---@param context YaziActiveContext
+function M.default_set_keymappings_function(yazi_buffer, config, context)
   vim.keymap.set({ 't' }, '<c-v>', function()
     keybinding_helpers.open_file_in_vertical_split(config)
   end, { buffer = yazi_buffer })
@@ -86,6 +87,10 @@ function M.default_set_keymappings_function(yazi_buffer, config)
         end
       end,
     })
+  end, { buffer = yazi_buffer })
+
+  vim.keymap.set({ 't' }, '<tab>', function()
+    keybinding_helpers.cycle_open_buffers(context)
   end, { buffer = yazi_buffer })
 end
 

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -1,7 +1,8 @@
----@class YaziProcessApi
+---@class YaziProcessApi # Provides yazi.nvim -> yazi process interactions
 ---@field private config YaziConfig
 ---@field private yazi_id string
 local YaziProcessApi = {}
+YaziProcessApi.__index = YaziProcessApi
 
 ---@param config YaziConfig
 ---@param yazi_id string

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -10,7 +10,7 @@
 ---@field public use_yazi_client_id_flag? boolean "use the `--client-id` flag with yazi, allowing communication with that specific instance as opposed to all yazis on the system"
 ---@field public enable_mouse_support? boolean
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
----@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig): nil "the function that will set the keymappings for the yazi floating window. It will be called after the floating window is created."
+---@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig, context: YaziActiveContext): nil "the function that will set the keymappings for the yazi floating window. It will be called after the floating window is created."
 ---@field public hooks? YaziConfigHooks
 ---@field public highlight_groups? YaziConfigHighlightGroups
 ---@field public integrations? YaziConfigIntegrations
@@ -18,6 +18,11 @@
 ---@field public yazi_floating_window_winblend? number "the transparency of the yazi floating window (0-100). See :h winblend"
 ---@field public yazi_floating_window_border? any "the type of border to use. See nvim_open_win() for the values your neovim version supports"
 ---@field public log_level? yazi.LogLevel
+
+---@class (exact) YaziActiveContext # context state for a single yazi session
+---@field api YaziProcessApi
+---@field input_path Path the path that is first selected by yazi when it's opened
+---@field cycled_file? RenameableBuffer the last file that was cycled to with e.g. the <tab> key
 
 ---@class (exact) YaziConfigHooks
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil

--- a/spec/yazi/helpers/fake_yazi_process.lua
+++ b/spec/yazi/helpers/fake_yazi_process.lua
@@ -6,13 +6,15 @@ local M = {}
 ---@field code integer
 ---@field selected_files string[]
 ---@field events YaziEvent[]
+---@field api YaziProcessApi
 M.mocks = {}
 
----@param arguments { code?: integer, selected_files?: string[], events?: YaziEvent[]}
+---@param arguments { code?: integer, selected_files?: string[], events?: YaziEvent[], api: YaziProcessApi }
 function M.setup_created_instances_to_instantly_exit(arguments)
   M.mocks.code = arguments.code or 0
   M.mocks.selected_files = arguments.selected_files or {}
   M.mocks.events = arguments.events or {}
+  M.api = arguments.api or {}
 end
 
 -- Fake yazi process that instantly exits with the mocked data that was set up
@@ -21,6 +23,7 @@ end
 ---@diagnostic disable-next-line: unused-local
 function M:start(_, _, on_exit)
   on_exit(M.mocks.code, M.mocks.selected_files, M.mocks.events)
+  return self
 end
 
 return M

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -34,7 +34,7 @@ describe('opening a file', function()
     assert.equals(file, path.filename)
   end
 
-  it('opens yazi with the current file selected', function()
+  it('#focus opens yazi with the current file selected', function()
     fake_yazi_process.setup_created_instances_to_instantly_exit({})
 
     -- the file name should have a space as well as special characters, in order to test that


### PR DESCRIPTION
    This feature is only supported for the latest yazi version. For now,
    you have to compile yazi from source to be able to use it. See the
    readme for instructions on how to do this.


https://github.com/user-attachments/assets/972542d2-d2ab-4d65-99a9-cad39b43ceeb



If you have files open in split windows in Neovim, and have started yazi, you can now press the `tab` key to make yazi jump to the directory of the next open buffer. This is useful when you have multiple files open in different directories and want to quickly jump between them.

Right now this has the following limitation: it can only jump to the directory of the next open buffer, but not necessarily focus the buffer in yazi. This is because yazi doesn't have a built-in way to jump to a specific file, only a directory. This is something that might be improved in the future.