### PR TITLE
refactor: adapt to grug-far deprecation

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -69,7 +69,7 @@ function M.default()
         -- `prefills.flags` get passed to ripgrep as is
         -- https://github.com/MagicDuck/grug-far.nvim/issues/146
         local filter = directory:make_relative(vim.uv.cwd())
-        require("grug-far").grug_far({
+        require("grug-far").open({
           prefills = {
             paths = filter:gsub(" ", "\\ "),
           },
@@ -82,7 +82,7 @@ function M.default()
           files[#files + 1] = path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
         end
 
-        require("grug-far").grug_far({
+        require("grug-far").open({
           prefills = {
             paths = table.concat(files, " "),
           },

--- a/spec/yazi/grug_far_spec.lua
+++ b/spec/yazi/grug_far_spec.lua
@@ -6,7 +6,7 @@ local config = require("yazi.config")
 local plenary_path = require("plenary.path")
 
 describe("the grug-far integration (search and replace)", function()
-  local mock_grug_far = { grug_far = function() end }
+  local mock_grug_far = { open = function() end }
 
   before_each(function()
     mock.revert(mock_grug_far)
@@ -18,7 +18,7 @@ describe("the grug-far integration (search and replace)", function()
 
     config.default().integrations.replace_in_directory(tmp_path)
 
-    assert.spy(mock_grug_far.grug_far).was_called_with({
+    assert.spy(mock_grug_far.open).was_called_with({
       prefills = {
         paths = "/tmp/folder\\ with\\ spaces",
       },


### PR DESCRIPTION
Last week in https://github.com/MagicDuck/grug-far.nvim/pull/233 the main function was renamed from `grug_far` to `open`. This commit updates the code to use the new function name.