### PR TITLE
fix: escape spaces in paths for grug-far integration

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -48,7 +48,7 @@ function M.default()
         local filter = directory:make_relative(vim.uv.cwd())
         require('grug-far').grug_far({
           prefills = {
-            paths = filter,
+            paths = filter:gsub(' ', '\\ '),
           },
         })
       end,

--- a/spec/yazi/grug_far_spec.lua
+++ b/spec/yazi/grug_far_spec.lua
@@ -1,0 +1,27 @@
+---@module "plenary.path"
+
+local assert = require('luassert')
+local mock = require('luassert.mock')
+local config = require('yazi.config')
+local plenary_path = require('plenary.path')
+
+describe('the grug-far integration (search and replace)', function()
+  local mock_grug_far = { grug_far = function() end }
+
+  before_each(function()
+    mock.revert(mock_grug_far)
+    package.loaded['grug-far'] = mock(mock_grug_far)
+  end)
+
+  it('opens yazi with the current file selected', function()
+    local tmp_path = plenary_path:new('/tmp/folder with spaces/')
+
+    config.default().integrations.replace_in_directory(tmp_path)
+
+    assert.spy(mock_grug_far.grug_far).was_called_with({
+      prefills = {
+        paths = '/tmp/folder\\ with\\ spaces',
+      },
+    })
+  end)
+end)


### PR DESCRIPTION
This change allows the grug-far integration to work with paths that contain spaces. It escapes spaces in the path before passing it to grug-far.

This was suggested by @MagicDuck in
https://github.com/mikavilpas/yazi.nvim/commit/be2ac43a530b9b8c8b1a6185f07fac13f128f046

👍🏻👍🏻