### PR TITLE
docs: add `--locked` flag to "installing-yazi-from-source" commands

### DIFF
--- a/documentation/installing-yazi-from-source.md
+++ b/documentation/installing-yazi-from-source.md
@@ -37,10 +37,10 @@ to the project.
    # in the yazi repository:
 
    # Install `yazi`, the main application
-   cargo install --path yazi-fm
+   cargo install --path yazi-fm --locked
 
    # Install `ya`, the command line interface that's internally used by yazi.nvim
-   cargo install --path yazi-cli
+   cargo install --path yazi-cli --locked
    ```
 
 4. In case there are any issues, you can try these steps:


### PR DESCRIPTION
The `--locked` flag tells Cargo to use the exact dependencies specified in the Cargo.lock file, without attempting to update them.