### PR TITLE
fix: report parent directory of input_path as last_directory

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -73,6 +73,7 @@ function M.yazi(config, input_path)
         yazi_event_handling.process_events_emitted_from_yazi(events)
 
       local last_directory = event_info.last_directory
+
       if last_directory == nil then
         if path:is_file() then
           last_directory = path:parent()
@@ -80,8 +81,9 @@ function M.yazi(config, input_path)
           last_directory = path
         end
       end
+
       utils.on_yazi_exited(prev_win, prev_buf, win, config, selected_files, {
-        last_directory = event_info.last_directory or path:parent(),
+        last_directory = last_directory,
       })
 
       if hovered_url then

--- a/spec/yazi/helpers/test_files.lua
+++ b/spec/yazi/helpers/test_files.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+---@param target_file string
+function M.create_test_file(target_file)
+  local plenary_path = require("plenary.path")
+  local file = io.open(target_file, "w") -- Open or create the file in write mode
+  assert(file, "Failed to create file " .. target_file)
+  if file then
+    file:write("")
+    file:close()
+  end
+  assert(plenary_path:new(target_file):exists())
+  assert(plenary_path:new(target_file):is_file())
+  assert(plenary_path:new(target_file):parent():is_dir())
+end
+
+return M


### PR DESCRIPTION
Background
==========

When yazi is started too late, it can happen that we don't know what the
last_directory was when yazi has exited. When this happens, yazi has
already reported its `cd` event before `ya` starts and yazi.nvim cannot
capture it.

The issue can be tracked in https://github.com/sxyazi/yazi/issues/1314

Issue
=====

Currently yazi.nvim works around this limitation by using the parent
directory of the input_path as the last_directory since it's a good guess.

However, it looks like this has never worked reliably due to a bug in the
implementation. The correct directory was calculated, but it was not
assigned to the last_directory field in the state - it was ignored and
had no effect.

Solution
========

Assign the correct directory to the last_directory field in the state.