### PR TITLE
perf: don't set up nvim-tree and neo-tree in lsp-file-operations

### DIFF
--- a/lua/yazi/lsp/embedded/lsp-file-operations.lua
+++ b/lua/yazi/lsp/embedded/lsp-file-operations.lua
@@ -57,6 +57,11 @@ M.setup = function(opts)
     log.level = 'debug'
   end
 
+  if true then
+    -- in yazi.nvim, we don't need to do anything here
+    return
+  end
+
   -- nvim-tree integration
   local ok_nvim_tree, nvim_tree_api = pcall(require, 'nvim-tree.api')
   if ok_nvim_tree then


### PR DESCRIPTION
In yazi.nvim, we don't need these plugins. If the user had them in their configuration, they were being set up which required some (minimal) work to be done. This commit removes that work.

I could have removed the code entirely, but I decided to keep it in case we want to depend on the official lsp-file-operations in the future.