### PR TITLE
fix: opening directories in splits and tabs opening empty buffers

### DIFF
--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -7,17 +7,26 @@ end
 
 ---@param chosen_file string
 function M.open_file_in_vertical_split(chosen_file)
-  vim.cmd(string.format("vsplit %s", vim.fn.fnameescape(chosen_file)))
+  local is_directory = vim.fn.isdirectory(chosen_file) == 1
+  if not is_directory then
+    vim.cmd(string.format("vsplit %s", vim.fn.fnameescape(chosen_file)))
+  end
 end
 
 ---@param chosen_file string
 function M.open_file_in_horizontal_split(chosen_file)
-  vim.cmd(string.format("split %s", vim.fn.fnameescape(chosen_file)))
+  local is_directory = vim.fn.isdirectory(chosen_file) == 1
+  if not is_directory then
+    vim.cmd(string.format("split %s", vim.fn.fnameescape(chosen_file)))
+  end
 end
 
 ---@param chosen_file string
 function M.open_file_in_tab(chosen_file)
-  vim.cmd(string.format("tabedit %s", vim.fn.fnameescape(chosen_file)))
+  local is_directory = vim.fn.isdirectory(chosen_file) == 1
+  if not is_directory then
+    vim.cmd(string.format("tabedit %s", vim.fn.fnameescape(chosen_file)))
+  end
 end
 
 ---@param chosen_files string[]

--- a/spec/yazi/file_openers_spec.lua
+++ b/spec/yazi/file_openers_spec.lua
@@ -1,0 +1,50 @@
+local openers = require("yazi.openers")
+local stub = require("luassert.stub")
+local assert = require("luassert")
+
+local base_dir = os.tmpname() -- create a temporary file with a unique name
+local snapshot
+
+before_each(function()
+  snapshot = assert:snapshot()
+  stub(vim, "cmd")
+
+  -- refuse to remove anything outside of /tmp/
+  assert(base_dir:match("/tmp/"), "Failed to create a temporary directory")
+  os.remove(base_dir)
+  vim.fn.mkdir(base_dir, "p")
+end)
+
+after_each(function()
+  snapshot:revert()
+end)
+
+describe("open_file_in_vertical_split", function()
+  it("does not open if the given path is a directory", function()
+    -- a directory cannot be opened in a split - it would show the netrw file
+    -- explorer, which is less useful than yazi
+    openers.open_file_in_vertical_split(base_dir)
+
+    assert.stub(vim.cmd).was_not_called()
+  end)
+end)
+
+describe("open_file_in_horizontal_split", function()
+  it("does not open if the given path is a directory", function()
+    -- a directory cannot be opened in a split - it would show the netrw file
+    -- explorer, which is less useful than yazi
+    openers.open_file_in_horizontal_split(base_dir)
+
+    assert.stub(vim.cmd).was_not_called()
+  end)
+end)
+
+describe("open_file_in_tab", function()
+  it("does not open if the given path is a directory", function()
+    -- a directory cannot be opened in a tab - it would show the netrw file
+    -- explorer, which is less useful than yazi
+    openers.open_file_in_tab(base_dir)
+
+    assert.stub(vim.cmd).was_not_called()
+  end)
+end)


### PR DESCRIPTION
In yazi.nvim, it's possible to open files in new splits (horizontal and vertical) and tabs.

Issue: when opening a directory in a split or tab, and when the setting open_for_directories is set to true, the directory would be opened in a new floating yazi window, and a useless split or tab would be opened with the currently open buffer.

Solution: check if the chosen file is a directory before opening it in a split or tab. If it's a directory, don't open it in a split or tab (do nothing).