### PR TITLE
feat: expose the current working directory to keybindings

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -95,19 +95,20 @@ function M.yazi(config, input_path)
 
   config.hooks.yazi_opened(path.filename, win.content_buffer, config)
 
+  ---@type YaziActiveContext
+  local context = {
+    api = yazi_process.api,
+    input_path = path,
+    ya_process = yazi_process.ya_process,
+  }
+
   local yazi_buffer = win.content_buffer
   if config.set_keymappings_function ~= nil then
-    config.set_keymappings_function(yazi_buffer, config, {
-      api = yazi_process.api,
-      input_path = path,
-    })
+    config.set_keymappings_function(yazi_buffer, config, context)
   end
 
   if config.keymaps ~= false then
-    require("yazi.config").set_keymappings(yazi_buffer, config, {
-      api = yazi_process.api,
-      input_path = path,
-    })
+    require("yazi.config").set_keymappings(yazi_buffer, config, context)
   end
 
   win.on_resized = function(event)

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -138,7 +138,7 @@ function YaProcess:start()
       local parsed = utils.safe_parse_events(data)
       -- Log:debug(string.format('Parsed events: %s', vim.inspect(parsed)))
 
-      YaProcess:process_events(parsed)
+      self:process_events(parsed)
     end,
 
     ---@param obj vim.SystemCompleted

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -8,7 +8,7 @@ local YaziProcessApi = require("yazi.process.yazi_process_api")
 ---@class YaziProcess
 ---@field public api YaziProcessApi
 ---@field public yazi_job_id integer
----@field private event_reader YaProcess "The process that reads events from yazi"
+---@field public ya_process YaProcess "The process that reads events from yazi"
 local YaziProcess = {}
 
 ---@diagnostic disable-next-line: inject-field
@@ -26,25 +26,25 @@ function YaziProcess:start(config, paths, on_exit)
   local yazi_id = string.format("%.0f", vim.uv.hrtime())
   self.api = YaziProcessApi.new(config, yazi_id)
 
-  self.event_reader = YaProcess.new(config, yazi_id)
+  self.ya_process = YaProcess.new(config, yazi_id)
 
-  local yazi_cmd = self.event_reader:get_yazi_command(paths)
+  local yazi_cmd = self.ya_process:get_yazi_command(paths)
   Log:debug(string.format("Opening yazi with the command: (%s).", yazi_cmd))
 
   self.yazi_job_id = vim.fn.termopen(yazi_cmd, {
     on_exit = function(_, code)
-      self.event_reader:kill()
-      local events = self.event_reader:wait(1000)
+      self.ya_process:kill()
+      local events = self.ya_process:wait(1000)
 
       local chosen_files = {}
       if utils.file_exists(config.chosen_file_path) == true then
         chosen_files = vim.fn.readfile(config.chosen_file_path)
       end
-      on_exit(code, chosen_files, events, self.event_reader.hovered_url)
+      on_exit(code, chosen_files, events, self.ya_process.hovered_url)
     end,
   })
 
-  self.event_reader:start()
+  self.ya_process:start()
 
   return self
 end

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -1,4 +1,4 @@
----@class YaziProcessApi # Provides yazi.nvim -> yazi process interactions
+---@class YaziProcessApi # Provides yazi.nvim -> yazi process interactions. This allows yazi.nvim to tell yazi what to do.
 ---@field private config YaziConfig
 ---@field private yazi_id string
 local YaziProcessApi = {}

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -37,6 +37,7 @@
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi
+---@field ya_process YaProcess the ya process that is currently running, listening for events from yazi
 ---@field input_path Path the path that is first selected by yazi when it's opened
 ---@field cycled_file? RenameableBuffer the last file that was cycled to with e.g. the <tab> key
 

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -70,3 +70,47 @@ describe("the get_yazi_command() function", function()
     )
   end)
 end)
+
+describe("process_events()", function()
+  describe("cd events", function()
+    -- processing cd events is important so that keymaps can retrieve the cwd
+    -- and operate on it
+
+    local config = require("yazi.config").default()
+
+    it("stores the current working directory (cwd)", function()
+      local ya = ya_process.new(config, "yazi_id_123")
+
+      ya:process_events({
+        {
+          type = "cd",
+          timestamp = "2021-09-01T12:00:00Z",
+          id = "cd_123",
+          url = "/tmp",
+        } --[[@as YaziChangeDirectoryEvent]],
+      })
+
+      assert.are.same("/tmp", ya.cwd)
+    end)
+
+    it("overrides the previous cwd when it's changed multiple times", function()
+      local ya = ya_process.new(config, "yazi_id_123")
+      ya:process_events({
+        {
+          type = "cd",
+          timestamp = "2021-09-01T12:00:00Z",
+          id = "cd_123",
+          url = "/tmp",
+        } --[[@as YaziChangeDirectoryEvent]],
+        {
+          type = "cd",
+          timestamp = "2021-09-01T12:00:00Z",
+          id = "cd_123",
+          url = "/tmp/directory",
+        } --[[@as YaziChangeDirectoryEvent]],
+      })
+
+      assert.are.same("/tmp/directory", ya.cwd)
+    end)
+  end)
+end)


### PR DESCRIPTION
This is a technical change that allows keybindings to access the current working directory of the ya process. It can be used to solve https://github.com/mikavilpas/yazi.nvim/issues/466 in the future