### PR TITLE
chore: enable lua-language-server `checkTableShape` by default

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,9 @@
 {
-  "diagnostics.globals": ["finally"]
+  "runtime": {
+    "version": "LuaJIT",
+    "pathStrict": true
+  },
+  "type": {
+    "checkTableShape": true
+  }
 }


### PR DESCRIPTION
It was released yesterday, but was toggled off by default. The example in the pull request works nicely.

- pull request
  - https://github.com/LuaLS/lua-language-server/pull/2768
- comment saying why it was toggled off
  - https://github.com/LuaLS/lua-language-server/pull/2768#issuecomment-2293094921
- changelog with a little more info
  - https://github.com/LuaLS/lua-language-server/blob/d702a55715df19a219e963da496e6fb76db0aacd/changelog.md?plain=1#L8