### PR TITLE
fix: starting telescope or grug-far when hovering a directory

### DIFF
--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -61,15 +61,8 @@ function RenameableBuffer:is_sibling_of_hovered(other)
   other = remove_trailing_slash(other)
   local utils = require("yazi.utils")
 
-  ---@type Path
-  local other_path = plenary_path:new(other)
-
   local my_dir = utils.dir_of(self.path.filename)
   local other_dir = utils.dir_of(other)
-
-  if other_path:is_dir() then
-    return my_dir.filename == other_dir:parent().filename
-  end
 
   return my_dir.filename == other_dir.filename
 end

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -116,14 +116,13 @@ end
 function M.dir_of(file_path)
   ---@type Path
   local path = plenary_path:new(file_path)
-  if path:is_dir() then
-    return path
-  else
-    local parent = path:parent()
-    assert(type(parent) == "table", "parent must be a table")
+  local parent = path:parent()
 
-    return parent
-  end
+  -- for some reason, plenary is documented as returning table|unknown[]. we
+  -- want the table version only
+  assert(type(parent) == "table", "parent must be a table")
+
+  return parent
 end
 
 -- Returns parsed events from the yazi events file

--- a/spec/yazi/dir_of_spec.lua
+++ b/spec/yazi/dir_of_spec.lua
@@ -46,7 +46,7 @@ describe("dir_of helper function", function()
       vim.fn.mkdir(dir)
       local d = utils.dir_of(dir)
 
-      assert.is_equal(dir, d.filename)
+      assert.is_equal(base_dir, d.filename)
     end)
   end)
 end)


### PR DESCRIPTION
Issue:
Given the following directory structure:

- root/
  - dir1/
      - file1
  - file2

When hovering `dir1/` and starting the search or replace operation, the operation would only consider the files in `dir1/`. This is not what the user would expect. The user would expect the operation to consider the files in `root/`.

Solution:
When hovering a directory, we should consider the directory the hovered directory is in. This is the same behavior as when hovering a file.