### PR TITLE
feat: allow cycle_open_buffers (`tab`) to work for a single file

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
         },
       })
     },
+    experimentalRunAllSpecs: true,
     retries: {
       runMode: 2,
       openMode: 0,

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/cd-to-buffer.cy.ts
@@ -115,4 +115,24 @@ describe("'cd' to another buffer's directory", () => {
       isHoveredInNeovim(view.rightFile.text)
     })
   })
+
+  it("can tab to the directory of just a single buffer", () => {
+    cy.startNeovim({
+      filename: "file.txt",
+    }).then((dir) => {
+      cy.contains("Hello")
+
+      cy.typeIntoTerminal("{upArrow}")
+      cy.contains("initial-file.txt")
+
+      cy.typeIntoTerminal(`/routes{enter}`, { delay: 1 })
+      cy.contains("posts.$postId")
+
+      // enter the directory and make sure its contents are shown
+      cy.typeIntoTerminal("l")
+      cy.contains(dir.contents["routes/posts.$postId/route.tsx"].name)
+
+      cy.typeIntoTerminal("{control+i}")
+    })
+  })
 })

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -98,10 +98,10 @@ function YaziOpenerActions.cycle_open_buffers(context)
           ~= current_cycle_position.filename
       end)
 
-      if not next_buffer then
+      if not next_buffer and #visible_buffers <= 1 then
         Log:debug(
           string.format(
-            'Could not find next buffer for path: "%s", probably only one is open.',
+            'Could not find next buffer for path: "%s".',
             context.input_path
           )
         )

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -98,7 +98,11 @@ function YaziOpenerActions.cycle_open_buffers(context)
           ~= current_cycle_position.filename
       end)
 
-      if not next_buffer and #visible_buffers <= 1 then
+      if #visible_buffers == 1 then
+        next_buffer = buffer
+      end
+
+      if not next_buffer then
         Log:debug(
           string.format(
             'Could not find next buffer for path: "%s".',


### PR DESCRIPTION
Issue
=====

Using `tab` to cycle through open buffers does not work when only one buffer is open. I disabled it because I thought it was not useful in that case, but actually it can still be useful in the following case:

- you have opened yazi and have a single buffer open in neovim (no splits)
- you have navigated to a different directory in the file explorer
- you have gotten lost
- you want to get back to the beginning with `tab`

Solution
========

Enable `tab` to cd to the single buffer's directory.

Solves https://github.com/mikavilpas/yazi.nvim/issues/447