### PR TITLE
fix: grug-far integration not being able to search outside of the cwd

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
@@ -23,12 +23,16 @@ describe("integrations to other tools", () => {
 
       // the directory we were in should be prefilled in grug-far.nvim's view
       cy.contains("testdirs")
-      const p = path.join(
-        dir.rootPathRelativeToTestEnvironmentDir,
-        "routes",
-        "**",
-      )
+      const p = path.join(dir.rootPathRelativeToTestEnvironmentDir, "routes")
       cy.contains(p)
+
+      // by default, the focus is on the search field in normal mode. Type
+      // something in the search field so we can see if results can be found
+      cy.typeIntoTerminal("ithis")
+
+      // maybe we don't want to make too many assertions on code we don't own
+      // though, so for now we trust that it works in CI, and can verify it
+      // works locally
     })
   })
 })

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -43,11 +43,14 @@ function M.default()
         })
       end,
       replace_in_directory = function(directory)
-        -- limit the search to the given path, based on cwd
-        local filter = directory:joinpath('**'):make_relative(vim.uv.cwd())
+        -- limit the search to the given path
+        --
+        -- `prefills.flags` get passed to ripgrep as is
+        -- https://github.com/MagicDuck/grug-far.nvim/issues/146
+        local filter = directory:make_relative(vim.uv.cwd())
         require('grug-far').grug_far({
           prefills = {
-            filesFilter = filter,
+            flags = filter,
           },
         })
       end,


### PR DESCRIPTION
There was a bug in the grug-far integration (the default search and replace integration in yazi.nvim) where it was not able to search outside of the current working directory. This was due to the fact that the file path to search in was passed in `Files Filter` instead of in `Flags`, which is the correct place to pass the file path.

https://github.com/MagicDuck/grug-far.nvim/issues/146