### PR TITLE
fix: grug-far appending extra text at the end of replaced files

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -48,7 +48,7 @@ function M.default()
         local filter = directory:make_relative(vim.uv.cwd())
         require('grug-far').grug_far({
           prefills = {
-            flags = filter,
+            paths = filter,
           },
         })
       end,


### PR DESCRIPTION
See this for more information:
https://github.com/MagicDuck/grug-far.nvim/issues/154