### PR TITLE
feat: emit YaziRenamedOrMoved event when files are renamed or moved

### DIFF
--- a/lua/yazi/event_handling/nvim_event_handling.lua
+++ b/lua/yazi/event_handling/nvim_event_handling.lua
@@ -1,12 +1,34 @@
--- This file is about emitting events to other Neovim plugins
+-- This file is about emitting events to other Neovim plugins so that they can
+-- react to things that happen in this plugin.
 
 local M = {}
 
 ---@alias YaziNeovimEvent
 ---| "'YaziDDSHover'" A file was hovered over in yazi
+---| "'YaziRenamedOrMoved'" Files were renamed or moved
+
+---@alias YaziNeovimEvent.YaziRenamedOrMovedData {changes: table<string, string>} # a table of old paths to new paths
+
+---Emit and event when files are renamed or moved.
+---@param event YaziRenameEvent | YaziMoveEvent | YaziBulkEvent
+---@see YaziNeovimEvent.YaziRenamedOrMovedData
+function M.emit_renamed_or_moved_event(event)
+  ---@type YaziNeovimEvent.YaziRenamedOrMovedData
+  local event_data = {
+    changes = {},
+  }
+
+  if event.type == "move" or event.type == "rename" then
+    event_data.changes[event.data.from] = event.data.to
+  elseif event.type == "bulk" then
+    event_data.changes = event.changes
+  end
+
+  M.emit("YaziRenamedOrMoved", event_data)
+end
 
 ---@param event_name YaziNeovimEvent
----@param event_data table
+---@param event_data table<string, unknown>
 function M.emit(event_name, event_data)
   vim.api.nvim_exec_autocmds("User", {
     pattern = event_name,

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -169,10 +169,23 @@ function YaProcess:process_events(events)
         event_handling.emit("YaziDDSHover", event)
       end)
     elseif event.type == "cd" then
-      ---@cast event YaziChangeDirectoryEvent
+      ---@cast event YaziHoverEvent
       self.cwd = event.url
     else
       self.events[#self.events + 1] = event
+
+      if
+        event.type == "rename"
+        or event.type == "move"
+        or event.type == "bulk"
+      then
+        local event_handling =
+          require("yazi.event_handling.nvim_event_handling")
+
+        pcall(function()
+          event_handling.emit_renamed_or_moved_event(event)
+        end)
+      end
     end
   end
 end


### PR DESCRIPTION
Problem
=======

When files are renamed or moved in yazi, there is no way for other plugins to know about this. If the user uses yazi.nvim along with other plugins that need to react to files being renamed or moved, it cannot be done. This means that other plugins that depend on yazi cannot react to these changes.

Currently yazi.nvim can only react to LSP delete/rename events, but plugins that operate outside of the LSP protocol are not supported.

Solution
========

Add a new Neovim autocmd/event called `YaziRenamedOrMoved` that is emitted when files are renamed or moved. This event will contain a table of the paths that were renamed or moved.

Previously we were already emitting a Neovim event for `YaziDDSHover` - now we have two custom events.

Closes https://github.com/mikavilpas/yazi.nvim/issues/494