### PR TITLE
fix: not being able to resolve the last_directory

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -63,6 +63,14 @@ export const MyTestDirectorySchema = z.object({
           extension: z.literal("lua"),
           stem: z.literal("modify_yazi_config_and_set_help_key."),
         }),
+        "modify_yazi_config_log_yazi_closed_successfully.lua": z.object({
+          name: z.literal(
+            "modify_yazi_config_log_yazi_closed_successfully.lua",
+          ),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("modify_yazi_config_log_yazi_closed_successfully."),
+        }),
         "notify_hover_events.lua": z.object({
           name: z.literal("notify_hover_events.lua"),
           type: z.literal("file"),
@@ -197,6 +205,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/modify_yazi_config_and_highlight_buffers_in_same_directory.lua",
   "config-modifications/modify_yazi_config_and_open_multiple_files.lua",
   "config-modifications/modify_yazi_config_and_set_help_key.lua",
+  "config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua",
   "config-modifications/notify_hover_events.lua",
   "config-modifications/notify_rename_events.lua",
   "config-modifications/report_loaded_yazi_modules.lua",

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -194,4 +194,34 @@ describe("'rename' events", () => {
       cy.contains("Just received a YaziRenamedOrMoved event!")
     })
   })
+
+  it("reports the correct last_directory when yazi is closed", () => {
+    cy.startNeovim({
+      startupScriptModifications: [
+        "modify_yazi_config_log_yazi_closed_successfully.lua",
+      ],
+    }).then((dir) => {
+      // the default file should already be open
+      cy.contains(dir.contents["initial-file.txt"].name)
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // start yazi
+      cy.typeIntoTerminal("{upArrow}")
+
+      // move to another directory
+      cy.typeIntoTerminal(`/${dir.contents["dir with spaces"].name}{enter}`)
+      cy.typeIntoTerminal("{rightArrow}")
+      cy.contains("this is the first file")
+
+      // close yazi
+      cy.typeIntoTerminal("q")
+
+      // yazi should now be closed
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      cy.contains("yazi_closed_successfully hook")
+      cy.contains("last_directory = ")
+      cy.contains("dir with spaces")
+    })
+  })
 })

--- a/integration-tests/test-environment/config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua
+++ b/integration-tests/test-environment/config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua
@@ -1,0 +1,19 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    ---@diagnostic disable-next-line: missing-fields
+    hooks = {
+      yazi_closed_successfully = function(chosen_file, _, state)
+        -- selene: allow(mixed_table)
+        vim.notify(vim.inspect({
+          "yazi_closed_successfully hook",
+          chosen_file = chosen_file,
+          last_directory = state.last_directory
+            and state.last_directory:normalize(vim.uv.cwd()),
+        }))
+      end,
+    },
+  }
+)

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -49,7 +49,7 @@ function M.yazi(config, input_path)
   local yazi_process = YaziProcess:start(
     config,
     paths,
-    function(exit_code, selected_files, events, hovered_url)
+    function(exit_code, selected_files, events, hovered_url, last_directory)
       if exit_code ~= 0 then
         print(
           "yazi.nvim: had trouble opening yazi. Run ':checkhealth yazi' for more information."
@@ -69,10 +69,7 @@ function M.yazi(config, input_path)
         )
       )
 
-      local event_info =
-        yazi_event_handling.process_events_emitted_from_yazi(events)
-
-      local last_directory = event_info.last_directory
+      yazi_event_handling.process_events_emitted_from_yazi(events)
 
       if last_directory == nil then
         if path:is_file() then
@@ -81,6 +78,10 @@ function M.yazi(config, input_path)
           last_directory = path
         end
       end
+
+      Log:debug(
+        string.format("Resolved the last_directory to %s", last_directory)
+      )
 
       utils.on_yazi_exited(prev_win, prev_buf, win, config, selected_files, {
         last_directory = last_directory,

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -2,7 +2,6 @@
 
 local utils = require("yazi.utils")
 local plenaryIterators = require("plenary.iterators")
-local plenary_path = require("plenary.path")
 local lsp_delete = require("yazi.lsp.delete")
 local lsp_rename = require("yazi.lsp.rename")
 
@@ -70,11 +69,7 @@ function M.get_buffers_that_need_renaming_after_yazi_exited(
 end
 
 ---@param events YaziEvent[]
----@return {last_directory?: Path}
 function M.process_events_emitted_from_yazi(events)
-  ---@type Path | nil
-  local last_directory = nil
-
   for i, event in ipairs(events) do
     if event.type == "rename" then
       ---@cast event YaziRenameEvent
@@ -119,15 +114,8 @@ function M.process_events_emitted_from_yazi(events)
       local remaining_events = vim.list_slice(events, i)
       ---@cast event YaziTrashEvent
       M.process_delete_event(event, remaining_events)
-    elseif event.type == "cd" then
-      ---@cast event YaziChangeDirectoryEvent
-      if event.url ~= nil and event.url ~= "" then
-        last_directory = plenary_path:new(event.url)
-      end
     end
   end
-
-  return { last_directory = last_directory }
 end
 
 return M

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -171,6 +171,9 @@ function YaProcess:process_events(events)
       end)
     elseif event.type == "cd" then
       ---@cast event YaziHoverEvent
+      Log:debug(
+        string.format("Changing the cwd from %s to %s", self.cwd, event.url)
+      )
       self.cwd = event.url
     else
       self.events[#self.events + 1] = event

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -130,6 +130,7 @@ function YaProcess:start()
         Log:debug(string.format("ya stdout error: '%s'", data))
       end
       data = data or ""
+      data = data:gsub("\n+", "\n")
 
       Log:debug(string.format("ya stdout: '%s'", data))
 

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -4,6 +4,7 @@ local YaProcess = require("yazi.process.ya_process")
 local Log = require("yazi.log")
 local utils = require("yazi.utils")
 local YaziProcessApi = require("yazi.process.yazi_process_api")
+local plenary_path = require("plenary.path")
 
 ---@class YaziProcess
 ---@field public api YaziProcessApi
@@ -16,7 +17,7 @@ YaziProcess.__index = YaziProcess
 
 ---@param config YaziConfig
 ---@param paths Path[]
----@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[], hovered_url: string | nil)
+---@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[], hovered_url: string | nil, last_cwd: Path | nil)
 function YaziProcess:start(config, paths, on_exit)
   os.remove(config.chosen_file_path)
 
@@ -40,7 +41,19 @@ function YaziProcess:start(config, paths, on_exit)
       if utils.file_exists(config.chosen_file_path) == true then
         chosen_files = vim.fn.readfile(config.chosen_file_path)
       end
-      on_exit(code, chosen_files, events, self.ya_process.hovered_url)
+
+      local last_directory = nil
+      if self.ya_process.cwd ~= nil then
+        last_directory = plenary_path:new(self.ya_process.cwd) --[[@as Path]]
+      end
+
+      on_exit(
+        code,
+        chosen_files,
+        events,
+        self.ya_process.hovered_url,
+        last_directory
+      )
     end,
   })
 

--- a/spec/yazi/helpers/fake_yazi_process.lua
+++ b/spec/yazi/helpers/fake_yazi_process.lua
@@ -7,22 +7,32 @@ local M = {}
 ---@field selected_files string[]
 ---@field events YaziEvent[]
 ---@field api YaziProcessApi
+---@field hovered_url string | nil
+---@field last_cwd Path | nil
 M.mocks = {}
 
----@param arguments { code?: integer, selected_files?: string[], events?: YaziEvent[], api: YaziProcessApi }
+---@param arguments { code?: integer, selected_files?: string[], events?: YaziEvent[], api: YaziProcessApi, hovered_url?: string | nil, last_cwd?: Path | nil }
 function M.setup_created_instances_to_instantly_exit(arguments)
   M.mocks.code = arguments.code or 0
   M.mocks.selected_files = arguments.selected_files or {}
   M.mocks.events = arguments.events or {}
   M.api = arguments.api or {}
+  M.mocks.hovered_url = arguments.hovered_url or nil
+  M.mocks.last_cwd = arguments.last_cwd or nil
 end
 
 -- Fake yazi process that instantly exits with the mocked data that was set up
 -- before.
----@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[])
+---@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[], hovered_url: string | nil, last_cwd: Path | nil)
 ---@diagnostic disable-next-line: unused-local
 function M:start(_, _, on_exit)
-  on_exit(M.mocks.code, M.mocks.selected_files, M.mocks.events)
+  on_exit(
+    M.mocks.code,
+    M.mocks.selected_files,
+    M.mocks.events,
+    M.mocks.hovered_url,
+    M.mocks.last_cwd
+  )
   return self
 end
 

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -74,18 +74,7 @@ describe("opening a file", function()
       "calls the yazi_closed_successfully hook with the target_file and last_directory",
       function()
         fake_yazi_process.setup_created_instances_to_instantly_exit({
-          selected_files = {
-            -- in this test, the cd event defines the last_directory so this is ignored
-          },
-          ---@type YaziChangeDirectoryEvent[]
-          events = {
-            {
-              type = "cd",
-              timestamp = "123",
-              id = "123",
-              url = "/abc",
-            },
-          },
+          last_cwd = { filename = "/abc" } --[[@as Path]],
         })
 
         ---@param state YaziClosedState
@@ -111,7 +100,7 @@ describe("opening a file", function()
     )
 
     it(
-      "uses the parent directory of the input_path as the last_directory when no events are emitted",
+      "uses the parent directory of the input_path as the last_directory when no last_directory is available",
       function()
         local plenary_path = require("plenary.path")
         -- it can happen that we don't know what the last_directory was when


### PR DESCRIPTION
Background
==========

The `last_directory` is the last directory that yazi was in before it was closed. This is useful for various custom integrations that users might want to do with yazi.

Issue
=====

The `last_directory` variable seemed to always be empty. It used to work, but I think it broke when I added the following commit some time ago:

> feat: expose the current working directory to keybindings (#471)
>
> https://github.com/mikavilpas/yazi.nvim/commit/445f4877d8b80f9d24ea1f9b890c878211878d63

The `last_directory` variable is being set currently, but using it still depends on the old implementation that was in effect before the commit above - it basically cannot be found because it's still expected to be in the old place.

Solution
========

Use the new implementation that was introduced in the commit above.

Might solve #95 