### PR TITLE
fix: use input dir if needed when changing cwd

### DIFF
--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -214,8 +214,10 @@ end
 
 ---@param context YaziActiveContext
 function YaziOpenerActions.change_working_directory(context)
+  local path = context.input_path
   local last_directory = context.ya_process.cwd
-  if last_directory then
+    or (path and path:parent().filename)
+  if last_directory and last_directory ~= vim.fn.getcwd() then
     vim.notify('cwd changed to "' .. last_directory .. '"')
     vim.cmd({ cmd = "cd", args = { last_directory } })
   end

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -215,7 +215,8 @@ end
 ---@param context YaziActiveContext
 function YaziOpenerActions.change_working_directory(context)
   local last_directory = context.ya_process.cwd
-    or context.input_path:parent().filename
+    or (context.input_path:is_file() and context.input_path:parent().filename)
+    or context.input_path.filename
 
   if last_directory ~= vim.fn.getcwd() then
     vim.notify('cwd changed to "' .. last_directory .. '"')

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -220,7 +220,11 @@ function YaziOpenerActions.change_working_directory(context)
       context.input_path,
       "No input_path found. Expected yazi to be started with an input_path"
     )
-    last_directory = context.input_path.filename
+    if context.input_path:is_file() then
+      last_directory = context.input_path:parent().filename
+    else
+      last_directory = context.input_path.filename
+    end
   end
 
   if last_directory ~= vim.fn.getcwd() then

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -214,10 +214,10 @@ end
 
 ---@param context YaziActiveContext
 function YaziOpenerActions.change_working_directory(context)
-  local path = context.input_path
   local last_directory = context.ya_process.cwd
-    or (path and path:parent().filename)
-  if last_directory and last_directory ~= vim.fn.getcwd() then
+    or context.input_path:parent().filename
+
+  if last_directory ~= vim.fn.getcwd() then
     vim.notify('cwd changed to "' .. last_directory .. '"')
     vim.cmd({ cmd = "cd", args = { last_directory } })
   end

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -215,8 +215,13 @@ end
 ---@param context YaziActiveContext
 function YaziOpenerActions.change_working_directory(context)
   local last_directory = context.ya_process.cwd
-    or (context.input_path:is_file() and context.input_path:parent().filename)
-    or context.input_path.filename
+  if not last_directory then
+    assert(
+      context.input_path,
+      "No input_path found. Expected yazi to be started with an input_path"
+    )
+    last_directory = context.input_path.filename
+  end
 
   if last_directory ~= vim.fn.getcwd() then
     vim.notify('cwd changed to "' .. last_directory .. '"')

--- a/spec/yazi/keybinding_helpers_spec.lua
+++ b/spec/yazi/keybinding_helpers_spec.lua
@@ -2,15 +2,18 @@ local assert = require("luassert")
 local config_module = require("yazi.config")
 local keybinding_helpers = require("yazi.keybinding_helpers")
 local match = require("luassert.match")
+local plenary_path = require("plenary.path")
 local stub = require("luassert.stub")
 
 describe("keybinding_helpers", function()
   local vim_cmd_stub
+  local vim_fn_stub
   local vim_notify_stub
   local snapshot
 
   before_each(function()
     snapshot = assert:snapshot()
+    vim_fn_stub = stub(vim.fn, "getcwd")
     vim_notify_stub = stub(vim, "notify")
     vim_cmd_stub = stub(vim, "cmd")
   end)
@@ -155,17 +158,37 @@ describe("keybinding_helpers", function()
       end
     )
 
-    it("should not crash when the cwd is not available", function()
+    it("uses yazi's input_path if no cwd is available yet", function()
       ---@diagnostic disable-next-line: missing-fields
       keybinding_helpers.change_working_directory({
+        input_path = plenary_path:new("/tmp"),
         ---@diagnostic disable-next-line: missing-fields
         ya_process = {
           cwd = nil,
         },
       })
 
-      assert.stub(vim_cmd_stub).was_not_called()
-      assert.stub(vim_notify_stub).was_not_called()
+      assert.stub(vim_cmd_stub).was_called_with({ cmd = "cd", args = { "/" } })
+      assert.stub(vim_notify_stub).was_called_with('cwd changed to "/"')
     end)
+
+    it(
+      "should not change the working directory if the new cwd is already the current one",
+      function()
+        vim_fn_stub.returns("/tmp")
+        ---@diagnostic disable-next-line: missing-fields
+        keybinding_helpers.change_working_directory({
+          input_path = plenary_path:new("/tmp"),
+          ---@diagnostic disable-next-line: missing-fields
+          ya_process = {
+            cwd = "/tmp",
+          },
+        })
+
+        assert.stub(vim_fn_stub).was_called_with()
+        assert.stub(vim_cmd_stub).was_not_called()
+        assert.stub(vim_notify_stub).was_not_called()
+      end
+    )
   end)
 end)

--- a/spec/yazi/keybinding_helpers_spec.lua
+++ b/spec/yazi/keybinding_helpers_spec.lua
@@ -168,8 +168,10 @@ describe("keybinding_helpers", function()
         },
       })
 
-      assert.stub(vim_cmd_stub).was_called_with({ cmd = "cd", args = { "/" } })
-      assert.stub(vim_notify_stub).was_called_with('cwd changed to "/"')
+      assert
+        .stub(vim_cmd_stub)
+        .was_called_with({ cmd = "cd", args = { "/tmp" } })
+      assert.stub(vim_notify_stub).was_called_with('cwd changed to "/tmp"')
     end)
 
     it(


### PR DESCRIPTION
1. I found a bug when trying to change cwd on startup, in which since ya process have not logged anything yet, `context.ya_process.cwd` is `nil`, making the function ineffective. Therefore,  I implement it so it uses input_path in this case. 
2. I modified the conditional to check if the `last_directory` equals cwd when the function is called, in which cwd does not need to be changed. 