### PR TITLE
fix: not being able to delete a buffer when it is modified

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -35,6 +35,9 @@ describe("reading events", () => {
       cy.contains(dir.contents["initial-file.txt"].name)
       cy.contains("If you see this text, Neovim is ready!")
 
+      // modify the buffer to make sure it works even if the buffer is modified
+      cy.typeIntoTerminal("ccchanged{esc}")
+
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
 
@@ -62,6 +65,9 @@ describe("reading events", () => {
       // the default file should already be open
       cy.contains(dir.contents["initial-file.txt"].name)
       cy.contains("If you see this text, Neovim is ready!")
+
+      // modify the buffer to make sure it works even if the buffer is modified
+      cy.typeIntoTerminal("ccchanged{esc}")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -34,7 +34,7 @@ function M.process_delete_event(event, remaining_events)
           deleted_buffers[#deleted_buffers + 1] = buffer
 
           vim.schedule(function()
-            vim.api.nvim_buf_delete(buffer.bufnr, { force = false })
+            vim.api.nvim_buf_delete(buffer.bufnr, { force = true })
             lsp_delete.file_deleted(buffer.path.filename)
           end)
         end


### PR DESCRIPTION
Problem:

When a file is trashed (moved to the trash) or deleted (hard deleted) in yazi, the buffer associated with the file is deleted. However, if the buffer is modified, the buffer cannot be deleted. This is because the buffer has unsaved changes.

Solution:

Force delete the buffer when it is being deleted, losing any unsaved changes.

Originally I wanted to make sure no unsaved changes are lost, but I noticed neo-tree does not care about unsaved changes when deleting a file, so I decided to follow the same behavior.

Solves https://github.com/mikavilpas/yazi.nvim/issues/397