### PR TITLE
chore: set repro log level to DEBUG

### DIFF
--- a/repro.lua
+++ b/repro.lua
@@ -55,6 +55,7 @@ local plugins = {
     ---@type YaziConfig
     opts = {
       open_for_directories = false,
+      log_level = vim.log.levels.DEBUG,
     },
   },
 }


### PR DESCRIPTION
This will enable logging by default when running the issue reproduction setup.