### PR TITLE
test: allow different sizes for the terminal in the integration tests

### DIFF
--- a/integration-tests/client/testEnvironmentTypes.ts
+++ b/integration-tests/client/testEnvironmentTypes.ts
@@ -49,6 +49,12 @@ export type StartNeovimServerArguments = z.infer<
 export const startNeovimServerArguments = z.intersection(
   z.object({
     directory: z.string(),
+    terminalDimensions: z
+      .object({
+        cols: z.number(),
+        rows: z.number(),
+      })
+      .optional(),
   }),
   startNeovimArguments,
 )

--- a/integration-tests/client/websocket-client.ts
+++ b/integration-tests/client/websocket-client.ts
@@ -73,10 +73,12 @@ window.startNeovim = async function startApp(
   directory: string,
   startArgs?: StartNeovimArguments,
 ) {
+  const terminalDimensions = { cols: terminal.cols, rows: terminal.rows }
   await trpc.neovim.start.mutate({
     directory,
     filename: startArgs?.filename ?? "initial-file.txt",
     startupScriptModifications: startArgs?.startupScriptModifications,
+    terminalDimensions,
   })
 
   terminal.onData((data) => {

--- a/integration-tests/server/utilities/DisposeableSingleApplication.ts
+++ b/integration-tests/server/utilities/DisposeableSingleApplication.ts
@@ -58,6 +58,7 @@ export class DisposeableSingleApplication {
 
       cwd: testDirectory,
       env: process.env,
+      dimensions: startArgs.terminalDimensions,
 
       onStdoutOrStderr(data: string) {
         eventEmitter.emit("stdout" satisfies StdoutMessage, data)

--- a/integration-tests/server/utilities/TerminalApplication.ts
+++ b/integration-tests/server/utilities/TerminalApplication.ts
@@ -1,8 +1,13 @@
 import winston from "winston"
 import { ExternallyResolvablePromise } from "./ExternallyResolvablePromise.ts"
 
+import type { ITerminalDimensions } from "@xterm/addon-fit"
 import type { IPty } from "node-pty"
 import pty from "node-pty"
+
+// NOTE the size for the terminal was chosen so that it looks good in my
+// cypress test preview
+const defaultDimensions: ITerminalDimensions = { cols: 125, rows: 43 }
 
 // NOTE separating stdout and stderr is not supported by node-pty
 // https://github.com/microsoft/node-pty/issues/71
@@ -48,22 +53,24 @@ export class TerminalApplication {
     args,
     cwd,
     env,
+    dimensions: givenDimensions,
   }: {
     onStdoutOrStderr: (data: string) => void
     command: string
     args: string[]
     cwd: string
     env?: NodeJS.ProcessEnv
+    dimensions?: ITerminalDimensions
   }): TerminalApplication {
-    // NOTE the size for the terminal was chosen so that it looks good in the
-    // cypress test preview
+    const dimensions = givenDimensions ?? defaultDimensions
+
     console.log(`Starting '${command} ${args.join(" ")}' in cwd '${cwd}'`)
     const ptyProcess = pty.spawn(command, args, {
       name: "xterm-color",
       cwd,
       env,
-      cols: 125,
-      rows: 43,
+      cols: dimensions.cols,
+      rows: dimensions.rows,
     })
 
     const processId = ptyProcess.pid


### PR DESCRIPTION
Previously there was a limitation for the browser window. Only a single size worked. Other sizes would cause neovim's text not to be shown at all. Not sure why this happened, but it seems that if I pass the current size of the terminal's textarea to the server, this issue is avoided.