### PR TITLE
feat: add fzf-lua integration for grepping in files and dirs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,22 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Set up dependencies
         run: |
-          # ripgrep is a telescope dependency
-          which rg || {
-            sudo apt-get install ripgrep
-          }
+          # ripgrep is a dependency of telescope and fzf-lua
+          sudo apt-get install ripgrep
+          rg --version
 
-          # realpath is used to resolve relative paths
+          # fd is a dependency of telescope and fzf-lua
+          # https://github.com/sharkdp/fd?tab=readme-ov-file#on-ubuntu
+          # make sure it's available as `fd` - there seems to be some conflict in Ubuntu
+          sudo apt-get install fd-find
+          sudo ln -s $(which fdfind) /usr/local/bin/fd
+          fd --version
+
+          # install fzf
+          sudo apt install fzf
+          fzf --version
+
+          # realpath is used to resolve relative paths in yazi.nvim
           which realpath || {
             # just fail with an error message if realpath is not found
             echo "realpath is not installed, but it should be part of GNU coreutils and included in Ubuntu"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ open yazi in a floating window in Neovim.
   vertical split, a horizontal split, a new tab, as quickfix items...
 - Integrations to other plugins and tools, if they are installed:
 
-  - For [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim): you
-    can grep/search in the directory yazi is in
+  - For [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and
+    [fzf-lua.nvim](https://github.com/ibhagwan/fzf-lua): you can grep/search in
+    the directory yazi is in. Select some files to limit the search to those
+    files only.
   - For [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim): you can
     search and replace in the directory yazi is in
   - Copy the relative path from the start file to the currently hovered file.
@@ -313,7 +315,10 @@ These are the default keybindings that are available when yazi is open:
   separately:
   - `<c-s>`: search in the current yazi directory using
     [telescope](https://github.com/nvim-telescope/telescope.nvim)'s `live_grep`,
-    if available.
+    if available. Optionally you can use
+    [fzf-lua.nvim](https://github.com/ibhagwan/fzf-lua) or provide your own
+    implementation - see the instructions in the configuration section for more
+    info.
     - if multiple files/directories are selected in yazi, the search and replace
       will only be done in the selected files/directories
   - `<c-g>`: search and replace in the current yazi directory using

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -107,6 +107,12 @@ export const MyTestDirectorySchema = z.object({
           extension: z.literal("lua"),
           stem: z.literal("modify_yazi_config_log_yazi_closed_successfully."),
         }),
+        "modify_yazi_config_use_fzf_lua.lua": z.object({
+          name: z.literal("modify_yazi_config_use_fzf_lua.lua"),
+          type: z.literal("file"),
+          extension: z.literal("lua"),
+          stem: z.literal("modify_yazi_config_use_fzf_lua."),
+        }),
         "modify_yazi_config_use_ya_emit_reveal.lua": z.object({
           name: z.literal("modify_yazi_config_use_ya_emit_reveal.lua"),
           type: z.literal("file"),
@@ -284,6 +290,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/modify_yazi_config_and_set_help_key.lua",
   "config-modifications/modify_yazi_config_do_not_use_ya_emit_open.lua",
   "config-modifications/modify_yazi_config_log_yazi_closed_successfully.lua",
+  "config-modifications/modify_yazi_config_use_fzf_lua.lua",
   "config-modifications/modify_yazi_config_use_ya_emit_reveal.lua",
   "config-modifications/notify_custom_events.lua",
   "config-modifications/notify_hover_events.lua",

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
@@ -74,8 +74,29 @@ describe("grug-far integration (search and replace)", () => {
 })
 
 describe("telescope integration (search)", () => {
+  // https://github.com/nvim-telescope/telescope.nvim
   beforeEach(() => {
     cy.visit("/")
+  })
+
+  it("can use telescope.nvim to search in the current directory", () => {
+    cy.startNeovim({
+      filename: "routes/posts.$postId/adjacent-file.txt",
+    }).then((dir) => {
+      cy.contains("this file is adjacent-file.txt")
+      cy.typeIntoTerminal("{upArrow}")
+      cy.contains(
+        dir.contents.routes.contents["posts.$postId"].contents["route.tsx"]
+          .name,
+      )
+
+      cy.typeIntoTerminal("{control+s}")
+
+      cy.contains(new RegExp(`Grep in testdirs/.*?/routes/posts.\\$postId`))
+
+      // verify this manually for now as I'm a bit scared this will be too
+      // flaky
+    })
   })
 
   it("can use telescope.nvim to search, limited to the selected files only", () => {

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -64,20 +64,21 @@ local plugins = {
         ya_emit_open = true,
       },
       integrations = {
-        grep_in_directory = function(directory)
-          require("telescope.builtin").live_grep({
-            -- disable previewer to be able to see the full directory name. The
-            -- tests can make assertions on this path.
-            previewer = false,
-            search = "",
-            prompt_title = "Grep in " .. directory,
-            cwd = directory,
-          })
-        end,
+        grep_in_directory = "telescope",
       },
     },
   },
-  { "nvim-telescope/telescope.nvim", lazy = true },
+  {
+    "nvim-telescope/telescope.nvim",
+    lazy = true,
+    opts = {
+      pickers = {
+        live_grep = {
+          theme = "dropdown",
+        },
+      },
+    },
+  },
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
   { "https://github.com/MagicDuck/grug-far.nvim", opts = {} },
   { "folke/snacks.nvim", opts = {} },

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -79,6 +79,7 @@ local plugins = {
       },
     },
   },
+  { "ibhagwan/fzf-lua" },
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
   { "https://github.com/MagicDuck/grug-far.nvim", opts = {} },
   { "folke/snacks.nvim", opts = {} },

--- a/integration-tests/test-environment/config-modifications/modify_yazi_config_use_fzf_lua.lua
+++ b/integration-tests/test-environment/config-modifications/modify_yazi_config_use_fzf_lua.lua
@@ -1,0 +1,11 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    integrations = {
+      grep_in_selected_files = "fzf-lua",
+      grep_in_directory = "fzf-lua",
+    },
+  }
+)

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -45,26 +45,8 @@ function M.default()
       hovered_buffer_in_same_directory = nil,
     },
     integrations = {
-      grep_in_directory = function(directory)
-        require("telescope.builtin").live_grep({
-          search = "",
-          prompt_title = "Grep in " .. directory,
-          cwd = directory,
-        })
-      end,
-      grep_in_selected_files = function(selected_files)
-        ---@type string[]
-        local files = {}
-        for _, path in ipairs(selected_files) do
-          files[#files + 1] = path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
-        end
-
-        require("telescope.builtin").live_grep({
-          search = "",
-          prompt_title = string.format("Grep in %d paths", #files),
-          search_dirs = files,
-        })
-      end,
+      grep_in_directory = "telescope",
+      grep_in_selected_files = "telescope",
       replace_in_directory = function(directory)
         -- limit the search to the given path
         --

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -175,11 +175,14 @@ function YaziOpenerActions.grep_in_directory(config, chosen_file)
       prompt_title = "Grep in " .. last_directory,
       cwd = last_directory,
     })
-    return
+  elseif config.integrations.grep_in_directory == "fzf-lua" then
+    require("fzf-lua").live_grep({
+      search_paths = { last_directory },
+    })
+  else
+    -- the user has a custom implementation. Call it.
+    config.integrations.grep_in_directory(last_directory)
   end
-
-  -- the user has a custom implementation. Call it.
-  config.integrations.grep_in_directory(last_directory)
 end
 
 ---@param config YaziConfig
@@ -196,23 +199,24 @@ function YaziOpenerActions.grep_in_selected_files(config, chosen_files)
     table.insert(paths, plenary_path:new(path))
   end
 
-  if config.integrations.grep_in_selected_files == "telescope" then
-    ---@type string[]
-    local files = {}
-    for _, path in ipairs(paths) do
-      files[#files + 1] = path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
-    end
+  ---@type string[]
+  local files = {}
+  for _, path in ipairs(paths) do
+    files[#files + 1] = path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
+  end
 
+  if config.integrations.grep_in_selected_files == "telescope" then
     require("telescope.builtin").live_grep({
       search = "",
       prompt_title = string.format("Grep in %d paths", #files),
       search_dirs = files,
     })
-    return
+  elseif config.integrations.grep_in_selected_files == "fzf-lua" then
+    require("fzf-lua").live_grep({ search_paths = files })
+  else
+    -- the user has a custom implementation. Call it.
+    config.integrations.grep_in_selected_files(paths)
   end
-
-  -- the user has a custom implementation. Call it.
-  config.integrations.grep_in_selected_files(paths)
 end
 
 ---@param config YaziConfig

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -54,8 +54,8 @@
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
----@field public grep_in_directory? fun(directory: string): nil "a function that will be called when the user wants to grep in a directory"
----@field public grep_in_selected_files? fun(selected_files: Path[]): nil"called to grep on files that were selected in yazi"
+---@field public grep_in_directory? "telescope" | fun(directory: string): nil "implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`"
+---@field public grep_in_selected_files? "telescope" | fun(selected_files: Path[]): nil "called to grep on files that were selected in yazi. Defaults to `"telescope"`"
 ---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil "called to start a replacement operation on some directory; by default uses grug-far.nvim"
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil "called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim"
 ---@field public resolve_relative_path_application? string "the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS"

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -54,8 +54,8 @@
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
----@field public grep_in_directory? "telescope" | fun(directory: string): nil "implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`"
----@field public grep_in_selected_files? "telescope" | fun(selected_files: Path[]): nil "called to grep on files that were selected in yazi. Defaults to `"telescope"`"
+---@field public grep_in_directory? "telescope" | "fzf-lua" | fun(directory: string): nil "implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`"
+---@field public grep_in_selected_files? "telescope" | "fzf-lua" | fun(selected_files: Path[]): nil "called to grep on files that were selected in yazi. Defaults to `"telescope"`"
 ---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil "called to start a replacement operation on some directory; by default uses grug-far.nvim"
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil "called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim"
 ---@field public resolve_relative_path_application? string "the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS"

--- a/spec/yazi/keybinding_helpers_spec.lua
+++ b/spec/yazi/keybinding_helpers_spec.lua
@@ -4,6 +4,7 @@ local keybinding_helpers = require("yazi.keybinding_helpers")
 local match = require("luassert.match")
 local plenary_path = require("plenary.path")
 local stub = require("luassert.stub")
+local spy = require("luassert.spy")
 
 describe("keybinding_helpers", function()
   local vim_cmd_stub
@@ -25,7 +26,9 @@ describe("keybinding_helpers", function()
   describe("grep_in_directory", function()
     it("should grep in the parent directory for a file", function()
       local config = config_module.default()
-      local s = stub(config.integrations, "grep_in_directory")
+      local s = spy.new(function() end)
+      ---@diagnostic disable-next-line: assign-type-mismatch
+      config.integrations.grep_in_directory = s
 
       keybinding_helpers.grep_in_directory(config, "/tmp/file")
 
@@ -34,7 +37,9 @@ describe("keybinding_helpers", function()
 
     it("should grep in the directory when a directory is passed", function()
       local config = config_module.default()
-      local s = stub(config.integrations, "grep_in_directory")
+      local s = spy.new(function() end)
+      ---@diagnostic disable-next-line: assign-type-mismatch
+      config.integrations.grep_in_directory = s
 
       keybinding_helpers.grep_in_directory(config, "/tmp")
 


### PR DESCRIPTION
Previously, it was only possible to use Telescope to grep (search for
text) in files and directories. This commit adds support for using
fzf-lua.nvim.

The default continues to be Telescope, but users can now set the
following values to opt into using fzf-lua:

```lua
---@type YaziConfig
{
  -- ... other settings
  integrations = {
    grep_in_directory = "fzf-lua",
    grep_in_selected_files = "fzf-lua",
  },
}
```