### PR TITLE
fix: not being in insert mode when opening a dir from the command line

### DIFF
--- a/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-directories.cy.ts
+++ b/integration-tests/cypress/e2e/using-shell-redirection-to-read-events/opening-directories.cy.ts
@@ -44,6 +44,13 @@ describe("opening directories", () => {
 
       // yazi should now be visible in the new directory
       cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name)
+
+      // yazi should now be in insert mode. This means pressing q should exit.
+      cy.typeIntoTerminal("q")
+
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name).should(
+        "not.exist",
+      )
     })
   })
 })

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
@@ -48,6 +48,13 @@ describe("opening directories", () => {
 
       // yazi should now be visible in the new directory
       cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name)
+
+      // yazi should now be in insert mode. This means pressing q should exit.
+      cy.typeIntoTerminal("q")
+
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name).should(
+        "not.exist",
+      )
     })
   })
 })

--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -40,6 +40,12 @@ function M.hijack_netrw(yazi_augroup)
 
         Log:debug(string.format('Opening yazi for directory %s', file))
         require('yazi').yazi(M.config, file)
+
+        -- HACK: for some reason, the cursor is not in insert mode when opening
+        -- yazi from the command line with `neovim .`, so just simulate
+        -- pressing "i" to enter insert mode :) It did nothing when when I
+        -- tried using vim.cmd('startinsert') or vim.cmd('normal! i')
+        vim.api.nvim_feedkeys('i', 'n', false)
       end)
     end
   end


### PR DESCRIPTION
I think this bug was introduced in 7eb5f933c863, but now it has a test and is unlikely to happen again.