### PR TITLE
refactor: use `vim.lsp.get_clients()` instead of deprecated `vim.lsp.get_active_clients()`

### DIFF
--- a/lua/yazi/lsp/embedded/lsp-file-operations/did-create.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/did-create.lua
@@ -4,7 +4,8 @@ local log = require('yazi.lsp.embedded.lsp-file-operations.log')
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local did_create = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'didCreate' }

--- a/lua/yazi/lsp/embedded/lsp-file-operations/did-delete.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/did-delete.lua
@@ -4,7 +4,8 @@ local log = require('yazi.lsp.embedded.lsp-file-operations.log')
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local did_delete = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'didDelete' }

--- a/lua/yazi/lsp/embedded/lsp-file-operations/did-rename.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/did-rename.lua
@@ -4,7 +4,8 @@ local log = require('yazi.lsp.embedded.lsp-file-operations.log')
 local M = {}
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local did_rename = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'didRename' }

--- a/lua/yazi/lsp/embedded/lsp-file-operations/will-create.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/will-create.lua
@@ -33,7 +33,8 @@ local function getWorkspaceEdit(client, fname)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local will_create = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'willCreate' }

--- a/lua/yazi/lsp/embedded/lsp-file-operations/will-delete.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/will-delete.lua
@@ -33,7 +33,8 @@ local function getWorkspaceEdit(client, fname)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local will_delete = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'willDelete' }

--- a/lua/yazi/lsp/embedded/lsp-file-operations/will-rename.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations/will-rename.lua
@@ -34,7 +34,8 @@ local function getWorkspaceEdit(client, old_name, new_name)
 end
 
 M.callback = function(data)
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  local clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in pairs(clients()) do
     local will_rename = utils.get_nested_path(
       client,
       { 'server_capabilities', 'workspace', 'fileOperations', 'willRename' }


### PR DESCRIPTION
`vim.lsp.get_active_clients()` is deprecated and will be removed in Neovim 0.12. This causes deprecation warning on 0.11 after renaming files with bulk renaming feature:


```console
- WARNING vim.lsp.get_active_clients() is deprecated. Feature will be removed in Nvim 0.12
  - ADVICE:
    - use vim.lsp.get_clients() instead.
    - stack traceback:
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/lsp/embedded/lsp-file-operations/will-rename.lua:37
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/lsp/rename.lua:11
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/event_handling.lua:100
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi.lua:75
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/process/yazi_process.lua:54
    - stack traceback:
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/lsp/embedded/lsp-file-operations/did-rename.lua:7
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/lsp/rename.lua:12
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/event_handling.lua:100
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi.lua:75
        /home/xfzv/.local/share/nvim/lazy/yazi.nvim/lua/yazi/process/yazi_process.lua:54
```

ref: https://github.com/neovim/neovim/blob/512d228111bccf3e52613c798edc7f803c1de13f/runtime/doc/deprecated.txt#L52