### PR TITLE
fix: pressing <esc> has a 1 second delay

### DIFF
--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -134,10 +134,9 @@ function YaziFloatingWindow:open_and_display()
     end,
   })
 
-  -- LazyVim sets <esc><esc> to forcibly enter normal mode. This has been
-  -- confusing for some users. Let's disable it when using yazi.nvim only.
+  -- Prevents a bug with lazyvim involving which-key.nvim: pressing <esc> in
+  -- the terminal window opens which-key and ignores the keypress.
   vim.keymap.set('t', '<esc>', '<esc>', { buffer = yazi_buffer })
-  vim.keymap.set({ 't' }, '<esc><esc>', '<Nop>', { buffer = yazi_buffer })
 
   return self
 end


### PR DESCRIPTION
Fixes https://github.com/mikavilpas/yazi.nvim/issues/295