### PR TITLE
fix: highlighting siblings of hovered directories

### DIFF
--- a/lua/yazi/buffer_highlighting/yazi_session_highlighter.lua
+++ b/lua/yazi/buffer_highlighting/yazi_session_highlighter.lua
@@ -64,7 +64,7 @@ function YaziSessionHighlighter:highlight_buffers_when_hovered(url, config)
         { when_light = -25, when_dark = 65 }
       )
     elseif
-      buffer.renameable_buffer:is_sibling_of(url)
+      buffer.renameable_buffer:is_sibling_of_hovered(url)
       and config.highlight_hovered_buffers_in_same_directory == true
     then
       Log:debug(

--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -54,12 +54,22 @@ function RenameableBuffer:matches_parent(path)
   return found ~= nil
 end
 
---- Check if the given `other` path is in the same directory as the buffer's path.
+--- When hovering over a file or a directory `other`, return true if this
+--- buffer is in the same directory as `other`.
 ---@param other string
-function RenameableBuffer:is_sibling_of(other)
+function RenameableBuffer:is_sibling_of_hovered(other)
   other = remove_trailing_slash(other)
-  local my_dir = require("yazi.utils").dir_of(self.path.filename)
-  local other_dir = require("yazi.utils").dir_of(other)
+  local utils = require("yazi.utils")
+
+  ---@type Path
+  local other_path = plenary_path:new(other)
+
+  local my_dir = utils.dir_of(self.path.filename)
+  local other_dir = utils.dir_of(other)
+
+  if other_path:is_dir() then
+    return my_dir.filename == other_dir:parent().filename
+  end
 
   return my_dir.filename == other_dir.filename
 end

--- a/spec/yazi/renameable_buffer_spec.lua
+++ b/spec/yazi/renameable_buffer_spec.lua
@@ -78,7 +78,7 @@ describe("the RenameableBuffer class", function()
     assert.are.equal("/my-tmp/file1", buffer.original_path)
   end)
 
-  describe("is_sibling_of", function()
+  describe("is_sibling_of_hovered", function()
     local base_dir
 
     before_each(function()
@@ -97,7 +97,7 @@ describe("the RenameableBuffer class", function()
       local buffer =
         RenameableBuffer.new(1, vim.fs.joinpath(parent_directory, "file1"))
       assert.is_true(
-        buffer:is_sibling_of(vim.fs.joinpath(parent_directory, "file2"))
+        buffer:is_sibling_of_hovered(vim.fs.joinpath(parent_directory, "file2"))
       )
     end)
 
@@ -109,7 +109,29 @@ describe("the RenameableBuffer class", function()
       vim.fn.mkdir(dir2)
 
       local buffer = RenameableBuffer.new(1, vim.fs.joinpath(dir1, "file1"))
-      assert.is_false(buffer:is_sibling_of(vim.fs.joinpath(dir2, "file2")))
+      assert.is_false(
+        buffer:is_sibling_of_hovered(vim.fs.joinpath(dir2, "file2"))
+      )
+    end)
+
+    it("can recognize the siblings of hovered directories", function()
+      -- when yazi hovers the helpers/ directory, it should highlight buffers
+      -- in this directory (`.`), not buffers in helpers/
+      --
+      --   󰉋 helpers
+      --    file.lua
+      --
+
+      local this_dir = vim.fs.joinpath(base_dir, "this_directory")
+      local helpers_dir = vim.fs.joinpath(this_dir, "helpers")
+
+      vim.fn.mkdir(this_dir, "p")
+      vim.fn.mkdir(helpers_dir, "p")
+
+      local file_path = vim.fs.joinpath(this_dir, "file.lua")
+
+      local buffer = RenameableBuffer.new(1, file_path)
+      assert.is_true(buffer:is_sibling_of_hovered(helpers_dir))
     end)
   end)
 end)


### PR DESCRIPTION
When hovering over a directory, Yazi should highlight buffers in the same directory, not in the hovered directory.

Previously, Yazi was highlighting buffers in the hovered directory instead of the same directory, causing confusion.