### PR TITLE
fix: leaving an empty buffer when opening a directory with `:edit .`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ init:
 	@echo "$(COLOR_WHITE)    Reformat all code$(COLOR_RESET)"
 
 lint:
-	selene ./lua/ ./spec/
+	selene ./lua/ ./spec/ ./integration-tests/test-environment/config-modifications
 	@if grep -r -e "#focus" --include \*.lua ./spec/; then \
 			echo "\n"; \
 			echo "Error: ${COLOR_GREEN}#focus${COLOR_RESET} tags found in the codebase.\n"; \

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
@@ -18,7 +18,9 @@ describe("opening directories", () => {
 
   it("can open a directory with `:edit .`", () => {
     cy.visit("http://localhost:5173")
-    startNeovimWithYa().then((dir) => {
+    startNeovimWithYa({
+      startupScriptModifications: ["add_command_to_count_open_buffers.lua"],
+    }).then((dir) => {
       cy.contains(dir.contents["initial-file.txt"].name)
 
       // open the current directory using a command
@@ -27,6 +29,13 @@ describe("opening directories", () => {
       // yazi should now be visible, showing the names of adjacent files
       cy.contains("-- TERMINAL --")
       cy.contains(dir.contents["test-setup.lua"].name)
+
+      cy.typeIntoTerminal("q")
+
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      cy.typeIntoTerminal(":CountBuffers{enter}")
+      cy.contains("Number of open buffers: 1")
     })
   })
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -19,15 +19,15 @@
     "@trpc/server": "11.0.0-rc.477",
     "@types/uuid": "10.0.0",
     "core-js": "3.38.0",
-    "cypress": "13.13.2",
+    "cypress": "13.13.3",
     "node-pty": "1.0.0",
     "tsx": "4.17.0",
     "wait-on": "7.2.0",
-    "winston": "3.14.1"
+    "winston": "3.14.2"
   },
   "devDependencies": {
     "@types/express": "4.17.21",
-    "@types/node": "22.2.0",
+    "@types/node": "22.3.0",
     "@types/tinycolor2": "1.4.6",
     "@types/ws": "8.5.12",
     "@typescript-eslint/eslint-plugin": "8.1.0",

--- a/integration-tests/server/neovim/environment/testEnvironmentTypes.ts
+++ b/integration-tests/server/neovim/environment/testEnvironmentTypes.ts
@@ -28,6 +28,7 @@ export const startupScriptModification = z.enum([
   "notify_hover_events.lua",
   "modify_yazi_config_and_highlight_buffers_in_same_directory.lua",
   "modify_yazi_config_and_open_multiple_files.lua",
+  "add_command_to_count_open_buffers.lua",
 ])
 export type StartupScriptModification = z.infer<
   typeof startupScriptModification

--- a/integration-tests/test-environment/config-modifications/add_command_to_count_open_buffers.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_count_open_buffers.lua
@@ -1,5 +1,5 @@
 vim.api.nvim_create_user_command("CountBuffers", function()
   local buffers = vim.fn.getbufinfo({ buflisted = 1 })
-  local msg = string.format("Number of open buffers: " .. #buffers)
+  local msg = "Number of open buffers: " .. #buffers
   print(msg)
 end, {})

--- a/integration-tests/test-environment/config-modifications/add_command_to_count_open_buffers.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_count_open_buffers.lua
@@ -1,0 +1,5 @@
+vim.api.nvim_create_user_command("CountBuffers", function()
+  local buffers = vim.fn.getbufinfo({ buflisted = 1 })
+  local msg = string.format("Number of open buffers: " .. #buffers)
+  print(msg)
+end, {})

--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -34,6 +34,7 @@ function M.hijack_netrw(yazi_augroup)
         )
 
         vim.api.nvim_buf_delete(bufnr, { force = true })
+        vim.api.nvim_buf_delete(empty_buffer, { force = true })
         Log:debug(
           string.format("Deleted buffer %s for directory %s", bufnr, file)
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,15 +27,15 @@
         "@trpc/server": "11.0.0-rc.477",
         "@types/uuid": "10.0.0",
         "core-js": "3.38.0",
-        "cypress": "13.13.2",
+        "cypress": "13.13.3",
         "node-pty": "1.0.0",
         "tsx": "4.17.0",
         "wait-on": "7.2.0",
-        "winston": "3.14.1"
+        "winston": "3.14.2"
       },
       "devDependencies": {
         "@types/express": "4.17.21",
-        "@types/node": "22.2.0",
+        "@types/node": "22.3.0",
         "@types/tinycolor2": "1.4.6",
         "@types/ws": "8.5.12",
         "@typescript-eslint/eslint-plugin": "8.1.0",
@@ -1369,12 +1369,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.2.0.tgz",
-      "integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "devOptional": true,
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.18.2"
       }
     },
     "node_modules/@types/qs": {
@@ -2705,11 +2705,10 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.13.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.2.tgz",
-      "integrity": "sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
@@ -8061,11 +8060,10 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
+      "devOptional": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -8367,9 +8365,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.1.tgz",
-      "integrity": "sha512-CJi4Il/msz8HkdDfXOMu+r5Au/oyEjFiOZzbX2d23hRLY0narGjqfE5lFlrT5hfYJhPtM8b85/GNFsxIML/RVA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",


### PR DESCRIPTION
When opening a directory with `:edit .`, yazi.nvim would open an empty
buffer for technical reasons. This empty buffer would show up in the
user's neovim session, and would be counted as an open buffer.