### PR TITLE
feat: open currently visible splits as yazi tabs (opt-in)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          # feat: new extract builtin plugin for archive extracting (#1321)
-          # https://github.com/sxyazi/yazi/commit/bce0fc1175c855ecb2dbee6f8575857b1e9616d4
-          commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
+          # feat: start with multiple tabs with different paths (#1443)
+          # https://github.com/sxyazi/yazi/commit/dac72eb39a846d15db7f1a7c54e9261675a90e53
+          commit: dac72eb39a846d15db7f1a7c54e9261675a90e53
 
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3.1.1
@@ -46,9 +46,9 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          # feat: new extract builtin plugin for archive extracting (#1321)
-          # https://github.com/sxyazi/yazi/commit/bce0fc1175c855ecb2dbee6f8575857b1e9616d4
-          commit: bce0fc1175c855ecb2dbee6f8575857b1e9616d4
+          # feat: start with multiple tabs with different paths (#1443)
+          # https://github.com/sxyazi/yazi/commit/dac72eb39a846d15db7f1a7c54e9261675a90e53
+          commit: dac72eb39a846d15db7f1a7c54e9261675a90e53
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@v1.0.1

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ You can optionally configure yazi.nvim by setting any of the options below.
     -- an upcoming optional feature
     use_yazi_client_id_flag = false,
 
+    -- open visible splits as yazi tabs for easy navigation. Requires a yazi
+    -- version more recent than 2024-08-10
+    open_multiple_tabs = false,
+
     -- NOTE: these only work if `use_ya_for_events_reading` is enabled, etc.
     highlight_groups = {
       -- See https://github.com/mikavilpas/yazi.nvim/pull/180

--- a/integration-tests/cypress/e2e/healthcheck.cy.ts
+++ b/integration-tests/cypress/e2e/healthcheck.cy.ts
@@ -23,8 +23,8 @@ describe("the healthcheck", () => {
     )
 
     // the `yazi` and `ya` applications should be found successfully
-    cy.contains("Found yazi version Yazi 0.2.5")
-    cy.contains("Found ya version Ya 0.2.5")
+    cy.contains(new RegExp("Found yazi version Yazi \\d+?.\\d+?.\\d+?"))
+    cy.contains(new RegExp("Found ya version Ya \\d+?.\\d+?.\\d+?"))
     cy.contains("OK yazi")
   })
 })

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
@@ -1,5 +1,5 @@
 import { startNeovimWithYa } from "./startNeovimWithYa"
-import { isHovered, isNotHovered } from "./utils/hover-utils"
+import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
 
 // NOTE: cypress doesn't support the tab key, but control+i seems to work fine
 // https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
@@ -38,9 +38,9 @@ describe("'cd' to another buffer's directory", () => {
 
       // before doing anything, both files should be unhovered (have the
       // default background color)
-      isNotHovered(view.leftFile.text)
-      isNotHovered(view.centerFile.text)
-      isNotHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -50,25 +50,25 @@ describe("'cd' to another buffer's directory", () => {
       //
       // Since each directory only has one file, it should be highlighted :)
       cy.typeIntoTerminal("{control+i}")
-      isNotHovered(view.leftFile.text)
-      isHovered(view.centerFile.text)
-      isNotHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftFile.text)
+      isHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
 
       cy.typeIntoTerminal("{control+i}")
-      isHovered(view.leftFile.text)
-      isNotHovered(view.centerFile.text)
-      isNotHovered(view.rightFile.text)
+      isHoveredInNeovim(view.leftFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
 
       cy.typeIntoTerminal("{control+i}")
-      isNotHovered(view.leftFile.text)
-      isNotHovered(view.centerFile.text)
-      isHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isHoveredInNeovim(view.rightFile.text)
 
       // tab once more to make sure it wraps around
       cy.typeIntoTerminal("{control+i}")
-      isNotHovered(view.leftFile.text)
-      isHovered(view.centerFile.text)
-      isNotHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftFile.text)
+      isHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
     })
   })
 
@@ -91,8 +91,8 @@ describe("'cd' to another buffer's directory", () => {
         "modify_yazi_config_and_add_hovered_buffer_background.lua",
       ],
     }).then(() => {
-      isNotHovered(view.leftAndCenterFile.text)
-      isNotHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftAndCenterFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -100,20 +100,20 @@ describe("'cd' to another buffer's directory", () => {
       cy.typeIntoTerminal("{control+i}")
 
       // the right file should be highlighted
-      isNotHovered(view.leftAndCenterFile.text)
-      isHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftAndCenterFile.text)
+      isHoveredInNeovim(view.rightFile.text)
 
       // tab again to make sure it wraps around. It should highlight both splits
       cy.typeIntoTerminal("{control+i}")
-      isHovered(view.leftAndCenterFile.text)
-      isNotHovered(view.rightFile.text)
+      isHoveredInNeovim(view.leftAndCenterFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
 
       // tab again. Since the left and center file are the same, it should
       // skip the center file and highlight the right file
 
       cy.typeIntoTerminal("{control+i}")
-      isNotHovered(view.leftAndCenterFile.text)
-      isHovered(view.rightFile.text)
+      isNotHoveredInNeovim(view.leftAndCenterFile.text)
+      isHoveredInNeovim(view.rightFile.text)
     })
   })
 })

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/hover-highlights.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/hover-highlights.cy.ts
@@ -2,8 +2,8 @@ import tinycolor2 from "tinycolor2"
 import { startNeovimWithYa } from "./startNeovimWithYa"
 import {
   darkBackgroundColors,
-  isHovered,
-  isNotHovered,
+  isHoveredInNeovim,
+  isNotHoveredInNeovim,
   lightBackgroundColors,
 } from "./utils/hover-utils"
 
@@ -37,7 +37,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      isNotHovered("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -53,12 +53,12 @@ describe("highlighting the buffer with 'hover' events", () => {
       // the current file is highlighted by default when
       // opening yazi. This should have sent the 'hover' event and caused the
       // Neovim window to be shown with a different background color
-      isHovered("If you see this text, Neovim is ready!")
+      isHoveredInNeovim("If you see this text, Neovim is ready!")
 
       // close yazi - the highlight should be removed and we should see the
       // same color as before
       cy.typeIntoTerminal("q")
-      isNotHovered("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
     })
   })
 
@@ -69,7 +69,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      isNotHovered("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -84,12 +84,12 @@ describe("highlighting the buffer with 'hover' events", () => {
       // the current file is highlighted by default when
       // opening yazi. This should have sent the 'hover' event and caused the
       // Neovim window to be shown with a different background color
-      isHovered("If you see this text, Neovim is ready!")
+      isHoveredInNeovim("If you see this text, Neovim is ready!")
 
       // hover another file - the highlight should be removed
       cy.typeIntoTerminal(`/^${dir.contents["test-setup.lua"].name}{enter}`)
 
-      isNotHovered("If you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("If you see this text, Neovim is ready!")
     })
   })
 
@@ -100,7 +100,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       ],
     }).then((dir) => {
       // wait until text on the start screen is visible
-      isNotHovered("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
 
       const testFile = dir.contents["test-setup.lua"].name
       // open an adjacent file and wait for it to be displayed
@@ -118,14 +118,14 @@ describe("highlighting the buffer with 'hover' events", () => {
       // yazi should be visible now
       cy.contains(dir.contents["test-setup.lua"].name)
       hoverAnotherFileToEnsureHoverEventIsReceivedInCI(testFile)
-      isHovered("how to initialize the test environment")
+      isHoveredInNeovim("how to initialize the test environment")
 
       // select the other file - the highlight should move to it
       cy.typeIntoTerminal(`/^${dir.contents["initial-file.txt"].name}{enter}`, {
         delay: 1,
       })
-      isNotHovered("how to initialize the test environment")
-      isHovered("If you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("how to initialize the test environment")
+      isHoveredInNeovim("If you see this text, Neovim is ready!")
     })
   })
 
@@ -137,7 +137,7 @@ describe("highlighting the buffer with 'hover' events", () => {
     it("for a dark colorscheme, hovers appear lighter in color", () => {
       startNeovimWithYa({ startupScriptModifications: [] }).then((dir) => {
         // wait until text on the start screen is visible
-        isNotHovered("f you see this text, Neovim is ready!")
+        isNotHoveredInNeovim("f you see this text, Neovim is ready!")
 
         // start yazi
         cy.typeIntoTerminal("{upArrow}")
@@ -240,8 +240,8 @@ describe("highlighting the buffer with 'hover' events", () => {
       },
     }).then((dir) => {
       // wait until text on the start screen is visible
-      isNotHovered("f you see this text, Neovim is ready!")
-      isNotHovered("Hello")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("Hello")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
@@ -252,16 +252,16 @@ describe("highlighting the buffer with 'hover' events", () => {
         dir.contents["test-setup.lua"].name,
       )
 
-      isHovered(
+      isHoveredInNeovim(
         "f you see this text, Neovim is ready!",
         darkBackgroundColors.hoveredInSameDirectory,
       )
-      isHovered("Hello", darkBackgroundColors.hoveredInSameDirectory)
+      isHoveredInNeovim("Hello", darkBackgroundColors.hoveredInSameDirectory)
 
       // highlights are cleared when yazi is closed
       cy.typeIntoTerminal("q")
-      isNotHovered("f you see this text, Neovim is ready!")
-      isNotHovered("Hello")
+      isNotHoveredInNeovim("f you see this text, Neovim is ready!")
+      isNotHoveredInNeovim("Hello")
     })
   })
 })

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/utils/hover-utils.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/utils/hover-utils.ts
@@ -3,7 +3,7 @@ import { flavors } from "@catppuccin/palette"
 const darkTheme = flavors.macchiato.colors
 const lightTheme = flavors.latte.colors
 
-function rgbify(color: (typeof darkTheme)["surface0"]["rgb"]) {
+export function rgbify(color: (typeof darkTheme)["surface0"]["rgb"]): string {
   return `rgb(${color.r.toString()}, ${color.g.toString()}, ${color.b.toString()})`
 }
 
@@ -21,7 +21,7 @@ export const lightBackgroundColors = {
 }
 
 // only works for the dark colorscheme for now
-export function isHovered(text: string, color?: string): void {
+export function isHoveredInNeovim(text: string, color?: string): void {
   cy.contains(text).should(
     "have.css",
     "background-color",
@@ -30,7 +30,7 @@ export function isHovered(text: string, color?: string): void {
 }
 
 // only works for the dark colorscheme for now
-export function isNotHovered(text: string): void {
+export function isNotHoveredInNeovim(text: string): void {
   cy.contains(text).should(
     "have.css",
     "background-color",

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/utils/yazi-utils.ts
@@ -1,0 +1,20 @@
+import { flavors } from "@catppuccin/palette"
+import { rgbify } from "./hover-utils"
+
+const darkTheme = flavors.macchiato.colors
+
+export function isFileSelectedInYazi(text: string): void {
+  cy.contains(text).should(
+    "have.css",
+    "background-color",
+    rgbify(darkTheme.text.rgb),
+  )
+}
+
+export function isFileNotSelectedInYazi(text: string): void {
+  cy.contains(text).should(
+    "have.css",
+    "background-color",
+    rgbify(darkTheme.base.rgb),
+  )
+}

--- a/integration-tests/server/application/neovim/environment/testEnvironmentTypes.ts
+++ b/integration-tests/server/application/neovim/environment/testEnvironmentTypes.ts
@@ -27,6 +27,7 @@ export const startupScriptModification = z.enum([
   "disable_a_keybinding.lua",
   "notify_hover_events.lua",
   "modify_yazi_config_and_highlight_buffers_in_same_directory.lua",
+  "modify_yazi_config_and_open_multiple_files.lua",
 ])
 export type StartupScriptModification = z.infer<
   typeof startupScriptModification

--- a/integration-tests/test-environment/config-modifications/modify_yazi_config_and_open_multiple_files.lua
+++ b/integration-tests/test-environment/config-modifications/modify_yazi_config_and_open_multiple_files.lua
@@ -1,0 +1,8 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    open_multiple_tabs = true,
+  }
+)

--- a/integration-tests/test-environment/dir with spaces/file1.txt
+++ b/integration-tests/test-environment/dir with spaces/file1.txt
@@ -1,1 +1,1 @@
-this is file1.txt
+this is the first file

--- a/integration-tests/test-environment/dir with spaces/file2.txt
+++ b/integration-tests/test-environment/dir with spaces/file2.txt
@@ -1,1 +1,1 @@
-this is file2.txt
+this is the second file

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -38,7 +38,8 @@ function M.yazi(config, input_path)
     return
   end
 
-  local path = utils.selected_file_path(input_path)
+  local paths = utils.selected_file_paths(input_path)
+  local path = paths[1]
 
   local prev_win = vim.api.nvim_get_current_win()
   local prev_buf = vim.api.nvim_get_current_buf()
@@ -51,7 +52,7 @@ function M.yazi(config, input_path)
 
   local yazi_process = YaziProcess:start(
     config,
-    path,
+    paths,
     function(exit_code, selected_files, events, hovered_url)
       if exit_code ~= 0 then
         print(

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -16,9 +16,9 @@ function M.default()
   return {
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
-    -- NOTE: right now this is opt-in, but will be the default in the future
     use_ya_for_events_reading = false,
     use_yazi_client_id_flag = false,
+    open_multiple_tabs = false,
     enable_mouse_support = false,
     open_file_function = openers.open_file,
     clipboard_register = "*",

--- a/lua/yazi/process/legacy_events_from_file.lua
+++ b/lua/yazi/process/legacy_events_from_file.lua
@@ -14,11 +14,11 @@ function LegacyEventReadingFromEventFile:new(config)
   return self
 end
 
----@param path Path
-function LegacyEventReadingFromEventFile:get_yazi_command(path)
+---@param paths Path[]
+function LegacyEventReadingFromEventFile:get_yazi_command(paths)
   return string.format(
     'yazi %s --local-events "rename,delete,trash,move,cd" --chooser-file "%s" > "%s"',
-    vim.fn.shellescape(path.filename),
+    vim.fn.shellescape(paths[1].filename),
     self.config.chosen_file_path,
     self.config.events_file_path
   )

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -35,22 +35,27 @@ function YaProcess.new(config, yazi_id)
   return self
 end
 
----@param path Path
-function YaProcess:get_yazi_command(path)
-  if self.yazi_id then
-    return string.format(
-      'yazi %s --chooser-file "%s" --client-id "%s"',
-      vim.fn.shellescape(path.filename),
-      self.config.chosen_file_path,
-      self.yazi_id
-    )
+---@param paths Path[]
+function YaProcess:get_yazi_command(paths)
+  local command_words = { "yazi" }
+
+  if self.config.open_multiple_tabs == true then
+    for _, path in ipairs(paths) do
+      table.insert(command_words, vim.fn.shellescape(path.filename))
+    end
   else
-    return string.format(
-      'yazi %s --chooser-file "%s"',
-      vim.fn.shellescape(path.filename),
-      self.config.chosen_file_path
-    )
+    table.insert(command_words, vim.fn.shellescape(paths[1].filename))
   end
+
+  table.insert(command_words, "--chooser-file")
+  table.insert(command_words, self.config.chosen_file_path)
+
+  if self.yazi_id then
+    table.insert(command_words, "--client-id")
+    table.insert(command_words, self.yazi_id)
+  end
+
+  return table.concat(command_words, " ")
 end
 
 function YaProcess:kill()

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -17,9 +17,9 @@ local YaziProcess = {}
 YaziProcess.__index = YaziProcess
 
 ---@param config YaziConfig
----@param path Path
+---@param paths Path[]
 ---@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[], hovered_url: string | nil)
-function YaziProcess:start(config, path, on_exit)
+function YaziProcess:start(config, paths, on_exit)
   os.remove(config.chosen_file_path)
 
   Log:debug(
@@ -39,7 +39,7 @@ function YaziProcess:start(config, path, on_exit)
       and YaProcess.new(config, yazi_id)
     or LegacyEventReadingFromEventFile:new(config)
 
-  local yazi_cmd = self.event_reader:get_yazi_command(path)
+  local yazi_cmd = self.event_reader:get_yazi_command(paths)
   Log:debug(string.format("Opening yazi with the command: (%s).", yazi_cmd))
 
   self.yazi_job_id = vim.fn.termopen(yazi_cmd, {

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -8,6 +8,7 @@
 ---@field public events_file_path? string "the path to a temporary file that will be created by yazi to store events. A random path will be used by default"
 ---@field public use_ya_for_events_reading? boolean "use `ya`, the yazi command line application to read events from the yazi process. Right now this is opt-in, but will be the default in the future"
 ---@field public use_yazi_client_id_flag? boolean "use the `--client-id` flag with yazi, allowing communication with that specific instance as opposed to all yazis on the system"
+---@field public open_multiple_tabs? boolean "open multiple open files in yazi tabs when opening yazi"
 ---@field public enable_mouse_support? boolean
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
 ---@field public keymaps? YaziKeymaps | false # The keymaps that are available when yazi is open and focused. Set to `false` to disable all default keymaps.

--- a/spec/yazi/selected_files_spec.lua
+++ b/spec/yazi/selected_files_spec.lua
@@ -1,0 +1,58 @@
+local assert = require("luassert")
+local utils = require("yazi.utils")
+
+describe("choosing the correct files when starting yazi", function()
+  before_each(function()
+    -- clear all buffers
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  describe(" selected_file_path", function()
+    it("when given a file, returns that file", function()
+      vim.fn.bufadd("/my-tmp/file1")
+
+      local result = utils.selected_file_path("/my-tmp/file1")
+
+      assert.is_equal("/my-tmp/file1", result.filename)
+    end)
+
+    it("when no file is loaded, returns the current directory", function()
+      local result = utils.selected_file_path()
+
+      assert.is_equal(result.filename, vim.fn.getcwd())
+    end)
+  end)
+
+  describe(" selected_files", function()
+    it("when no file is loaded, returns the current directory", function()
+      local result = utils.selected_file_paths()
+      assert.is_equal(result[1].filename, vim.fn.getcwd())
+    end)
+
+    it("when given a file, returns that file", function()
+      vim.fn.bufadd("/my-tmp/file1")
+
+      local result = utils.selected_file_paths("/my-tmp/file1")
+
+      assert.is_equal("/my-tmp/file1", result[1].filename)
+      assert.is_equal(1, #result)
+    end)
+
+    it(
+      "when there is another file open in a split, includes that file",
+      function()
+        vim.fn.bufadd("/my-tmp/file1")
+        vim.cmd("vsplit /my-tmp/file2")
+
+        local result = utils.selected_file_paths("/my-tmp/file1")
+
+        assert.is_equal(#result, 2)
+
+        assert.is_equal("/my-tmp/file1", result[1].filename)
+        assert.is_equal("/my-tmp/file2", result[2].filename)
+      end
+    )
+  end)
+end)

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -25,13 +25,24 @@ describe("opening a file", function()
     })
   end)
 
-  ---@param file string
-  local function assert_opened_yazi_with_file(file)
+  ---@param files string[]
+  local function assert_opened_yazi_with_files(files)
     local call = mock(fake_yazi_process).start.calls[1]
 
-    ---@type Path
-    local path = call.vals[3]
-    assert.equals(file, path.filename)
+    ---@type Path[]
+    local actual_files = call.vals[3]
+    assert.is_equal(type(actual_files), "table")
+
+    local file_names = vim.tbl_map(function(file)
+      return file.filename
+    end, actual_files)
+
+    for _, file in ipairs(files) do
+      print("opened file: " .. file)
+      assert.is_true(type(file) == "string")
+    end
+
+    assert.is(files, file_names)
   end
 
   it("opens yazi with the current file selected", function()
@@ -44,7 +55,7 @@ describe("opening a file", function()
       events_file_path = "/tmp/yazi.nvim.events.txt",
     })
 
-    assert_opened_yazi_with_file("/abc/test file-$1.txt")
+    assert_opened_yazi_with_files({ "/abc/test file-$1.txt" })
   end)
 
   it("opens yazi with the current directory selected", function()
@@ -57,7 +68,7 @@ describe("opening a file", function()
       events_file_path = "/tmp/yazi.nvim.events.txt",
     })
 
-    assert_opened_yazi_with_file("/tmp/")
+    assert_opened_yazi_with_files({ "/tmp/" })
   end)
 
   it(


### PR DESCRIPTION
If you have multiple splits open in Neovim, yazi will now open all of them in tabs when you open yazi. This is useful when you want to perform file operations to whatever you are working on.

This feature is off by default. To enable it, you can set `open_multiple_tabs = true` in your configuration.

By default, the number keys currently switch between tabs. See all the default keybindings here:
https://github.com/sxyazi/yazi/blob/main/yazi-config/preset/keymap.toml

Limitations:
- the bleeding edge yazi version from yesterday is required (https://github.com/sxyazi/yazi/commit/dac72eb39a846d15db7f1a7c54e9261675a90e53)
- yazi can only display up to 9 paths, so only the first 9 files will be opened in tabs


https://github.com/user-attachments/assets/49ed1af4-5463-401a-a328-82f486ee50a1

