### PR TITLE
refactor: remove events_file_path config option (unused)

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -42,7 +42,6 @@ function M.yazi(config, input_path)
   local prev_buf = vim.api.nvim_get_current_buf()
 
   config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
-  config.events_file_path = config.events_file_path or vim.fn.tempname()
 
   local win = require("yazi.window").YaziFloatingWindow.new(config)
   win:open_and_display()

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -5,7 +5,6 @@
 ---@class (exact) YaziConfig
 ---@field public open_for_directories? boolean
 ---@field public chosen_file_path? string "the path to a temporary file that will be created by yazi to store the chosen file path"
----@field public events_file_path? string "the path to a temporary file that will be created by yazi to store events. A random path will be used by default"
 ---@field public open_multiple_tabs? boolean "open multiple open files in yazi tabs when opening yazi"
 ---@field public enable_mouse_support? boolean
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -51,7 +51,6 @@ describe("opening a file", function()
     vim.api.nvim_command("edit " .. vim.fn.fnameescape("/abc/test file-$1.txt"))
     plugin.yazi({
       chosen_file_path = "/tmp/yazi_filechosen",
-      events_file_path = "/tmp/yazi.nvim.events.txt",
     })
 
     assert_opened_yazi_with_files({ "/abc/test file-$1.txt" })
@@ -64,7 +63,6 @@ describe("opening a file", function()
 
     plugin.yazi({
       chosen_file_path = "/tmp/yazi_filechosen",
-      events_file_path = "/tmp/yazi.nvim.events.txt",
     })
 
     assert_opened_yazi_with_files({ "/tmp/" })


### PR DESCRIPTION
This was a leftover from the initial implementation of the plugin, and is no longer used for anything.