### PR TITLE
chore!: update to the latest commit of yazi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          # refactor: reimplement the signal system (#1307)
-          # https://github.com/sxyazi/yazi/commit/d6081fbe6f57
-          commit: d6081fbe6f57
+          # feat: new extract builtin plugin for archive extracting (#1321)
+          # https://github.com/sxyazi/yazi/commit/bce0fc1175c855ecb2dbee6f8575857b1e9616d4
+          commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
 
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3
@@ -39,9 +39,9 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          # refactor: reimplement the signal system (#1307)
-          # https://github.com/sxyazi/yazi/commit/d6081fbe6f57
-          commit: d6081fbe6f57
+          # feat: new extract builtin plugin for archive extracting (#1321)
+          # https://github.com/sxyazi/yazi/commit/bce0fc1175c855ecb2dbee6f8575857b1e9616d4
+          commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@v1

--- a/documentation/installing-yazi-from-source.md
+++ b/documentation/installing-yazi-from-source.md
@@ -11,6 +11,14 @@ If you need the latest version of yazi, you can install it from source. This is
 useful if you want to try out the latest features or if you want to contribute
 to the project.
 
+> [!WARNING]
+>
+> yazi.nvim tracks a recent version of yazi, but it might not always be the very
+> latest version. Most of the time, the latest yazi version is compatible with
+> yazi.nvim, but there might be exceptions. If you run into issues, you can try
+> installing the version used in testing. The version can be found in
+> [test.yml](../.github/workflows/test.yml).
+
 > [!NOTE]
 >
 > Keep in mind that installing from source might be more complex than installing

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -19,10 +19,9 @@ function YaziProcessApi:cd(path)
     self.config.use_ya_for_events_reading == true
     and self.config.use_yazi_client_id_flag == true
   then
-    -- ya pub --str "/" dds-cd 1760127405452166
     assert(path, 'path is required')
     vim.system(
-      { 'ya', 'pub', '--str', path, 'dds-cd', self.yazi_id },
+      { 'ya', 'pub-to', self.yazi_id, '--str', path, 'dds-cd' },
       { timeout = 1000 }
     )
   end


### PR DESCRIPTION
chore!: update to the latest commit of yazi

BREAKING CHANGE: If you use `use_ya_for_events_reading = true` in your
yazi.nvim config, you need to upgrade your yazi version to the currently
latest version:

> feat: new extract builtin plugin for archive extracting (#1321)
>
> https://github.com/sxyazi/yazi/commit/bce0fc1175c855ecb2dbee6f8575857b1e9616d4

@sxyazi fyi, noticed that the latest commit of yazi has some new
features and seems like `pub-to` should be used. I'm changing this in
the bleeding edge version of yazi.nvim to keep up.