### PR TITLE
fix: showing error message when background color is not found

### DIFF
--- a/lua/yazi/buffer_highlighting/window_highlight.lua
+++ b/lua/yazi/buffer_highlighting/window_highlight.lua
@@ -62,10 +62,6 @@ function WindowHighlight:set_highlight(
     local color = create_hover_color_from_theme(lighten_or_darken)
     if color == nil then
       Log:debug("Could not find a background color, not highlighting")
-      vim.notify(
-        "Could not find a background color, not highlighting",
-        vim.log.levels.ERROR
-      )
 
       return
     end


### PR DESCRIPTION
Problem:
When highlighting a buffer that's hovered in yazi, or highlighting a buffer that's in the same directory as the hovered file, the background color is not found, and the highlighting is not applied. However, the error message is also shown to the user.

I originally intended this to be a "this should never happen" kind of error, but it's not the case. It is also shown if the user is using a transparent background with a plugin like "xiyaowong/transparent.nvim".

See here for the exact configuration that causes this issue: https://github.com/mikavilpas/yazi.nvim/issues/392#issuecomment-2295345115

> I use tokyonight theme and "xiyaowong/transparent.nvim" plugin to
> toggle transparency
>
> https://github.com/xiyaowong/transparent.nvim

Solution:
Remove the error message, and let the highlighting fail silently.

Resolves https://github.com/mikavilpas/yazi.nvim/issues/392