### PR TITLE
feat: can use `ya emit` for more accurate <tab> to file (opt-in)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,10 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          commit:
-            # https://github.com/sxyazi/yazi/commit/d72f90356b98
-            d72f90356b98
+          tag: 0.4.0
+          # commit:
+          #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
+          #   d72f90356b98
 
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3.1.1
@@ -46,9 +47,10 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          commit:
-            # https://github.com/sxyazi/yazi/commit/d72f90356b98
-            d72f90356b98
+          tag: 0.4.0
+          # commit:
+          #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
+          #   d72f90356b98
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          tag: 0.4.0
+          tag: v0.4.0
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98
@@ -47,7 +47,7 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          tag: 0.4.0
+          tag: v0.4.0
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98

--- a/README.md
+++ b/README.md
@@ -277,6 +277,13 @@ You can optionally configure yazi.nvim by setting any of the options below.
       -- `grealpath` on OSX, (GNU) `realpath` otherwise
       resolve_relative_path_application = ""
     },
+
+    future_features = {
+      -- Whether to use `ya emit reveal` to reveal files in the file manager.
+      -- This requires yazi 0.4.0 but will likely be the default in the
+      -- future.
+      ya_emit_reveal = true,
+    },
   },
 }
 ```

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -101,6 +101,12 @@ export const MyTestDirectorySchema = z.object({
           extension: z.literal("lua"),
           stem: z.literal("modify_yazi_config_log_yazi_closed_successfully."),
         }),
+        "modify_yazi_config_use_ya_emit.lua": z.object({
+          name: z.literal("modify_yazi_config_use_ya_emit.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("modify_yazi_config_use_ya_emit."),
+        }),
         "notify_custom_events.lua": z.object({
           name: z.literal("notify_custom_events.lua"),
           type: z.literal("file"),
@@ -156,6 +162,30 @@ export const MyTestDirectorySchema = z.object({
       type: z.literal("file"),
       extension: z.literal("txt"),
       stem: z.literal("file2."),
+    }),
+    highlights: z.object({
+      name: z.literal("highlights/"),
+      type: z.literal("directory"),
+      contents: z.object({
+        "file_1.txt": z.object({
+          name: z.literal("file_1.txt"),
+          type: z.literal("file"),
+          extension: z.literal("txt"),
+          stem: z.literal("file_1."),
+        }),
+        "file_2.txt": z.object({
+          name: z.literal("file_2.txt"),
+          type: z.literal("file"),
+          extension: z.literal("txt"),
+          stem: z.literal("file_2."),
+        }),
+        "file_3.txt": z.object({
+          name: z.literal("file_3.txt"),
+          type: z.literal("file"),
+          extension: z.literal("txt"),
+          stem: z.literal("file_3."),
+        }),
+      }),
     }),
     "initial-file.txt": z.object({
       name: z.literal("initial-file.txt"),
@@ -241,6 +271,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/modify_yazi_config_and_open_multiple_files.lua",
   "config-modifications/modify_yazi_config_and_set_help_key.lua",
   "config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua",
+  "config-modifications/modify_yazi_config_use_ya_emit.lua",
   "config-modifications/notify_custom_events.lua",
   "config-modifications/notify_hover_events.lua",
   "config-modifications/notify_rename_events.lua",
@@ -251,6 +282,10 @@ export const testDirectoryFiles = z.enum([
   "dir with spaces/file2.txt",
   "dir with spaces",
   "file2.txt",
+  "highlights/file_1.txt",
+  "highlights/file_2.txt",
+  "highlights/file_3.txt",
+  "highlights",
   "initial-file.txt",
   "other-subdirectory/other-sub-file.txt",
   "other-subdirectory",

--- a/integration-tests/test-environment/config-modifications/modify_yazi_config_use_ya_emit.lua
+++ b/integration-tests/test-environment/config-modifications/modify_yazi_config_use_ya_emit.lua
@@ -1,0 +1,10 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    future_features = {
+      ya_emit_reveal = true,
+    },
+  }
+)

--- a/integration-tests/test-environment/highlights/file_1.txt
+++ b/integration-tests/test-environment/highlights/file_1.txt
@@ -1,0 +1,1 @@
+Hello from file_1.txt

--- a/integration-tests/test-environment/highlights/file_2.txt
+++ b/integration-tests/test-environment/highlights/file_2.txt
@@ -1,0 +1,1 @@
+This is file_2.txt

--- a/integration-tests/test-environment/highlights/file_3.txt
+++ b/integration-tests/test-environment/highlights/file_3.txt
@@ -1,0 +1,1 @@
+You are looking at file_3.txt

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -16,6 +16,7 @@ function M.default()
   return {
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
+    future_features = {},
     open_multiple_tabs = false,
     enable_mouse_support = false,
     open_file_function = openers.open_file,
@@ -151,7 +152,7 @@ function M.set_keymappings(yazi_buffer, config, context)
 
   if config.keymaps.cycle_open_buffers ~= false then
     vim.keymap.set({ "t" }, config.keymaps.cycle_open_buffers, function()
-      keybinding_helpers.cycle_open_buffers(context)
+      keybinding_helpers.cycle_open_buffers(config, context)
     end, { buffer = yazi_buffer })
   end
 

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -113,6 +113,14 @@ return {
       )
     end
 
+    if config.future_features and config.future_features.ya_emit_reveal then
+      if not checker.ge(yazi_semver, "0.4.0") then
+        vim.health.warn(
+          "You have enabled `future_features.ya_emit_reveal` in your config. This requires yazi.nvim version 0.4.0 or newer."
+        )
+      end
+    end
+
     vim.health.start("yazi.config")
     vim.health.info(table.concat({
       "hint: execute the following command to see your configuration: >",

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -61,8 +61,9 @@ function YaziOpenerActions.select_current_file_and_close_yazi(config, callbacks)
   )
 end
 
+---@param config YaziConfig
 ---@param context YaziActiveContext
-function YaziOpenerActions.cycle_open_buffers(context)
+function YaziOpenerActions.cycle_open_buffers(config, context)
   assert(context.input_path, "No input path found")
   assert(context.input_path.filename, "No input path filename found")
 
@@ -112,19 +113,29 @@ function YaziOpenerActions.cycle_open_buffers(context)
         return
       end
 
-      local directory =
-        vim.fn.fnamemodify(next_buffer.renameable_buffer.path.filename, ":h")
-      assert(
-        directory,
-        string.format(
-          'Found the next buffer, but could not find its base directory. The buffer: "%s", aborting.',
-          next_buffer.renameable_buffer.path.filename
-        )
-      )
+      if config.future_features.ya_emit_reveal then
+        local nextfile = next_buffer.renameable_buffer.path.filename
 
-      context.api:cd(directory)
-      context.cycled_file = next_buffer.renameable_buffer
-      return
+        -- make sure the type is a string, because plenary thinks it is `string|unknown`
+        assert(type(nextfile) == "string", "Expected filename to be a string")
+        context.api:reveal(nextfile)
+        context.cycled_file = next_buffer.renameable_buffer
+        return
+      else
+        local directory =
+          vim.fn.fnamemodify(next_buffer.renameable_buffer.path.filename, ":h")
+        assert(
+          directory,
+          string.format(
+            'Found the next buffer, but could not find its base directory. The buffer: "%s", aborting.',
+            next_buffer.renameable_buffer.path.filename
+          )
+        )
+
+        context.api:cd(directory)
+        context.cycled_file = next_buffer.renameable_buffer
+        return
+      end
     end
   end
 

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -1,3 +1,5 @@
+---@module "plenary.path"
+
 ---@class YaziProcessApi # Provides yazi.nvim -> yazi process interactions. This allows yazi.nvim to tell yazi what to do.
 ---@field private config YaziConfig
 ---@field private yazi_id string
@@ -15,9 +17,17 @@ end
 
 ---@param path string
 function YaziProcessApi:cd(path)
-  assert(path, "path is required")
   vim.system(
     { "ya", "pub-to", self.yazi_id, "--str", path, "dds-cd" },
+    { timeout = 1000 }
+  )
+end
+
+---@see https://yazi-rs.github.io/docs/configuration/keymap#manager.reveal
+---@param path string
+function YaziProcessApi:reveal(path)
+  vim.system(
+    { "ya", "emit-to", self.yazi_id, "reveal", "--str", path },
     { timeout = 1000 }
   )
 end

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -22,6 +22,10 @@
 ---@field public clipboard_register? string the register to use for copying. Defaults to "*", the system clipboard
 ---@field public highlight_hovered_buffers_in_same_directory? boolean "highlight buffers in the same directory as the hovered buffer"
 ---@field public forwarded_dds_events? string[] "Yazi events to listen to. These are published as neovim autocmds so that the user can set up custom handlers for themselves. Defaults to `nil`."
+---@field public future_features? yazi.OptInFeatures # Features that are not yet stable, but can be tested by the user. These features might change or be removed in the future. They may also become built-in features that are on by default, making it unnecessary to opt into using them.
+
+---@class(exact) yazi.OptInFeatures
+---@field ya_emit_reveal? boolean # Whether to use `ya emit reveal` to reveal files in the file manager. This requires https://github.com/sxyazi/yazi/pull/1979 (from 2024-12-01).
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 

--- a/spec/yazi/health_spec.lua
+++ b/spec/yazi/health_spec.lua
@@ -184,6 +184,41 @@ Options:
     )
   end)
 
+  describe("future_features", function()
+    it(
+      "warns when yazi is < 0.4.0 and `config.future_features.ya_emit_reveal` is enabled",
+      function()
+        yazi.setup({
+          future_features = {
+            ya_emit_reveal = true,
+          },
+        })
+
+        vim.cmd("checkhealth yazi")
+
+        assert_buffer_contains_text(
+          "You have enabled `future_features.ya_emit_reveal` in your config. This requires yazi.nvim version 0.4.0 or newer."
+        )
+      end
+    )
+
+    it(
+      "does not warn when yazi is >= 0.4.0 and `config.future_features.ya_emit_reveal` is enabled",
+      function()
+        mock_app_versions["yazi"] = "yazi 0.4.0 (f5a7ace 2024-07-23)"
+        yazi.setup({
+          future_features = {
+            ya_emit_reveal = true,
+          },
+        })
+
+        vim.cmd("checkhealth yazi")
+
+        assert_buffer_does_not_contain_text("future_features.ya_emit_reveal")
+      end
+    )
+  end)
+
   describe("the checks for resolve_relative_path_application", function()
     it(
       "warns when the keymap for this integration is set but the resolver is missing",

--- a/spec/yazi/keybinding_helpers_spec.lua
+++ b/spec/yazi/keybinding_helpers_spec.lua
@@ -150,9 +150,7 @@ describe("keybinding_helpers", function()
           ya_process = { cwd = "/tmp" },
         })
 
-        assert
-          .stub(vim_cmd_stub)
-          .called_with({ cmd = "cd", args = { "/tmp" } })
+        assert.stub(vim_cmd_stub).called_with({ cmd = "cd", args = { "/tmp" } })
 
         assert.stub(vim_notify_stub).called_with('cwd changed to "/tmp"')
       end
@@ -168,9 +166,7 @@ describe("keybinding_helpers", function()
         },
       })
 
-      assert
-        .stub(vim_cmd_stub)
-        .called_with({ cmd = "cd", args = { "/tmp" } })
+      assert.stub(vim_cmd_stub).called_with({ cmd = "cd", args = { "/tmp" } })
       assert.stub(vim_notify_stub).called_with('cwd changed to "/tmp"')
     end)
 


### PR DESCRIPTION
To celebrate the release of yazi 0.4.0, you can now opt in to improve the accuracy of `<tab>` to a file. Read below for more information on what this is and how you can opt into using it.

https://github.com/sxyazi/yazi/releases/tag/v0.4.0

Background
==========

When yazi is open, and there are multiple splits open in neovim, it's currently possible to press `<tab>` to cycle through the open buffers. When you press `<tab>`, yazi will change its current directory and focus the file that's next in the list of open splits (vertical or horizontal split).

Issue
=====

When pressing `<tab>`, yazi was only able to change its current directory to the same directory the next split is in. If there were multiple files in that directory, the first file would be focused. This is not necessarily the file that's next in the list of open splits, which can be disorienting.

Solution
========

If you have yazi 0.4.0 or later, you can now set the following in your yazi.nvim configuration:

```lua
---@type YaziConfig
{
  -- ... lots of other settings, see the README
  future_features = {
    -- Whether to use `ya emit reveal` to reveal files in the file manager.
    -- This requires yazi 0.4.0 but will likely be the default in the
    -- future.
    ya_emit_reveal = true,
  },
}
```