### PR TITLE
feat: can limit search and replace to selected files only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ integration-tests/pid.txt
 integration-tests/server/build
 *.pem
 integration-tests/test-environment/testdirs
+integration-tests/cypress/screenshots

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ These are the default keybindings that are available when yazi is open:
     if available.
   - `<c-g>`: search and replace in the current yazi directory using
     [grug-far](https://github.com/MagicDuck/grug-far.nvim), if available
+    - if multiple files/directories are selected in yazi, the search and replace
+      will only be done in the selected files/directories
 
 ## 🪛 Customizing yazi
 

--- a/integration-tests/client/testEnvironmentTypes.ts
+++ b/integration-tests/client/testEnvironmentTypes.ts
@@ -1,12 +1,12 @@
 export type MultipleFiles = {
-  openInVerticalSplits: File[]
+  openInVerticalSplits: IntegrationTestFile[]
 }
 
-type File = TestDirectoryFile | "."
+export type IntegrationTestFile = TestDirectoryFile | "."
 
 /** The arguments given from the tests to send to the server */
 export type StartNeovimArguments = {
-  filename?: File | MultipleFiles
+  filename?: IntegrationTestFile | MultipleFiles
   startupScriptModifications?: StartupScriptModification[]
 }
 
@@ -73,6 +73,7 @@ export type TestDirectory = {
     ["other-subdirectory/other-sub-file.txt"]: FileEntry
     ["routes/posts.$postId/route.tsx"]: FileEntry
     ["routes/posts.$postId/adjacent-file.txt"]: FileEntry
+    ["routes/posts.$postId/should-be-excluded-file.txt"]: FileEntry
   }
 }
 

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -113,6 +113,11 @@ export default defineConfig({
                   stem: "route",
                   extension: ".tsx",
                 },
+                "routes/posts.$postId/should-be-excluded-file.txt": {
+                  name: "should-be-excluded-file.txt",
+                  stem: "should-be-excluded-file",
+                  extension: ".txt",
+                },
               },
             }
             directory satisfies Serializable // required by cypress

--- a/integration-tests/test-environment/routes/posts.$postId/should-be-excluded-file.txt
+++ b/integration-tests/test-environment/routes/posts.$postId/should-be-excluded-file.txt
@@ -1,0 +1,1 @@
+this file should be excluded

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -205,7 +205,7 @@ function M.set_keymappings(yazi_buffer, config, context)
         relative = 'win',
         bufpos = { 5, 30 },
         noautocmd = true,
-        width = math.min(40, math.floor(w * 0.5)),
+        width = math.min(46, math.floor(w * 0.5)),
         height = math.min(11, math.floor(h * 0.5)),
         border = config.yazi_floating_window_border,
       })
@@ -223,7 +223,9 @@ function M.set_keymappings(yazi_buffer, config, context)
           .. config.keymaps.open_file_in_vertical_split
           .. ' - open file in vertical split',
         '' .. config.keymaps.grep_in_directory .. ' - search in directory',
-        '' .. config.keymaps.replace_in_directory .. ' - replace in directory',
+        ''
+          .. config.keymaps.replace_in_directory
+          .. ' - replace in directory / selected files',
         '' .. config.keymaps.cycle_open_buffers .. ' - cycle open buffers',
         '' .. config.keymaps.show_help .. ' - show this help',
         '',

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -43,7 +43,8 @@
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
 ---@field public grep_in_directory? fun(directory: string): nil "a function that will be called when the user wants to grep in a directory"
----@field public replace_in_directory? fun(directory: Path): nil "called to start a replacement operation on some directory; by default grug-far.nvim"
+---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil "called to start a replacement operation on some directory; by default uses grug-far.nvim"
+---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil "called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim"
 
 ---@class (exact) YaziConfigHighlightGroups # Defines the highlight groups that will be used in yazi
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi


### PR DESCRIPTION
Previously the search and replace operation would be applied to all files in the directory where the operation was started. This commit adds a feature to limit the search and replace operation to only the files that were visually selected (with `v` or `<space>` by default in yazi) in the yazi view.

> Demo: I select some files using `<space>`, and then press `<c-g>` to open the default search and replace integration (grug-far.nvim). The search is limited to the selected files only.

https://github.com/user-attachments/assets/5ce6feac-c355-443c-b9f3-b1f514eb1583



This allows fine tuning of the search and replace operation to only the files that are relevant to the user.