### PR TITLE
feat: `<c-y>` to copy relative path to selected file(s)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up ripgrep
-        # it's a telescope dependency
+      - name: Set up dependencies
         run: |
+          # ripgrep is a telescope dependency
           which rg || {
             sudo apt-get install ripgrep
+          }
+
+          # realpath is used to resolve relative paths
+          which realpath || {
+            # just fail with an error message if realpath is not found
+            echo "realpath is not installed, but it should be part of GNU coreutils and included in Ubuntu"
+            exit 1
           }
 
       - name: Compile and install `yazi-fm` from source

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
       grep_in_directory = '<c-s>',
       replace_in_directory = '<c-g>',
       cycle_open_buffers = '<tab>',
+      copy_relative_path_to_selected_files = '<c-y>',
     },
 
     -- completely override the keymappings for yazi. This function will be
@@ -254,6 +255,8 @@ You can optionally configure yazi.nvim by setting any of the options below.
       replace_in_selected_files = function(selected_files)
         -- default: grug-far.nvim
       end,
+      -- `grealpath` on OSX, (GNU) `realpath` otherwise
+      resolve_relative_path_application = ""
     },
   },
 }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ You can optionally configure yazi.nvim by setting any of the options below.
     -- more information, see :h nvim_open_win
     yazi_floating_window_border = 'rounded',
 
+    -- some yazi.nvim commands copy text to the clipboard. This is the register
+    -- yazi.nvim should use for copying. Defaults to "*", the system clipboard
+    clipboard_register = "*",
+
     hooks = {
       -- if you want to execute a custom action when yazi has been opened,
       -- you can define it here.

--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
@@ -1,3 +1,5 @@
+import type { IntegrationTestFile } from "../../../client/testEnvironmentTypes"
+
 describe("opening files", () => {
   beforeEach(() => {
     cy.visit("http://localhost:5173")
@@ -129,6 +131,92 @@ describe("opening files", () => {
 
       // the file contents should now be visible
       cy.contains("02c67730-6b74-4b7c-af61-fe5844fdc3d7")
+    })
+  })
+
+  it("can copy the relative path to the initial file", () => {
+    // the copied path should be relative to the file/directory yazi was
+    // started in (the initial file)
+
+    cy.startNeovim().then((dir) => {
+      cy.contains("If you see this text, Neovim is ready!")
+
+      cy.typeIntoTerminal("{upArrow}")
+      cy.contains(dir.contents["test-setup.lua"].name)
+
+      // enter another directory and select a file
+      cy.typeIntoTerminal("/routes{enter}")
+      cy.contains("posts.$postId")
+      cy.typeIntoTerminal("{rightArrow}")
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name) // file in the directory
+      cy.typeIntoTerminal("{rightArrow}")
+      cy.typeIntoTerminal(
+        `/${dir.contents["routes/posts.$postId/adjacent-file.txt"].name}{enter}`,
+      )
+
+      // the file contents should now be visible
+      cy.contains("this file is adjacent-file.txt")
+
+      cy.typeIntoTerminal("{control+y}")
+
+      // yazi should now be closed
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name).should(
+        "not.exist",
+      )
+
+      // the relative path should now be in the clipboard. Let's paste it to
+      // the file to verify this.
+      // NOTE: the test-setup configures the `"` register to be the clipboard
+      cy.typeIntoTerminal("o{enter}{esc}")
+      cy.typeIntoTerminal(':normal ""p{enter}')
+
+      cy.contains(
+        "routes/posts.$postId/adjacent-file.txt" satisfies IntegrationTestFile,
+      )
+    })
+  })
+
+  it("can copy the relative paths of multiple selected files", () => {
+    // similarly, the copied path should be relative to the file/directory yazi
+    // was started in (the initial file)
+
+    cy.startNeovim().then((dir) => {
+      cy.contains("If you see this text, Neovim is ready!")
+
+      cy.typeIntoTerminal("{upArrow}")
+      cy.contains(dir.contents["test-setup.lua"].name)
+
+      // enter another directory and select a file
+      cy.typeIntoTerminal("/routes{enter}")
+      cy.contains("posts.$postId")
+      cy.typeIntoTerminal("{rightArrow}")
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name) // file in the directory
+      cy.typeIntoTerminal("{rightArrow}")
+      cy.typeIntoTerminal("{control+a}")
+
+      cy.typeIntoTerminal("{control+y}")
+
+      // yazi should now be closed
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name).should(
+        "not.exist",
+      )
+
+      // the relative path should now be in the clipboard. Let's paste it to
+      // the file to verify this.
+      // NOTE: the test-setup configures the `"` register to be the clipboard
+      cy.typeIntoTerminal("o{enter}{esc}")
+      cy.typeIntoTerminal(':normal ""p{enter}')
+
+      // all selected files should now be visible
+      cy.contains(
+        "routes/posts.$postId/adjacent-file.txt" satisfies IntegrationTestFile,
+      )
+      cy.contains(
+        "routes/posts.$postId/route.tsx" satisfies IntegrationTestFile,
+      )
+      cy.contains(
+        "routes/posts.$postId/adjacent-file.txt" satisfies IntegrationTestFile,
+      )
     })
   })
 })

--- a/integration-tests/test-environment/test-setup.lua
+++ b/integration-tests/test-environment/test-setup.lua
@@ -63,6 +63,10 @@ local plugins = {
     ---@type YaziConfig
     opts = {
       open_for_directories = true,
+      -- use different register than the system clipboard for yanking, so that
+      -- the developers can work on the code while the tests run without any
+      -- disturbances
+      clipboard_register = '"',
       -- allows logging debug data, which can be shown in CI when cypress tests fail
       log_level = vim.log.levels.DEBUG,
       integrations = {

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -114,6 +114,22 @@ return {
       )
     end
 
+    local resolver = config.integrations.resolve_relative_path_application
+    if
+      config.keymaps.copy_relative_path_to_selected_files ~= false
+      and vim.fn.executable(resolver) ~= 1
+    then
+      vim.health.warn(
+        string.format(
+          'The `resolve_relative_path_application` (`%s`) is not found on PATH. Please either install it, make sure it is on your PATH, or set `config.keymaps.copy_relative_path_to_selected_files = nil` in your configuration.',
+          resolver
+        )
+      )
+      vim.health.info(
+        'The default application (realpath) should be installed on most linux systems by default. On OSX, the default (grealpath) can be found in https://formulae.brew.sh/formula/coreutils'
+      )
+    end
+
     vim.health.ok('yazi')
   end,
 }

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -19,17 +19,19 @@
 ---@field public yazi_floating_window_winblend? number "the transparency of the yazi floating window (0-100). See :h winblend"
 ---@field public yazi_floating_window_border? any "the type of border to use. See nvim_open_win() for the values your neovim version supports"
 ---@field public log_level? yazi.LogLevel
+---@field public clipboard_register? string the register to use for copying. Defaults to "*", the system clipboard
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 
 ---@class YaziKeymaps # The keybindings that are set by yazi, and can be overridden by the user. Will be set to a default value if not given explicitly
+---@field show_help? YaziKeymap # Show a help menu with all the keybindings
 ---@field open_file_in_vertical_split? YaziKeymap # When a file is hovered, open it in a vertical split
 ---@field open_file_in_horizontal_split? YaziKeymap # When a file is hovered, open it in a horizontal split
 ---@field open_file_in_tab? YaziKeymap # When a file is hovered, open it in a new tab
 ---@field grep_in_directory? YaziKeymap # Close yazi and open a grep (default: telescope) narrowed to the directory yazi is in
 ---@field replace_in_directory? YaziKeymap # Close yazi and open a replacer (default: grug-far.nvim) narrowed to the directory yazi is in
 ---@field cycle_open_buffers? YaziKeymap # When Neovim has multiple splits open and visible, make yazi jump to the directory of the next one
----@field show_help? YaziKeymap # Show a help menu with all the keybindings
+---@field copy_relative_path_to_selected_files? YaziKeymap # Copy the relative paths of the selected files to the clipboard
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi
@@ -46,6 +48,7 @@
 ---@field public grep_in_selected_files? fun(selected_files: Path[]): nil"called to grep on files that were selected in yazi"
 ---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil "called to start a replacement operation on some directory; by default uses grug-far.nvim"
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil "called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim"
+---@field public resolve_relative_path_application? string "the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS"
 
 ---@class (exact) YaziConfigHighlightGroups # Defines the highlight groups that will be used in yazi
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -17,6 +17,8 @@ function M.relative_path(config, current_file_dir, selected_file)
     error(msg)
   end
 
+  assert(command ~= nil, 'realpath command must be set')
+
   ---@type Path
   local start_path = plenary_path:new(current_file_dir)
   local start_directory = nil
@@ -28,7 +30,7 @@ function M.relative_path(config, current_file_dir, selected_file)
 
   local stdout, exit_code, stderr = require('plenary.job')
     :new({
-      command = 'grealpath',
+      command = command,
       args = { '--relative-to', start_directory.filename, selected_file },
     })
     :sync()

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -1,15 +1,55 @@
-local fn = vim.fn
 local RenameableBuffer = require('yazi.renameable_buffer')
 local plenary_path = require('plenary.path')
 
 local M = {}
 
+---@param config YaziConfig
+---@param current_file_dir string
+---@param selected_file string
+---@return string
+function M.relative_path(config, current_file_dir, selected_file)
+  local command = config.integrations.resolve_relative_path_application
+
+  if vim.fn.executable(command) == 0 then
+    local msg =
+      'error copying relative_path. Try running `:healthcheck yazi` for more information.'
+    vim.notify(msg)
+    error(msg)
+  end
+
+  ---@type Path
+  local start_path = plenary_path:new(current_file_dir)
+  local start_directory = nil
+  if start_path:is_dir() then
+    start_directory = start_path
+  else
+    start_directory = start_path:parent()
+  end
+
+  local stdout, exit_code, stderr = require('plenary.job')
+    :new({
+      command = 'grealpath',
+      args = { '--relative-to', start_directory.filename, selected_file },
+    })
+    :sync()
+
+  if exit_code ~= 0 or stdout == nil or stdout == '' then
+    vim.notify('error copying relative_path, exit code ' .. exit_code)
+    error('error running command, exit code ' .. exit_code)
+    print(vim.inspect(stderr))
+  end
+
+  local path = stdout[1]
+
+  return path
+end
+
 function M.is_yazi_available()
-  return fn.executable('yazi') == 1
+  return vim.fn.executable('yazi') == 1
 end
 
 function M.is_ya_available()
-  return fn.executable('ya') == 1
+  return vim.fn.executable('ya') == 1
 end
 
 function M.file_exists(name)

--- a/spec/yazi/health_spec.lua
+++ b/spec/yazi/health_spec.lua
@@ -144,12 +144,10 @@ Options:
         end
       end)
 
-      require('yazi').setup(
-        ---@type YaziConfig
-        {
-          use_ya_for_events_reading = true,
-        }
-      )
+      ---@type YaziConfig
+      yazi.setup({
+        use_ya_for_events_reading = true,
+      })
 
       vim.cmd('checkhealth yazi')
 
@@ -195,7 +193,7 @@ Options:
       function()
         mock_app_versions['yazi --help'] =
           yazi_help_output_with_client_id_flag_missing
-        require('yazi').setup({ use_yazi_client_id_flag = true })
+        yazi.setup({ use_yazi_client_id_flag = true })
         vim.cmd('checkhealth yazi')
 
         assert_buffer_contains_text(
@@ -209,7 +207,7 @@ Options:
       function()
         mock_app_versions['yazi --help'] =
           yazi_help_output_with_client_id_flag_missing
-        require('yazi').setup({ use_yazi_client_id_flag = false })
+        yazi.setup({ use_yazi_client_id_flag = false })
         vim.cmd('checkhealth yazi')
 
         assert_buffer_does_not_contain_text('use_yazi_client_id_flag')
@@ -219,7 +217,7 @@ Options:
     it(
       'does not warn when the `--client-id` flag is found in the yazi --help output',
       function()
-        require('yazi').setup({ use_yazi_client_id_flag = true })
+        yazi.setup({ use_yazi_client_id_flag = true })
         vim.cmd('checkhealth yazi')
 
         assert_buffer_does_not_contain_text('use_yazi_client_id_flag')
@@ -231,7 +229,7 @@ Options:
     it(
       'instructs the user to load yazi on startup when `open_for_directories` is set',
       function()
-        require('yazi').setup({ open_for_directories = true })
+        yazi.setup({ open_for_directories = true })
         vim.cmd('checkhealth yazi')
 
         assert_buffer_contains_text(
@@ -243,10 +241,47 @@ Options:
     it(
       'does not instruct the user to load yazi on startup when `open_for_directories` is not set',
       function()
-        require('yazi').setup({ open_for_directories = false })
+        yazi.setup({ open_for_directories = false })
         vim.cmd('checkhealth yazi')
 
         assert_buffer_does_not_contain_text('open_for_directories')
+      end
+    )
+  end)
+
+  describe('the checks for resolve_relative_path_application', function()
+    it(
+      'warns when the keymap for this integration is set but the resolver is missing',
+      function()
+        yazi.setup({
+          integrations = {
+            resolve_relative_path_application = 'missing-nonexistent',
+          },
+        })
+
+        vim.cmd('checkhealth yazi')
+
+        assert_buffer_contains_text(
+          'WARNING The `resolve_relative_path_application` (`missing-nonexistent`) is not found on PATH.'
+        )
+      end
+    )
+
+    it(
+      'does not warn when the keymap for this integration is not set',
+      function()
+        yazi.setup({
+          keymaps = {
+            copy_relative_path_to_selected_files = false,
+          },
+          integrations = {
+            resolve_relative_path_application = 'missing-nonexistent',
+          },
+        })
+
+        vim.cmd('checkhealth yazi')
+
+        assert_buffer_does_not_contain_text('resolve_relative_path_application')
       end
     )
   end)

--- a/spec/yazi/plugin_spec.lua
+++ b/spec/yazi/plugin_spec.lua
@@ -7,7 +7,8 @@ describe('installing a plugin', function()
 
   before_each(function()
     stub(vim, 'notify')
-    -- convert the unique name from a file to a directory
+
+    -- refuse to remove anything outside of /tmp/
     assert(base_dir:match('/tmp/'), 'Failed to create a temporary directory')
     os.remove(base_dir)
     vim.fn.mkdir(base_dir, 'p')
@@ -97,8 +98,9 @@ describe('installing a plugin', function()
       }, { yazi_dir = yazi_dir, sub_dir = 'easyjump.yazi' })
 
       -- verify that the plugin was symlinked
-      local symlink =
-        vim.uv.fs_readlink(vim.fs.joinpath(yazi_dir, 'plugins', 'easyjump.yazi'))
+      local symlink = vim.uv.fs_readlink(
+        vim.fs.joinpath(yazi_dir, 'plugins', 'easyjump.yazi')
+      )
 
       assert.are.same(plugin_dir, symlink)
     end)

--- a/spec/yazi/relative_path_spec.lua
+++ b/spec/yazi/relative_path_spec.lua
@@ -1,0 +1,67 @@
+---@module "plenary.path"
+
+local assert = require('luassert')
+local utils = require('yazi.utils')
+local yazi = require('yazi')
+
+local function create_file(path)
+  local file = io.open(path, 'w')
+  assert(file, 'could not open file')
+  file:write('hello')
+  file:close()
+end
+
+describe('relative_path', function()
+  local base_dir = os.tmpname() -- create a temporary file with a unique name
+
+  before_each(function()
+    -- use the defaults, which set realpath and grealpath depending on the OS
+    yazi.setup()
+
+    assert(
+      base_dir:match('/tmp/'),
+      "base_dir is not under `/tmp/`, it's too dangerous to continue"
+    )
+    os.remove(base_dir)
+    vim.fn.mkdir(base_dir, 'p')
+  end)
+
+  after_each(function()
+    vim.fn.delete(base_dir, 'rf')
+  end)
+
+  -- test basic cases, not necessarily the entire feature set of GNU realpath
+
+  it('returns the relative path from a directory to a subdirectory', function()
+    local subdirectory = vim.fs.joinpath(base_dir, 'subdirectory')
+
+    vim.fn.mkdir(subdirectory)
+    local result = utils.relative_path(yazi.config, base_dir, subdirectory)
+
+    assert.are.same('subdirectory', result)
+  end)
+
+  it('returns the relative path from a directory to a subfile', function()
+    local subfile = vim.fs.joinpath(base_dir, 'subfile')
+    create_file(subfile)
+
+    local result = utils.relative_path(yazi.config, base_dir, subfile)
+
+    assert.are.same('subfile', result)
+  end)
+
+  it('returns the relative path from a file to a directory', function()
+    -- when yazi is started from a file (which is almost always), that file is
+    -- called the "start file" here
+
+    local file = vim.fs.joinpath(base_dir, 'file')
+    create_file(file)
+
+    local subdirectory = vim.fs.joinpath(base_dir, 'subdirectory')
+    vim.fn.mkdir(subdirectory)
+
+    local result = utils.relative_path(yazi.config, file, subdirectory)
+
+    assert.are.same('subdirectory', result)
+  end)
+end)


### PR DESCRIPTION
> This feature is available both when using `ya_for_events_reading and
> without it.
>
> If you get any errors, run `:healthcheck yazi` for more information.

When yazi is open, pressing `<c-y>` will copy the relative path of the currently hovered file to the clipboard. If multiple files are selected, the relative paths of all selected files will be copied, one per line.

The relative path is calculated from the file/directory yazi was started in, so it should do the right thing in most cases.

This feature requires GNU `realpath` on Linux and `grealpath` on macOS. `grealpath` is available in the `coreutils` package on Homebrew. On most Linux systems, `realpath` should be available by default.