### PR TITLE
fix: YaziRenamedOrMoved events could not be published in practice

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -69,6 +69,12 @@ export const MyTestDirectorySchema = z.object({
           extension: z.literal("lua"),
           stem: z.literal("notify_hover_events."),
         }),
+        "notify_rename_events.lua": z.object({
+          name: z.literal("notify_rename_events.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("notify_rename_events."),
+        }),
         "report_loaded_yazi_modules.lua": z.object({
           name: z.literal("report_loaded_yazi_modules.lua"),
           type: z.literal("file"),
@@ -192,6 +198,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/modify_yazi_config_and_open_multiple_files.lua",
   "config-modifications/modify_yazi_config_and_set_help_key.lua",
   "config-modifications/notify_hover_events.lua",
+  "config-modifications/notify_rename_events.lua",
   "config-modifications/report_loaded_yazi_modules.lua",
   "config-modifications/use_light_neovim_colorscheme.lua",
   "config-modifications",

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -161,4 +161,37 @@ describe("'rename' events", () => {
       cy.contains(newFileName).should("not.exist")
     })
   })
+
+  it("can publish YaziRenamedOrMoved events when a file is renamed", () => {
+    cy.startNeovim({
+      startupScriptModifications: ["notify_rename_events.lua"],
+    }).then((dir) => {
+      // the default file should already be open
+      cy.contains(dir.contents["initial-file.txt"].name)
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // start yazi
+      cy.typeIntoTerminal("{upArrow}")
+
+      // start file renaming
+      cy.typeIntoTerminal("r")
+      cy.contains("Rename:")
+      cy.typeIntoTerminal("2{enter}")
+
+      cy.get("Rename").should("not.exist")
+
+      // yazi should be showing the new file name
+      const newFileName = `initial-file2.txt`
+      cy.contains(newFileName)
+
+      // close yazi
+      cy.typeIntoTerminal("q")
+
+      // yazi should now be closed
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      cy.typeIntoTerminal(":mes{enter}")
+      cy.contains("Just received a YaziRenamedOrMoved event!")
+    })
+  })
 })

--- a/integration-tests/test-environment/config-modifications/notify_rename_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_rename_events.lua
@@ -1,0 +1,14 @@
+---@module "yazi"
+
+require("yazi")
+
+vim.api.nvim_create_autocmd("User", {
+  pattern = "YaziRenamedOrMoved",
+  ---@param event {data: YaziNeovimEvent.YaziRenamedOrMovedData}
+  callback = function(event)
+    -- printing the messages will allow seeing them with `:messages`
+    print(
+      vim.inspect({ "Just received a YaziRenamedOrMoved event!", event.data })
+    )
+  end,
+})

--- a/lua/yazi/event_handling/nvim_event_handling.lua
+++ b/lua/yazi/event_handling/nvim_event_handling.lua
@@ -30,6 +30,8 @@ end
 ---@param event_name YaziNeovimEvent
 ---@param event_data table<string, unknown>
 function M.emit(event_name, event_data)
+  local Log = require("yazi.log")
+  Log:debug(vim.inspect({ "emitting", event_name, event_data }))
   vim.api.nvim_exec_autocmds("User", {
     pattern = event_name,
     data = event_data,

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -179,11 +179,19 @@ function YaProcess:process_events(events)
         or event.type == "move"
         or event.type == "bulk"
       then
-        local event_handling =
-          require("yazi.event_handling.nvim_event_handling")
-
-        pcall(function()
-          event_handling.emit_renamed_or_moved_event(event)
+        vim.schedule(function()
+          local event_handling =
+            require("yazi.event_handling.nvim_event_handling")
+          local success, result = pcall(function()
+            event_handling.emit_renamed_or_moved_event(event)
+          end)
+          if not success then
+            Log:debug(vim.inspect({
+              "Failed to emit YaziRenamedOrMoved event",
+              event,
+              result,
+            }))
+          end
         end)
       end
     end

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -2,6 +2,8 @@ local assert = require("luassert")
 local ya_process = require("yazi.process.ya_process")
 local spy = require("luassert.spy")
 
+require("plenary.async").tests.add_to_env()
+
 describe("the get_yazi_command() function", function()
   it("specifies opening multiple tabs when enabled in the config", function()
     local config = require("yazi.config").default()
@@ -149,6 +151,9 @@ describe("process_events()", function()
         })
 
         ya:process_events(events)
+        vim.wait(2000, function()
+          return #event_callback.calls > 0
+        end)
 
         assert.spy(event_callback).was_called()
         assert.same(#event_callback.calls, 1)
@@ -190,6 +195,9 @@ describe("process_events()", function()
         })
 
         ya:process_events(events)
+        vim.wait(2000, function()
+          return #event_callback.calls > 0
+        end)
 
         assert.spy(event_callback).was_called()
         assert.same(#event_callback.calls, 1)
@@ -229,6 +237,9 @@ describe("process_events()", function()
         })
 
         ya:process_events(events)
+        vim.wait(2000, function()
+          return #event_callback.calls > 0
+        end)
 
         assert.spy(event_callback).was_called()
         assert.same(#event_callback.calls, 1)


### PR DESCRIPTION
Issue
=====

When a file was renamed/moved, a YaziRenamedOrMoved event was supposed to be published. However, the event was not actually published in practice due to `E5560: nvim_exec_autocmds must not be called in a lua loop callback`.

Solution
========

The solution was to schedule the event publishing in a `vim.schedule` block. This way, the event publishing is deferred to the next event loop iteration, which avoids the error.

For some reason, this error is not visible in unit tests, so I added an integration test to make sure it doesn't break again.