### PR TITLE
✨feat(`openers`): New opener `open_multiple_files()` is now the default value for `config.hooks.yazi_opened_multiple_files`.

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,8 +10,6 @@ jobs:
     name: prettier
     steps:
       - uses: actions/checkout@v4.1.6
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v4.0.3
         with:
           node-version-file: .nvmrc

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
       replace_in_directory = '<c-g>',
       cycle_open_buffers = '<tab>',
       copy_relative_path_to_selected_files = '<c-y>',
+      send_to_quickfix_list = '<c-q>',
     },
 
     -- completely override the keymappings for yazi. This function will be
@@ -278,9 +279,11 @@ You can optionally configure yazi.nvim by setting any of the options below.
 
 These are the default keybindings that are available when yazi is open:
 
-- `<c-v>`: open the selected file in a vertical split
-- `<c-x>`: open the selected file in a horizontal split
-- `<c-t>`: open the selected file in a new tab
+- `<f1>`: show the help menu
+- `<c-v>`: open the selected file(s) in vertical splits
+- `<c-x>`: open the selected file(s) in horizontal splits
+- `<c-t>`: open the selected file(s) in new tabs
+- `<c-q>`: send the selected file(s) to the quickfix list
 - There are also integrations to other plugins, which you need to install
   separately:
   - `<c-s>`: search in the current yazi directory using
@@ -292,6 +295,11 @@ These are the default keybindings that are available when yazi is open:
     [grug-far](https://github.com/MagicDuck/grug-far.nvim), if available
     - if multiple files/directories are selected in yazi, the operation is
       limited to those only
+  - `<c-y>`: copy the relative path of the selected file(s) to the clipboard.
+    Requires GNU `realpath` or `grealpath` on OSX
+  - `<tab>`: cycle through the open buffers in Neovim. See
+    [#232](https://github.com/mikavilpas/yazi.nvim/pull/232) for more
+    information
 
 ## 🪛 Customizing yazi
 

--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-files.cy.ts
@@ -101,7 +101,7 @@ describe("opening files", () => {
       cy.typeIntoTerminal(" ")
       // also select the next file because multiple files have to be selected
       cy.typeIntoTerminal(" ")
-      cy.typeIntoTerminal("{enter}")
+      cy.typeIntoTerminal("{control+q}")
 
       // yazi should now be closed
       cy.contains("-- TERMINAL --").should("not.exist")

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
@@ -100,7 +100,7 @@ describe("opening files", () => {
       cy.typeIntoTerminal(" ")
       // also select the next file because multiple files have to be selected
       cy.typeIntoTerminal(" ")
-      cy.typeIntoTerminal("{enter}")
+      cy.typeIntoTerminal("{control+q}")
 
       // yazi should now be closed
       cy.contains("-- TERMINAL --").should("not.exist")

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -36,7 +36,7 @@ function M.default()
     hooks = {
       yazi_opened = function() end,
       yazi_closed_successfully = function() end,
-      yazi_opened_multiple_files = openers.send_files_to_quickfix_list,
+      yazi_opened_multiple_files = openers.open_multiple_files,
     },
 
     highlight_groups = {

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -31,6 +31,7 @@ function M.default()
       replace_in_directory = '<c-g>',
       cycle_open_buffers = '<tab>',
       copy_relative_path_to_selected_files = '<c-y>',
+      send_to_quickfix_list = '<c-q>',
     },
     set_keymappings_function = nil,
     hooks = {
@@ -167,6 +168,18 @@ function M.set_keymappings(yazi_buffer, config, context)
     end, { buffer = yazi_buffer })
   end
 
+  if config.keymaps.send_to_quickfix_list ~= false then
+    vim.keymap.set({ 't' }, config.keymaps.send_to_quickfix_list, function()
+      local openers = require('yazi.openers')
+      keybinding_helpers.select_current_file_and_close_yazi(config, {
+        on_multiple_files_opened = openers.send_files_to_quickfix_list,
+        on_file_opened = function(chosen_file)
+          openers.send_files_to_quickfix_list({ chosen_file })
+        end,
+      })
+    end, { buffer = yazi_buffer })
+  end
+
   if config.keymaps.show_help ~= false then
     vim.keymap.set({ 't' }, config.keymaps.show_help, function()
       local w = vim.api.nvim_win_get_width(0)
@@ -179,7 +192,7 @@ function M.set_keymappings(yazi_buffer, config, context)
         bufpos = { 5, 30 },
         noautocmd = true,
         width = math.min(46, math.floor(w * 0.5)),
-        height = math.min(12, math.floor(h * 0.5)),
+        height = math.min(13, math.floor(h * 0.5)),
         border = config.yazi_floating_window_border,
       })
 
@@ -199,6 +212,9 @@ function M.set_keymappings(yazi_buffer, config, context)
         ''
           .. show(config.keymaps.open_file_in_vertical_split)
           .. ' - open file in vertical split',
+        ''
+          .. show(config.keymaps.send_to_quickfix_list)
+          .. ' - send to the quickfix list',
         ''
           .. show(config.keymaps.grep_in_directory)
           .. ' - search in directory / selected files',

--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -21,6 +21,11 @@ function M.open_file_in_tab(chosen_file)
 end
 
 ---@param chosen_files string[]
+function M.open_multiple_files(chosen_files)
+  vim.cmd('args' .. table.concat(chosen_files, ' '))
+end
+
+---@param chosen_files string[]
 function M.send_files_to_quickfix_list(chosen_files)
   vim.fn.setqflist({}, 'r', {
     title = 'Yazi',

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -32,6 +32,7 @@
 ---@field replace_in_directory? YaziKeymap # Close yazi and open a replacer (default: grug-far.nvim) narrowed to the directory yazi is in
 ---@field cycle_open_buffers? YaziKeymap # When Neovim has multiple splits open and visible, make yazi jump to the directory of the next one
 ---@field copy_relative_path_to_selected_files? YaziKeymap # Copy the relative paths of the selected files to the clipboard
+---@field send_to_quickfix_list? YaziKeymap # Send the selected files to the quickfix list for later processing
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi

--- a/spec/yazi/open_multiple_files_spec.lua
+++ b/spec/yazi/open_multiple_files_spec.lua
@@ -6,12 +6,39 @@ describe('the default configuration', function()
     end
   end)
 
+  local plenary_path = require('plenary.path')
+  local test_file_path = plenary_path:new(vim.fn.getcwd(), 'test-file.txt')
+
+  it('opens multiple files in buffers by default', function()
+    local config = require('yazi.config').default()
+    local chosen_files = { '/abc/test-file.txt', '/abc/test-file2.txt' }
+
+    config.hooks.yazi_opened_multiple_files(
+      chosen_files,
+      config,
+      test_file_path
+    )
+
+    local buffers = vim.api.nvim_list_bufs()
+
+    assert.equals(2, #buffers)
+    assert.equals('/abc/test-file.txt', vim.api.nvim_buf_get_name(buffers[1]))
+    assert.equals('/abc/test-file2.txt', vim.api.nvim_buf_get_name(buffers[2]))
+  end)
+
   it('can display multiple files in the quickfix list', function()
     local config = require('yazi.config').default()
+    config.hooks.yazi_opened_multiple_files =
+      require('yazi.openers').send_files_to_quickfix_list
+
     -- include problematic characters in the file names to preserve their behaviour
     local chosen_files = { '/abc/test-$@file.txt', '/abc/test-file2.txt' }
 
-    config.hooks.yazi_opened_multiple_files(chosen_files, config)
+    config.hooks.yazi_opened_multiple_files(
+      chosen_files,
+      config,
+      test_file_path
+    )
 
     local quickfix_list = vim.fn.getqflist()
 


### PR DESCRIPTION
## Current behavior
Opening multiple files send them to the quickfix by default.

## Behavior after this PR
Opening multiple files open multiple buffers.

## Reason for this PR
It is unlikely the default behavior users expect when opening multiple files is to send them to the quickfix.

## Screenshots
Selecting 3 files and pressing enter...
![screenshot_2024-08-04_00-00-33_480374196](https://github.com/user-attachments/assets/120d97df-f29f-4e5b-b491-ab377e8377f5)

Open them as 3 buffers as result by default
![screenshot_2024-08-04_00-00-51_527460128](https://github.com/user-attachments/assets/f04afd1e-bb1f-429d-b75f-d56f78faaa31)

Users who want a different behavior can still override the function in opts. This PR is just about better UX.