### PR TITLE
docs: update keyjump plugin to easyjump plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Yazi is highly customizable. It features its own plugin and event system,
 themes, and keybindings. This section lists some of the plugins and themes that
 I like.
 
-- <https://gitee.com/DreamMaoMao/keyjump.yazi.git> allows jumping to a line by
+- <https://gitee.com/DreamMaoMao/easyjump.yazi.git> allows jumping to a line by
   typing a hint character, much like
   [hop.nvim](https://github.com/smoka7/hop.nvim)
 - <https://github.com/Rolv-Apneseth/starship.yazi> is a port of the

--- a/documentation/plugin-management.md
+++ b/documentation/plugin-management.md
@@ -129,7 +129,7 @@ return {
       -- This is a plugin like flash.nvim in neovim - it allows you to jump to
       -- a line by typing the first few characters of the line.
       -- https://github.com/redbeardymcgee/yazi-plugins
-      require("yazi.plugin").build_plugin(plugin, { sub_dir = "keyjump.yazi" })
+      require("yazi.plugin").build_plugin(plugin, { sub_dir = "easyjump.yazi" })
     end,
   },
   {

--- a/spec/yazi/plugin_spec.lua
+++ b/spec/yazi/plugin_spec.lua
@@ -83,7 +83,7 @@ describe('installing a plugin', function()
 
     it('can install a plugin from a monorepo subdirectory', function()
       local plugin_monorepo_dir = vim.fs.joinpath(base_dir, 'yazi-plugins')
-      local plugin_dir = vim.fs.joinpath(plugin_monorepo_dir, 'keyjump.yazi')
+      local plugin_dir = vim.fs.joinpath(plugin_monorepo_dir, 'easyjump.yazi')
       local yazi_dir = vim.fs.joinpath(base_dir, 'fake-yazi-dir')
 
       vim.fn.mkdir(plugin_monorepo_dir)
@@ -94,11 +94,11 @@ describe('installing a plugin', function()
       plugin.build_plugin({
         dir = plugin_monorepo_dir,
         name = 'yazi-plugins',
-      }, { yazi_dir = yazi_dir, sub_dir = 'keyjump.yazi' })
+      }, { yazi_dir = yazi_dir, sub_dir = 'easyjump.yazi' })
 
       -- verify that the plugin was symlinked
       local symlink =
-        vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'plugins', 'keyjump.yazi'))
+        vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'plugins', 'easyjump.yazi'))
 
       assert.are.same(plugin_dir, symlink)
     end)


### PR DESCRIPTION
Looks like keyjump has been deprecated and easyjump is the new name for it.