### PR TITLE
feat: support reacting to custom yazi DDS events

### DIFF
--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -30,6 +30,18 @@ export const MyTestDirectorySchema = z.object({
             }),
           }),
         }),
+        yazi: z.object({
+          name: z.literal("yazi/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "keymap.toml": z.object({
+              name: z.literal("keymap.toml"),
+              type: z.literal("file"),
+              extension: z.literal("toml"),
+              stem: z.literal("keymap."),
+            }),
+          }),
+        }),
       }),
     }),
     "config-modifications": z.object({
@@ -88,6 +100,12 @@ export const MyTestDirectorySchema = z.object({
           type: z.literal("file"),
           extension: z.literal("lua"),
           stem: z.literal("modify_yazi_config_log_yazi_closed_successfully."),
+        }),
+        "notify_custom_events.lua": z.object({
+          name: z.literal("notify_custom_events.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("notify_custom_events."),
         }),
         "notify_hover_events.lua": z.object({
           name: z.literal("notify_hover_events.lua"),
@@ -213,6 +231,8 @@ export type MyTestDirectory = MyTestDirectoryContentsSchemaType["contents"]
 export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
   ".config/nvim",
+  ".config/yazi/keymap.toml",
+  ".config/yazi",
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications/disable_a_keybinding.lua",
@@ -221,6 +241,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/modify_yazi_config_and_open_multiple_files.lua",
   "config-modifications/modify_yazi_config_and_set_help_key.lua",
   "config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua",
+  "config-modifications/notify_custom_events.lua",
   "config-modifications/notify_hover_events.lua",
   "config-modifications/notify_rename_events.lua",
   "config-modifications/report_loaded_yazi_modules.lua",

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -239,4 +239,37 @@ describe("'rename' events", () => {
       cy.contains("dir with spaces")
     })
   })
+
+  describe("custom YaziDDSCustom events", () => {
+    it("emits events the user has subscribed to", () => {
+      cy.startNeovim({
+        startupScriptModifications: ["notify_custom_events.lua"],
+      }).then((dir) => {
+        // The user can set a config option to specify custom yazi dds events that
+        // they want to subscribe to. These are emitted as YaziDDSCustom events.
+        cy.contains("If you see this text, Neovim is ready!")
+        cy.typeIntoTerminal("{upArrow}")
+        cy.contains(dir.contents["file2.txt"].name)
+
+        // publish the custom MyMessageNoData event that we subscribed to in
+        // notify_custom_events.lua
+        cy.typeIntoTerminal("{control+p}")
+
+        // also publish MyMessageWithData that contains json data
+        cy.typeIntoTerminal("{control+h}")
+
+        cy.typeIntoTerminal("q")
+        cy.contains(dir.contents["file2.txt"].name).should("not.exist")
+        cy.typeIntoTerminal(":messages{enter}", { delay: 0 })
+
+        // should see a message for the event kind MyMessageNoData that has no data
+        // this checks that events without data are supported
+        cy.contains("Just received a YaziDDSCustom event 'MyMessageNoData'!")
+
+        // should see the data for MyMessageWithData
+        cy.contains("Just received a YaziDDSCustom event 'MyMessageWithData'!")
+        cy.contains("somedata")
+      })
+    })
+  })
 })

--- a/integration-tests/cypress/support/commands.ts
+++ b/integration-tests/cypress/support/commands.ts
@@ -68,8 +68,5 @@ declare global {
 
 afterEach(() => {
   cy.task("showYaziLog")
-})
-
-beforeEach(() => {
   cy.task("removeYaziLog")
 })

--- a/integration-tests/test-environment/.config/yazi/keymap.toml
+++ b/integration-tests/test-environment/.config/yazi/keymap.toml
@@ -1,0 +1,13 @@
+# https://yazi-rs.github.io/docs/configuration/overview
+# https://yazi-rs.github.io/docs/configuration/keymap
+"$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
+
+# send an event with no data
+[[manager.prepend_keymap]]
+on = "<C-p>"
+run = """shell 'ya pub-to 0 MyMessageNoData' --confirm"""
+
+# send an event that also has json data
+[[manager.prepend_keymap]]
+on = "<C-h>"
+run = """shell "ya pub-to 0 MyMessageWithData --json '{\\"somedata\\": 123}'" --confirm"""

--- a/integration-tests/test-environment/config-modifications/notify_custom_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_custom_events.lua
@@ -1,0 +1,20 @@
+---@module "yazi"
+
+require("yazi").config.forwarded_dds_events =
+  { "MyMessageNoData", "MyMessageWithData" }
+
+vim.api.nvim_create_autocmd("User", {
+  pattern = "YaziDDSCustom",
+  -- see `:help event-args`
+  ---@param event yazi.AutoCmdEvent
+  callback = function(event)
+    -- printing the messages will allow seeing them with `:messages` in tests
+    print(vim.inspect({
+      string.format(
+        "Just received a YaziDDSCustom event '%s'!",
+        event.data.type
+      ),
+      event.data,
+    }))
+  end,
+})

--- a/lua/yazi/event_handling/nvim_event_handling.lua
+++ b/lua/yazi/event_handling/nvim_event_handling.lua
@@ -6,6 +6,7 @@ local M = {}
 ---@alias YaziNeovimEvent
 ---| "'YaziDDSHover'" A file was hovered over in yazi
 ---| "'YaziRenamedOrMoved'" Files were renamed or moved
+---| "'YaziDDSCustom'" A custom event was received from yazi. The event was specifically subscribed to with the `forwarded_dds_events` yazi.nvim config option.
 
 ---@alias YaziNeovimEvent.YaziRenamedOrMovedData {changes: table<string, string>} # a table of old paths to new paths
 

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -21,6 +21,7 @@
 ---@field public log_level? yazi.LogLevel
 ---@field public clipboard_register? string the register to use for copying. Defaults to "*", the system clipboard
 ---@field public highlight_hovered_buffers_in_same_directory? boolean "highlight buffers in the same directory as the hovered buffer"
+---@field public forwarded_dds_events? string[] "Yazi events to listen to. These are published as neovim autocmds so that the user can set up custom handlers for themselves. Defaults to `nil`."
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 
@@ -58,7 +59,7 @@
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 ---@field public hovered_buffer_in_same_directory? vim.api.keyset.highlight # the color of a buffer that is in the same directory as the hovered buffer
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent
 
 ---@class (exact) YaziPreviousState # describes the previous state of yazi when it was closed; the last known state
 ---@field public last_hovered? string
@@ -108,6 +109,11 @@
 ---@class (exact) YaziBulkEvent "Like `rename` and `move` but for bulk renaming"
 ---@field public type "bulk"
 ---@field public changes table<string, string> # a table of old paths to new paths
+
+---@class (exact) YaziCustomDDSEvent "A custom event that is emitted by yazi. It could be coming from yazi itself, or a yazi plugin that uses custom events."
+---@field public yazi_id string
+---@field public type string
+---@field public raw_data string # the data included in the event as a string. Might be the empty string in case no data is included.
 
 ---@class (exact) yazi.AutoCmdEvent # the nvim_create_autocmd() event object copied from the nvim help docs
 ---@field public id number

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -248,6 +248,21 @@ function M.parse_events(events_file_lines)
         url = url or "",
       }
       table.insert(events, event)
+    else
+      require("yazi.log"):debug(string.format("Unknown event type: %s", type))
+      -- Custom user event.
+      -- It could look like this (with optional data at the end)
+      -- MyMessageNoData,0,1731774290298033,
+      local data_string = table.concat(parts, ",", 4, #parts)
+      local yazi_id = parts[3]
+
+      ---@type YaziCustomDDSEvent
+      local event = {
+        yazi_id = yazi_id,
+        type = type,
+        raw_data = data_string,
+      }
+      table.insert(events, event)
     end
   end
 


### PR DESCRIPTION
> note: DDS means "Data Distribution Service". It's a way for yazi to
> communicate with neovim and other processes.
>
> https://yazi-rs.github.io/docs/dds

Issue
=====

Yazi is incredibly versatile and can be used for many different things.
However, it's too difficult to predict what the needs of every user will
be. Power users have no easy way to extend the behaviour of yazi.nvim
beyond the features that are built-in.

Solution
========

Allow users to subscribe to custom yazi DDS events. These events are
possibly not included in yazi by default, but can be published by yazi
plugins or by other applications using yazi's DDS system.

By default, all custom events are ignored. The user can specify which
events they want to listen to by setting a new `forwarded_dds_events`
(string[], default nil) config option.

When an event whose kind is included in this `forwarded_dds_events` list
is received, yazi.nvim will emit a neovim autocmd event with the name
`YaziDDSCustom`. The event will contain the `type` of the event and the
`raw_data` as a string. The user can then set up custom handlers for
these events in their neovim config.

Solves https://github.com/mikavilpas/yazi.nvim/issues/547