### PR TITLE
ci: don't run lint and style checks on push events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Linting
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   selene:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,7 +2,11 @@
 
 name: Style checking
 
-on: [push, pull_request]
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
 
 jobs:
   prettier:


### PR DESCRIPTION
Issue
=====

Currently these jobs run when a pull_request is created or updated:

```text
Linkspector / runner / linkspector (pull_request) Successful in 2m
Linting / markdownlint (pull_request) Successful in 4s
Linting / markdownlint (push) Successful in 3s
Linting / selene (pull_request) Successful in 4s
Linting / selene (push) Successful in 3s
LuaRocks release / LuaRocks upload (pull_request) Successful in 28s
Run tests / Run tests (nightly) (pull_request) Successful in 2m
Run tests / Run tests (stable) (pull_request) Successful in 2m
Style checking / prettier (pull_request) Successful in 32s
Style checking / prettier (push) Successful in 29s
Style checking / stylua (pull_request) Successful in 3s
Style checking / stylua (push) Successful in 3s
Type check / Type check (pull_request) Successful in 14s
reviewdog eslint / runner / eslint (pull_request) Successful in 43s
```

https://github.com/mikavilpas/yazi.nvim/pull/508

There are duplicate jobs for push and pull_request events. This is unnecessary and can be removed.

Solution
========

Remove the push event from the lint and style workflows.