### PR TITLE
fix: opening a LazyVim session with folke/persistence.nvim starting yazi

### DIFF
--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -66,6 +66,11 @@ function M.hijack_netrw(yazi_augroup)
     pattern = "*",
     ---@param ev yazi.AutoCmdEvent
     callback = function(ev)
+      if vim.g.SessionLoad == 1 then
+        -- Fix https://github.com/mikavilpas/yazi.nvim/issues/440
+        -- See `:h SessionLoad-variable`
+        return
+      end
       open_yazi_in_directory(ev.file, ev.buf)
     end,
     group = yazi_augroup,


### PR DESCRIPTION
Issue
=

In the following scenario, when all of these happened, yazi would always open when restoring a session:
- When using LazyVim / folke/persistence.nvim
- start neovim with `nvim .`
- open a file
- close neovim
- start neovim with `nvim`
- restore the last session with persistence.nvim

This seemed to happen because the session includes the `.` which was given as an argument to neovim. Restoring the session would open the directory in yazi.

Solution
=

The solution is to check if the `SessionLoad` variable is set to `1` and skip opening yazi if it is. This is because the `SessionLoad` variable is set to `1` when restoring a session.

See `:h SessionLoad-variable` for more information.

Fixes https://github.com/mikavilpas/yazi.nvim/issues/440