### PR TITLE
perf: lazy load yazi.nvim modules by default

### DIFF
--- a/integration-tests/client/testEnvironmentTypes.ts
+++ b/integration-tests/client/testEnvironmentTypes.ts
@@ -19,6 +19,7 @@ export type StartupScriptModification =
   | "modify_yazi_config_to_use_ya_as_event_reader.lua"
   | "modify_yazi_config_and_add_hovered_buffer_background.lua"
   | "use_light_neovim_colorscheme.lua"
+  | "report_loaded_yazi_modules.lua"
 
 declare global {
   interface Window {

--- a/integration-tests/cypress/e2e/lazy-loading.cy.ts
+++ b/integration-tests/cypress/e2e/lazy-loading.cy.ts
@@ -1,0 +1,22 @@
+import { startNeovimWithYa } from "./using-ya-to-read-events/startNeovimWithYa"
+
+describe("lazy loading yazi.nvim", () => {
+  // The idea is that yazi.nvim exposes its public functions when you call
+  // `require("yazi")`. It should load as little code up front as possible,
+  // because some users don't use a package manager like lazy.nvim that
+  // supports lazy loading modules by default.
+
+  it("can run the :healthcheck for yazi.nvim", () => {
+    // Not sure what would be a good way to test lazy loading. For now, just
+    // load the plugin and see how many modules have been loaded.
+    //
+    // Maybe in the future, we can have a better way to do this.
+    cy.visit("http://localhost:5173")
+    startNeovimWithYa({
+      startupScriptModifications: ["report_loaded_yazi_modules.lua"],
+    })
+
+    cy.typeIntoTerminal(":=CountYaziModules(){enter}")
+    cy.contains("Loaded 7 modules")
+  })
+})

--- a/integration-tests/cypress/e2e/lazy-loading.cy.ts
+++ b/integration-tests/cypress/e2e/lazy-loading.cy.ts
@@ -6,7 +6,7 @@ describe("lazy loading yazi.nvim", () => {
   // because some users don't use a package manager like lazy.nvim that
   // supports lazy loading modules by default.
 
-  it("can run the :healthcheck for yazi.nvim", () => {
+  it("delays loading of many source code files", () => {
     // Not sure what would be a good way to test lazy loading. For now, just
     // load the plugin and see how many modules have been loaded.
     //
@@ -17,6 +17,10 @@ describe("lazy loading yazi.nvim", () => {
     })
 
     cy.typeIntoTerminal(":=CountYaziModules(){enter}")
+
+    // NOTE: if this number changes in the future, it's ok. This test is just
+    // to make sure that we don't accidentally load all modules up front due to
+    // an unrelated change.
     cy.contains("Loaded 7 modules")
   })
 })

--- a/integration-tests/server/server.ts
+++ b/integration-tests/server/server.ts
@@ -73,6 +73,15 @@ io.on("connection", function connection(socket) {
               args.push("-c", `lua dofile('${file}')`)
               break
             }
+            case "report_loaded_yazi_modules.lua": {
+              const file = path.join(
+                testDirectory,
+                "config-modifications",
+                "report_loaded_yazi_modules.lua",
+              )
+              args.push("-c", `lua dofile('${file}')`)
+              break
+            }
             default:
               modification satisfies never
               throw new Error(

--- a/integration-tests/test-environment/config-modifications/report_loaded_yazi_modules.lua
+++ b/integration-tests/test-environment/config-modifications/report_loaded_yazi_modules.lua
@@ -1,5 +1,6 @@
 require('yazi')
 
+-- selene: allow(unused_variable)
 function CountYaziModules()
   ---@type string[]
   local yazi_modules = {}

--- a/integration-tests/test-environment/config-modifications/report_loaded_yazi_modules.lua
+++ b/integration-tests/test-environment/config-modifications/report_loaded_yazi_modules.lua
@@ -1,0 +1,17 @@
+require('yazi')
+
+function CountYaziModules()
+  ---@type string[]
+  local yazi_modules = {}
+
+  for k, _ in pairs(package.loaded) do
+    if k:sub(1, 4) == 'yazi' then
+      yazi_modules[#yazi_modules + 1] = k
+    end
+  end
+
+  return vim.inspect({
+    string.format('Loaded %s modules', #yazi_modules),
+    table.concat(yazi_modules, ','),
+  })
+end

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -1,11 +1,6 @@
 ---@module "plenary"
 
-local window = require('yazi.window')
-local utils = require('yazi.utils')
 local configModule = require('yazi.config')
-local event_handling = require('yazi.event_handling')
-local Log = require('yazi.log')
-local YaziProcess = require('yazi.process.yazi_process')
 
 local M = {}
 
@@ -18,6 +13,10 @@ M.previous_state = {}
 ---@param config? YaziConfig?
 ---@param input_path? string
 function M.yazi(config, input_path)
+  local utils = require('yazi.utils')
+  local YaziProcess = require('yazi.process.yazi_process')
+  local event_handling = require('yazi.event_handling')
+
   if utils.is_yazi_available() ~= true then
     print('Please install yazi. Check the documentation for more information')
     return
@@ -25,6 +24,8 @@ function M.yazi(config, input_path)
 
   config =
     vim.tbl_deep_extend('force', configModule.default(), M.config, config or {})
+
+  local Log = require('yazi.log')
   Log.level = config.log_level
 
   if
@@ -45,7 +46,7 @@ function M.yazi(config, input_path)
   config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
   config.events_file_path = config.events_file_path or vim.fn.tempname()
 
-  local win = window.YaziFloatingWindow.new(config)
+  local win = require('yazi.window').YaziFloatingWindow.new(config)
   win:open_and_display()
 
   local yazi_process = YaziProcess:start(
@@ -140,6 +141,8 @@ function M.toggle(config)
   )
 
   local path = M.previous_state and M.previous_state.last_hovered or nil
+
+  local Log = require('yazi.log')
   if path == nil then
     Log:debug('No previous file hovered, opening yazi with default path')
   else
@@ -157,6 +160,7 @@ function M.setup(opts)
   M.config =
     vim.tbl_deep_extend('force', configModule.default(), M.config, opts or {})
 
+  local Log = require('yazi.log')
   Log.level = M.config.log_level
 
   local yazi_augroup = vim.api.nvim_create_augroup('yazi', { clear = true })


### PR DESCRIPTION
Previously yazi.nvim would load most of its modules up front when required. This is not ideal as typically this delays Neovim's startup time. Although the delay is measured in milliseconds, it might add up if tens of other plugins need to be loaded too.

This commit changes the behavior so that yazi.nvim only loads the modules when they are actually needed. The number of loaded modules has changed from 17 to 7, but I did not measure the startup time difference.