### PR TITLE
fix: `nvim .` sent extra `i` key to yazi

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1.2.0
+        uses: umbrelladocs/action-linkspector@v1.2.1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -19,7 +19,7 @@
     "@trpc/server": "11.0.0-rc.498",
     "@types/uuid": "10.0.0",
     "core-js": "3.38.1",
-    "cypress": "13.14.1",
+    "cypress": "13.14.2",
     "node-pty": "1.0.0",
     "tsx": "4.19.0",
     "wait-on": "8.0.0",
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/express": "4.17.21",
-    "@types/node": "22.5.2",
+    "@types/node": "22.5.4",
     "@types/tinycolor2": "1.4.6",
     "@types/ws": "8.5.12",
     "@typescript-eslint/eslint-plugin": "8.4.0",

--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -7,51 +7,55 @@ function M.hijack_netrw(yazi_augroup)
   ---@param file string
   ---@param bufnr number
   local function open_yazi_in_directory(file, bufnr)
-    if vim.fn.isdirectory(file) == 1 then
-      local winid = vim.api.nvim_get_current_win()
-      local dir_bufnr = vim.api.nvim_get_current_buf()
-
-      -- A buffer was opened for a directory.
-      -- Remove the buffer as we want to show yazi instead
-      local empty_buffer = vim.api.nvim_create_buf(true, false)
-      local next_buffer = vim.fn.bufnr("#") or empty_buffer
-      Log:debug(
-        string.format(
-          "Removing buffer %s for directory %s and replacing it with the next buffer %s",
-          dir_bufnr,
-          file,
-          next_buffer
-        )
-      )
-      vim.schedule(function()
-        Log:debug(
-          string.format("Deleting buffer %s for directory %s", dir_bufnr, file)
-        )
-
-        pcall(function()
-          vim.api.nvim_win_set_buf(winid, next_buffer)
-          Log:debug(
-            string.format("Set buffer %s for window %s", next_buffer, winid)
-          )
-        end)
-        vim.api.nvim_buf_delete(bufnr, { force = true })
-        if next_buffer ~= empty_buffer then
-          vim.api.nvim_buf_delete(empty_buffer, { force = true })
-        end
-        Log:debug(
-          string.format("Deleted buffer %s for directory %s", bufnr, file)
-        )
-
-        Log:debug(string.format("Opening yazi for directory %s", file))
-        require("yazi").yazi(M.config, file)
-
-        -- HACK: for some reason, the cursor is not in insert mode when opening
-        -- yazi from the command line with `neovim .`, so just simulate
-        -- pressing "i" to enter insert mode :) It did nothing when when I
-        -- tried using vim.cmd('startinsert') or vim.cmd('normal! i')
-        vim.api.nvim_feedkeys("i", "n", false)
-      end)
+    if vim.fn.isdirectory(file) ~= 1 then
+      return
     end
+
+    local winid = vim.api.nvim_get_current_win()
+    local dir_bufnr = vim.api.nvim_get_current_buf()
+
+    -- A buffer was opened for a directory.
+    -- Remove the buffer as we want to show yazi instead
+    local empty_buffer = vim.api.nvim_create_buf(true, false)
+    local next_buffer = vim.fn.bufnr("#") or empty_buffer
+    Log:debug(
+      string.format(
+        "Removing buffer %s for directory %s and replacing it with the next buffer %s",
+        dir_bufnr,
+        file,
+        next_buffer
+      )
+    )
+    vim.schedule(function()
+      Log:debug(
+        string.format("Deleting buffer %s for directory %s", dir_bufnr, file)
+      )
+
+      pcall(function()
+        vim.api.nvim_win_set_buf(winid, next_buffer)
+        Log:debug(
+          string.format("Set buffer %s for window %s", next_buffer, winid)
+        )
+      end)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+      if next_buffer ~= empty_buffer then
+        vim.api.nvim_buf_delete(empty_buffer, { force = true })
+      end
+      Log:debug(
+        string.format("Deleted buffer %s for directory %s", bufnr, file)
+      )
+
+      Log:debug(string.format("Opening yazi for directory %s", file))
+      require("yazi").yazi(M.config, file)
+
+      -- HACK: for some reason, the cursor is not in insert mode when opening
+      -- yazi from the command line with `neovim .`, so just simulate
+      -- pressing "i" to enter insert mode :) It did nothing when when I
+      -- tried using vim.cmd('startinsert') or vim.cmd('normal! i')
+      if vim.fn.mode(true) == "t" then
+        vim.api.nvim_feedkeys("i", "n", false)
+      end
+    end)
   end
 
   -- disable netrw, the built-in file explorer

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -141,6 +141,9 @@ function YaziFloatingWindow:open_and_display()
   return self
 end
 
+--- Compatibility with tmux and neovim mouse support
+--- https://github.com/mikavilpas/yazi.nvim/issues/176
+--- https://github.com/mikavilpas/yazi.nvim/issues/49
 ---@param yazi_buffer integer
 function YaziFloatingWindow:add_hacky_mouse_support(yazi_buffer)
   -- Disable nvim mouse support so that yazi can handle mouse events instead

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@trpc/server": "11.0.0-rc.498",
         "@types/uuid": "10.0.0",
         "core-js": "3.38.1",
-        "cypress": "13.14.1",
+        "cypress": "13.14.2",
         "node-pty": "1.0.0",
         "tsx": "4.19.0",
         "wait-on": "8.0.0",
@@ -35,7 +35,7 @@
       },
       "devDependencies": {
         "@types/express": "4.17.21",
-        "@types/node": "22.5.2",
+        "@types/node": "22.5.4",
         "@types/tinycolor2": "1.4.6",
         "@types/ws": "8.5.12",
         "@typescript-eslint/eslint-plugin": "8.4.0",
@@ -1323,9 +1323,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
-      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "devOptional": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2599,9 +2599,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.14.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.1.tgz",
-      "integrity": "sha512-Wo+byPmjps66hACEH5udhXINEiN3qS3jWNGRzJOjrRJF3D0+YrcP2LVB1T7oYaVQM/S+eanqEvBWYc8cf7Vcbg==",
+      "version": "13.14.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.2.tgz",
+      "integrity": "sha512-lsiQrN17vHMB2fnvxIrKLAjOr9bPwsNbPZNrWf99s4u+DVmCY6U+w7O3GGG9FvP4EUVYaDu+guWeNLiUzBrqvA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.1",


### PR DESCRIPTION
Issue
=

When opening yazi with `nvim .`, an extra `i` key was sent yazi. If the
user had set up a custom mapping for `i` in their yazi config, it would
be triggered when opening yazi with `nvim .`. In other cases this bug
would not get triggered.

Solution
=

Check if we're in the situation where the `i` key needs to be pressed
(to enter insert mode) and only then send the key.