### PR TITLE
Ensuring self.win is valid before closing

### DIFF
--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -39,7 +39,9 @@ function YaziFloatingWindow:close()
   end
 
   if vim.api.nvim_win_is_valid(self.win) then
-    vim.api.nvim_win_close(self.win, true)
+    if vim.api.nvim_win_is_valid(self.win) then
+        vim.api.nvim_win_close(self.win, true)
+    end
     Log:debug(
       string.format(
         "YaziFloatingWindow closing (content_buffer: %s, win: %s)",


### PR DESCRIPTION
It was raising an error for me, and commenting it out worked for a while, but found that checking its validity helped keeping the functionality.

Enhanced Version of https://github.com/mikavilpas/yazi.nvim/pull/488