### PR TITLE
ci: use exact versions for actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,12 +8,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - uses: actions/setup-node@v4.0.3
         with:
           node-version-file: .nvmrc
       - run: npm run clean-install:all
-      - uses: reviewdog/action-eslint@v1
+      - uses: reviewdog/action-eslint@v1.31.0
         with:
           workdir: integration-tests
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v9.0.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.6
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@v1.1.3
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/release-luarocks.yml
+++ b/.github/workflows/release-luarocks.yml
@@ -14,9 +14,9 @@ jobs:
     name: LuaRocks upload
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.6
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v7
+        uses: nvim-neorocks/luarocks-tag-release@v7.1.0
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.6
-      - uses: JohnnyMorganz/stylua-action@v4
+      - uses: JohnnyMorganz/stylua-action@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         neovim_version: ["nightly", "stable"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - name: Set up dependencies
         run: |
           # ripgrep is a telescope dependency
@@ -31,7 +31,7 @@ jobs:
           }
 
       - name: Compile and install `yazi-fm` from source
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@v3.1.1
         with:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
@@ -41,7 +41,7 @@ jobs:
           commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
 
       - name: Compile and install yazi from source
-        uses: baptiste0928/cargo-install@v3
+        uses: baptiste0928/cargo-install@v3.1.1
         with:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
@@ -51,7 +51,7 @@ jobs:
           commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
 
       - name: Run tests
-        uses: nvim-neorocks/nvim-busted-action@v1
+        uses: nvim-neorocks/nvim-busted-action@v1.0.1
         with:
           nvim_version: ${{ matrix.neovim_version }}
           luarocks_version: "3.11.1"
@@ -61,7 +61,7 @@ jobs:
         with:
           command: npm run cy:run
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.3.5
         # add the line below to store screenshots only on failures
         # if: failure()
         if: failure()

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.6
       - uses: stevearc/nvim-typecheck-action@v2
         with:
           path: lua


### PR DESCRIPTION
This might help to avoid breaking changes in the future. Dependabot will still be able to update the actions to the latest version, an example can be seen in 7062de6