### PR TITLE
feat: allow scaling the floating window width and height separately

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,7 +21,7 @@
     "core-js": "3.38.1",
     "cypress": "13.14.2",
     "node-pty": "1.0.0",
-    "tsx": "4.19.0",
+    "tsx": "4.19.1",
     "wait-on": "8.0.1",
     "winston": "3.14.2"
   },
@@ -35,7 +35,7 @@
     "@xterm/addon-attach": "0.11.0",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/xterm": "5.5.0",
-    "concurrently": "9.0.0",
+    "concurrently": "9.0.1",
     "eslint": "9.10.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-no-only-tests": "3.3.0",
@@ -44,6 +44,6 @@
     "prettier-plugin-organize-imports": "4.0.0",
     "tinycolor2": "1.6.0",
     "typescript": "5.6.2",
-    "vite": "5.4.4"
+    "vite": "5.4.5"
   }
 }

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -2,6 +2,8 @@
 
 ---@module "plenary.path"
 
+---@alias YaziFloatingWindowScaling { height: number, width: number }
+
 ---@class (exact) YaziConfig
 ---@field public open_for_directories? boolean
 ---@field public chosen_file_path? string "the path to a temporary file that will be created by yazi to store the chosen file path"
@@ -13,7 +15,7 @@
 ---@field public hooks? YaziConfigHooks
 ---@field public highlight_groups? YaziConfigHighlightGroups
 ---@field public integrations? YaziConfigIntegrations
----@field public floating_window_scaling_factor? number "the scaling factor for the floating window. 1 means 100%, 0.9 means 90%, etc."
+---@field public floating_window_scaling_factor? number | YaziFloatingWindowScaling "the scaling factor for the floating window. 1 means 100%, 0.9 means 90%, etc."
 ---@field public yazi_floating_window_winblend? number "the transparency of the yazi floating window (0-100). See :h winblend"
 ---@field public yazi_floating_window_border? any "the type of border to use. See nvim_open_win() for the values your neovim version supports"
 ---@field public log_level? yazi.LogLevel

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -58,8 +58,20 @@ local function get_window_dimensions(config)
     return value > 1 and math.min(value, max) or math.floor(max * value)
   end
 
-  local height = size(vim.o.lines, config.floating_window_scaling_factor)
-  local width = size(vim.o.columns, config.floating_window_scaling_factor)
+  local height
+  local width
+
+  if type(config.floating_window_scaling_factor) == "number" then
+    height = size(vim.o.lines, config.floating_window_scaling_factor)
+    width = size(vim.o.columns, config.floating_window_scaling_factor)
+  else
+    assert(
+      type(config.floating_window_scaling_factor) == "table",
+      "floating_window_scaling_factor must be a number or a table"
+    )
+    height = size(vim.o.lines, config.floating_window_scaling_factor.height)
+    width = size(vim.o.columns, config.floating_window_scaling_factor.width)
+  end
 
   local row = math.floor((vim.o.lines - height) / 2)
   local col = math.floor((vim.o.columns - width) / 2)

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -52,12 +52,17 @@ end
 
 ---@param config YaziConfig
 local function get_window_dimensions(config)
-  local height = math.ceil(vim.o.lines * config.floating_window_scaling_factor)
-    - 1
-  local width = math.ceil(vim.o.columns * config.floating_window_scaling_factor)
+  -- some of the sizing logic is borrowed from lazy.nvim
+  -- https://github.com/folke/lazy.nvim/blob/077102c5bfc578693f12377846d427f49bc50076/lua/lazy/view/float.lua?plain=1#L87-L89
+  local function size(max, value)
+    return value > 1 and math.min(value, max) or math.floor(max * value)
+  end
 
-  local row = math.ceil(vim.o.lines - height) / 2
-  local col = math.ceil(vim.o.columns - width) / 2
+  local height = size(vim.o.lines, config.floating_window_scaling_factor)
+  local width = size(vim.o.columns, config.floating_window_scaling_factor)
+
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
 
   return {
     height = height,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "core-js": "3.38.1",
         "cypress": "13.14.2",
         "node-pty": "1.0.0",
-        "tsx": "4.19.0",
+        "tsx": "4.19.1",
         "wait-on": "8.0.1",
         "winston": "3.14.2"
       },
@@ -43,7 +43,7 @@
         "@xterm/addon-attach": "0.11.0",
         "@xterm/addon-fit": "0.10.0",
         "@xterm/xterm": "5.5.0",
-        "concurrently": "9.0.0",
+        "concurrently": "9.0.1",
         "eslint": "9.10.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-no-only-tests": "3.3.0",
@@ -52,7 +52,7 @@
         "prettier-plugin-organize-imports": "4.0.0",
         "tinycolor2": "1.6.0",
         "typescript": "5.6.2",
-        "vite": "5.4.4"
+        "vite": "5.4.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2482,9 +2482,9 @@
       "dev": true
     },
     "node_modules/concurrently": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.0.0.tgz",
-      "integrity": "sha512-iAxbsDeUkn8E/4+QalT7T3WvlyTfmsoez+19lbbcsxZdOEMfBukd8LA30KYez2UR5xkKFzbcqXIZy5RisCbaxw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.0.1.tgz",
+      "integrity": "sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -7542,9 +7542,9 @@
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/tsx": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.0.tgz",
-      "integrity": "sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
+      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
       "dependencies": {
         "esbuild": "~0.23.0",
         "get-tsconfig": "^4.7.5"
@@ -8239,9 +8239,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.4.tgz",
-      "integrity": "sha512-RHFCkULitycHVTtelJ6jQLd+KSAAzOgEYorV32R2q++M6COBjKJR6BxqClwp5sf0XaBDjVMuJ9wnNfyAJwjMkA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.5.tgz",
+      "integrity": "sha512-pXqR0qtb2bTwLkev4SE3r4abCNioP3GkjvIDLlzziPpXtHgiJIjuKl+1GN6ESOT3wMjG3JTeARopj2SwYaHTOA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",


### PR DESCRIPTION
Now you can have e.g. a wide screen yazi.nvim experience by setting
`floating_window_scaling_factor = { width = 0.95, height = 0.70 }` in
your configuration 😄

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/d1d49462-9e86-47f0-a586-7a42c83ba4e9">
