### PR TITLE
feat: allow using :Yazi commands automatically by default

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -175,8 +175,6 @@ function M.setup(opts)
     Log:debug("Hijacking netrw to open yazi for directories")
     require("yazi.hijack_netrw").hijack_netrw(yazi_augroup)
   end
-
-  require("yazi.commands").create_yazi_commands()
 end
 
 return M

--- a/plugin/yazi.lua
+++ b/plugin/yazi.lua
@@ -1,0 +1,1 @@
+require("yazi.commands").create_yazi_commands()

--- a/spec/yazi/lazy_loading_spec.lua
+++ b/spec/yazi/lazy_loading_spec.lua
@@ -31,7 +31,6 @@ describe("lazy loading", function()
     table.sort(yazi_modules)
     assert.are.same(yazi_modules, {
       "yazi",
-      "yazi.commands",
       "yazi.config",
       "yazi.log",
       "yazi.lsp.embedded-lsp-file-operations.lsp-file-operations",


### PR DESCRIPTION
It might help users that don't use lazy.nvim by making the initialization slightly easier. An example is possibly the following issue:

https://github.com/mikavilpas/yazi.nvim/issues/340