### PR TITLE
fix: don't open duplicate tabs when opening files

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -35,6 +35,20 @@ function YaProcess.new(config, yazi_id)
   return self
 end
 
+---@param items string[]
+local function remove_duplicates(items)
+  local seen = {}
+  local result = {}
+  for _, word in ipairs(items) do
+    if not seen[word] then
+      seen[word] = true
+      result[#result + 1] = word
+    end
+  end
+
+  return result
+end
+
 ---@param paths Path[]
 function YaProcess:get_yazi_command(paths)
   local command_words = { "yazi" }
@@ -54,6 +68,8 @@ function YaProcess:get_yazi_command(paths)
     table.insert(command_words, "--client-id")
     table.insert(command_words, self.yazi_id)
   end
+
+  command_words = remove_duplicates(command_words)
 
   return table.concat(command_words, " ")
 end

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -1,0 +1,72 @@
+local assert = require("luassert")
+local ya_process = require("yazi.process.ya_process")
+
+describe("the get_yazi_command() function", function()
+  it("specifies opening multiple tabs when enabled in the config", function()
+    local config = require("yazi.config").default()
+    config.open_multiple_tabs = true
+    config.chosen_file_path = "/tmp/chosen_file_path"
+
+    local ya = ya_process.new(config, "yazi_id_123")
+
+    local paths = {
+      { filename = "file1" },
+      { filename = "file2" },
+    }
+
+    local command = ya:get_yazi_command(paths)
+
+    assert.are.same(
+      "yazi 'file1' 'file2' --chooser-file /tmp/chosen_file_path",
+      command
+    )
+  end)
+
+  it(
+    "does not specify opening multiple tabs when disabled in the config",
+    function()
+      local config = require("yazi.config").default()
+      config.open_multiple_tabs = false
+      config.chosen_file_path = "/tmp/chosen_file_path"
+
+      local ya = ya_process.new(config, "yazi_id_123")
+
+      local paths = {
+        { filename = "file1" },
+        { filename = "file2" },
+      }
+
+      local command = ya:get_yazi_command(paths)
+
+      assert.are.same(
+        "yazi 'file1' --chooser-file /tmp/chosen_file_path",
+        command
+      )
+    end
+  )
+
+  it("doesn't open duplicate tabs", function()
+    local config = require("yazi.config").default()
+    config.open_multiple_tabs = true
+    config.chosen_file_path = "/tmp/chosen_file_path"
+
+    local ya = ya_process.new(config, "yazi_id_123")
+
+    local paths = {
+      { filename = "file1" },
+      { filename = "file1" },
+
+      { filename = "file2" },
+      { filename = "file2" },
+
+      { filename = "file3" },
+    }
+
+    local command = ya:get_yazi_command(paths)
+
+    assert.are.same(
+      "yazi 'file1' 'file2' 'file3' --chooser-file /tmp/chosen_file_path",
+      command
+    )
+  end)
+end)

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -38,7 +38,6 @@ describe("opening a file", function()
     end, actual_files)
 
     for _, file in ipairs(files) do
-      print("opened file: " .. file)
       assert.is_true(type(file) == "string")
     end
 

--- a/spec/yazi/yazi_visible_buffer_spec.lua
+++ b/spec/yazi/yazi_visible_buffer_spec.lua
@@ -15,7 +15,6 @@ describe("YaziVisibleBuffer", function()
   end)
 
   it("is found for a visible buffer editing a file", function()
-    --
     vim.cmd("edit file1")
     vim.fn.bufadd("/YaziVisibleBuffer/file1")
 


### PR DESCRIPTION
Problem:
With a split window setup of two files (a and b) like this `a|a|b`, when the split `b` was focused, yazi.nvim would open 3 yazi tabs instead of 2.

Solution:
Add a function to remove duplicates from the list of files to open.