### PR TITLE
feat(health): add instructions for `open_for_directories`

### DIFF
--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -108,6 +108,12 @@ return {
       end
     end
 
+    if config.open_for_directories == true then
+      vim.health.info(
+        'You have enabled `open_for_directories` in your config. Because of this, please make sure you are loading yazi when Neovim starts.'
+      )
+    end
+
     vim.health.ok('yazi')
   end,
 }

--- a/spec/yazi/health_spec.lua
+++ b/spec/yazi/health_spec.lua
@@ -226,4 +226,28 @@ Options:
       end
     )
   end)
+
+  describe('the checks for `open_for_directories`', function()
+    it(
+      'instructs the user to load yazi on startup when `open_for_directories` is set',
+      function()
+        require('yazi').setup({ open_for_directories = true })
+        vim.cmd('checkhealth yazi')
+
+        assert_buffer_contains_text(
+          'You have enabled `open_for_directories` in your config. Because of this, please make sure you are loading yazi when Neovim starts.'
+        )
+      end
+    )
+
+    it(
+      'does not instruct the user to load yazi on startup when `open_for_directories` is not set',
+      function()
+        require('yazi').setup({ open_for_directories = false })
+        vim.cmd('checkhealth yazi')
+
+        assert_buffer_does_not_contain_text('open_for_directories')
+      end
+    )
+  end)
 end)


### PR DESCRIPTION
When `open_for_directories` is set to `true`, the user should be instructed to load yazi when Neovim starts. This is because the autocmds that yazi sets up to load the directories need to be set up before a directory is opened.