### PR TITLE
fix: closing split when opening directory

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-directories.cy.ts
@@ -18,6 +18,9 @@ describe("opening directories", () => {
     cy.visit("http://localhost:5173")
     cy.startNeovim({
       startupScriptModifications: ["add_command_to_count_open_buffers.lua"],
+      filename: {
+        openInVerticalSplits: ["initial-file.txt", "file.txt"],
+      },
     }).then((dir) => {
       cy.contains(dir.contents["initial-file.txt"].name)
 
@@ -29,11 +32,10 @@ describe("opening directories", () => {
       cy.contains(dir.contents["test-setup.lua"].name)
 
       cy.typeIntoTerminal("q")
-
       cy.contains("-- TERMINAL --").should("not.exist")
 
       cy.typeIntoTerminal(":CountBuffers{enter}")
-      cy.contains("Number of open buffers: 1")
+      cy.contains("Number of open buffers: 2")
     })
   })
 

--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -14,27 +14,30 @@ function M.hijack_netrw(yazi_augroup)
       -- A buffer was opened for a directory.
       -- Remove the buffer as we want to show yazi instead
       local empty_buffer = vim.api.nvim_create_buf(true, false)
+      local next_buffer = vim.fn.bufnr("#") or empty_buffer
       Log:debug(
         string.format(
-          "Removing buffer %s for directory %s and replacing it with empty buffer %s",
+          "Removing buffer %s for directory %s and replacing it with the next buffer %s",
           dir_bufnr,
           file,
-          empty_buffer
+          next_buffer
         )
       )
-      pcall(function()
-        vim.api.nvim_win_set_buf(winid, empty_buffer)
-        Log:debug(
-          string.format("Set buffer %s for window %s", empty_buffer, winid)
-        )
-      end)
       vim.schedule(function()
         Log:debug(
           string.format("Deleting buffer %s for directory %s", dir_bufnr, file)
         )
 
+        pcall(function()
+          vim.api.nvim_win_set_buf(winid, next_buffer)
+          Log:debug(
+            string.format("Set buffer %s for window %s", next_buffer, winid)
+          )
+        end)
         vim.api.nvim_buf_delete(bufnr, { force = true })
-        vim.api.nvim_buf_delete(empty_buffer, { force = true })
+        if next_buffer ~= empty_buffer then
+          vim.api.nvim_buf_delete(empty_buffer, { force = true })
+        end
         Log:debug(
           string.format("Deleted buffer %s for directory %s", bufnr, file)
         )


### PR DESCRIPTION
Problem:

When the user had two or more split windows open and opened a directory in yazi, the current split window was closed. The buffer was not closed, however, and the user could still see the buffer in the buffer list.

This is an annoying side effect that serves no real purpose.

Solution:

Don't close the current split window when opening a directory in yazi.