### PR TITLE
ci: use yazi v0.4.1 in integration-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          tag: v0.4.0
+          tag: v0.4.1
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98
@@ -47,7 +47,7 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          tag: v0.4.0
+          tag: v0.4.1
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98


### PR DESCRIPTION
It includes this important fix
- https://github.com/mikavilpas/yazi.nvim/issues/603

For the full release notes, see
- https://github.com/sxyazi/yazi/releases/tag/v0.4.1