### PR TITLE
refactor: use jobstart instead of deprecated termopen

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -3,7 +3,9 @@ on: [pull_request]
 jobs:
   check-links:
     name: runner / linkspector
-    runs-on: ubuntu-latest
+    # Temporarily work around this issue by downgrading the runner OS
+    # https://github.com/UmbrellaDocs/action-linkspector/issues/32
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Run linkspector

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -32,7 +32,8 @@ function YaziProcess:start(config, paths, on_exit)
   local yazi_cmd = self.ya_process:get_yazi_command(paths)
   Log:debug(string.format("Opening yazi with the command: (%s).", yazi_cmd))
 
-  self.yazi_job_id = vim.fn.termopen(yazi_cmd, {
+  self.yazi_job_id = vim.fn.jobstart(yazi_cmd, {
+    term = true,
     env = {
       -- expose NVIM_CWD so that yazi keybindings can use it to offer basic
       -- neovim specific functionality

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -275,8 +275,8 @@ describe("opening the yazi in a terminal", function()
       vim.uv.cwd = spy.new(function()
         return "/tmp/fakedir"
       end)
-      local termopen_spy = spy.new(function() end)
-      vim.fn.termopen = termopen_spy
+      local jobstart_spy = spy.new(function() end)
+      vim.fn.jobstart = jobstart_spy
 
       require("yazi.process.yazi_process"):start(
         config,
@@ -284,11 +284,11 @@ describe("opening the yazi in a terminal", function()
         function() end
       )
 
-      assert(termopen_spy.calls[1])
-      assert(termopen_spy.calls[1].vals[2])
-      assert(termopen_spy.calls[1].vals[2].env)
-      local env = termopen_spy.calls[1].vals[2].env
+      assert(jobstart_spy.calls[1])
+      assert(jobstart_spy.calls[1].vals[2])
 
+      local env = jobstart_spy.calls[1].vals[2].env
+      assert(env)
       assert.equal(env.NVIM_CWD, "/tmp/fakedir")
     end
   )


### PR DESCRIPTION
This was deprecated on neovim nightly yesterday, and will probably be removed in the future. This should have no effect on the user.

https://github.com/neovim/neovim/pull/31343