### PR TITLE
fix: renaming a file twice not updating the buffer name

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -84,6 +84,12 @@ describe("reading events", () => {
       cy.contains("If you see this text, Neovim is ready").should("not.exist")
     })
   })
+})
+
+describe("'rename' events", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:5173")
+  })
 
   it("can read 'rename' events and update the buffer name when the file was renamed", () => {
     startNeovimWithYa().then((dir) => {
@@ -110,6 +116,46 @@ describe("reading events", () => {
 
       // the buffer name should now be updated
       cy.contains(`${file.stem}2${file.extension}`)
+    })
+  })
+
+  it("can rename twice and keep track of the correct file name", () => {
+    startNeovimWithYa().then((dir) => {
+      // the default file should already be open
+      cy.contains(dir.contents["initial-file.txt"].name)
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // start yazi
+      cy.typeIntoTerminal("{upArrow}")
+
+      // start file renaming
+      cy.typeIntoTerminal("r")
+      cy.contains("Rename:")
+      cy.typeIntoTerminal("2{enter}")
+
+      cy.get("Rename").should("not.exist")
+
+      // yazi should be showing the new file name
+      const file = dir.contents["initial-file.txt"]
+      cy.contains(`${file.stem}2${file.extension}`)
+
+      // close yazi
+      cy.typeIntoTerminal("q")
+
+      const newName = `${file.stem}2${file.extension}`
+      // the buffer name should now be updated
+      cy.contains(newName)
+
+      // rename a second time, returning to the original name
+      cy.typeIntoTerminal("{upArrow}")
+      cy.typeIntoTerminal("r")
+      cy.contains("Rename:")
+      cy.typeIntoTerminal("{backspace}")
+      cy.contains(`${file.stem}${file.extension}`)
+      cy.typeIntoTerminal("{enter}")
+
+      cy.typeIntoTerminal("q")
+      cy.contains(newName).should("not.exist")
     })
   })
 })

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -249,10 +249,14 @@ function M.rename_or_close_buffer(instruction)
   -- If the target buffer is already open in neovim, just close the old buffer.
   -- It causes an error to try to rename to a buffer that's already open.
   if M.is_buffer_open(instruction.path.filename) then
-    vim.api.nvim_buf_delete(instruction.bufnr, {})
-  else
-    vim.api.nvim_buf_set_name(instruction.bufnr, instruction.path.filename)
+    pcall(function()
+      vim.api.nvim_buf_delete(instruction.bufnr, { force = true })
+    end)
   end
+
+  pcall(function()
+    vim.api.nvim_buf_set_name(instruction.bufnr, instruction.path.filename)
+  end)
 end
 
 ---@param prev_win integer


### PR DESCRIPTION
When a file was renamed once, the buffer name was updated correctly. But when the file was renamed a second time, the buffer name was not updated.

Anyway, this is quite a rare bug, so I don't expect a huge impact one way or the other.