### PR TITLE
Fix buffer cycling small errors

### DIFF
--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -71,6 +71,16 @@ function YaziOpenerActions.cycle_open_buffers(context)
   ) or context.input_path
   local visible_buffers = utils.get_visible_open_buffers()
 
+  if #visible_buffers == 0 then
+    Log:debug(
+      string.format(
+        'No visible buffers found for path: "%s"',
+        context.input_path
+      )
+    )
+    return
+  end
+
   for i, buffer in ipairs(visible_buffers) do
     if
       buffer.renameable_buffer:matches_exactly(current_cycle_position.filename)

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -97,15 +97,16 @@ function YaziOpenerActions.cycle_open_buffers(context)
         return b.renameable_buffer.path.filename
           ~= current_cycle_position.filename
       end)
-      assert(
-        next_buffer,
-        vim.inspect({
-          'Could not find next buffer',
-          #visible_buffers,
-          i,
-          next,
-        })
-      )
+
+      if not next_buffer then
+        Log:debug(
+          string.format(
+            'Could not find next buffer for path: "%s", probably only one is open.',
+            context.input_path
+          )
+        )
+        return
+      end
 
       local directory =
         vim.fn.fnamemodify(next_buffer.renameable_buffer.path.filename, ':h')


### PR DESCRIPTION
These errors are minor and only occurred in edge cases. They reported error messages that were meant for developers, and the fix is not to report these messages and simply abort.