### PR TITLE
Ensure window is valid before closing

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -44,6 +44,11 @@ local function on_exit(job_id, code, event)
 			if chosen_file then
 				vim.cmd(string.format('edit %s', chosen_file))
 			end
+
+			-- if open a folder, auto switch nvim working directory
+			if vim.fn.isdirectory(chosen_file) == 1 then
+				vim.cmd('cd ' .. chosen_file)
+			end
 		end
 		prev_win = -1
 		if vim.api.nvim_buf_is_valid(buffer) and vim.api.nvim_buf_is_loaded(buffer) then

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -37,7 +37,9 @@ local function on_exit(job_id, code, event)
 	vim.cmd("silent! :checktime")
 
 	if vim.api.nvim_win_is_valid(prev_win) then
-		vim.api.nvim_win_close(win, true)
+		if vim.api.nvim_win_is_valid(win) then
+			vim.api.nvim_win_close(win, true)
+		end
 		vim.api.nvim_set_current_win(prev_win)
 		if code == 0 and file_exists(output_path) == true then
 			local chosen_file = vim.fn.readfile(output_path)[1]


### PR DESCRIPTION
It was raising an error for me, and commenting it out worked for a while, but found that checking its validity helped keeping the functionality.