### PR TITLE
feat: open yazi, hovering the visual selection file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ open yazi in a floating window in Neovim.
   splits that you have open.
 - Files selected in yazi can be opened in various ways: as the current buffer, a
   vertical split, a horizontal split, a new tab, as quickfix items...
+  - if you have selected a file path in visual mode, yazi will open that file
+    instead of current file
 - Integrations to other plugins and tools, if they are installed:
 
   - For [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and
@@ -76,6 +78,7 @@ This is the preferred installation method.
     -- 👇 in this section, choose your own keymappings!
     {
       "<leader>-",
+      mode = { "n", "v" },
       "<cmd>Yazi<cr>",
       desc = "Open yazi at the current file",
     },

--- a/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/opening-files.cy.ts
@@ -1,4 +1,6 @@
+import { flavors } from "@catppuccin/palette"
 import type { MyTestDirectoryFile } from "MyTestDirectory"
+import { rgbify } from "./utils/hover-utils"
 import {
   isFileNotSelectedInYazi,
   isFileSelectedInYazi,
@@ -35,6 +37,43 @@ describe("opening files", () => {
 
       // the file content should now be visible
       cy.contains("Hello 👋")
+    })
+  })
+
+  it("can open a file that was selected in yazi", () => {
+    cy.startNeovim().then((_nvim) => {
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // add text that contains a filename in the middle to test that limiting
+      // the recognition of the filename works
+      //
+      // use a complicated filename to test that the filename is recognized
+      // even in these cases
+      cy.typeIntoTerminal("ccletsgo./dir with spaces/file2.txt__moretext{esc}")
+
+      // select the file name
+      cy.typeIntoTerminal(`_f.vt_`)
+      cy.typeIntoTerminal(`{upArrow}`)
+
+      // wait until yazi is showing the file contents (so we know it has
+      // started up)
+      cy.contains("this is the second file")
+
+      cy.get("span")
+        .filter(
+          (_, el) =>
+            el.textContent?.includes(
+              "file2.txt" satisfies MyTestDirectoryFile,
+            ) ?? false,
+        )
+        .then((elements) => {
+          const matchingElements = elements.map((_, el) => {
+            return window.getComputedStyle(el).backgroundColor
+          })
+
+          return matchingElements.toArray()
+        })
+        .should("contain", rgbify(flavors.macchiato.colors.text.rgb))
     })
   })
 

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -48,7 +48,7 @@ local plugins = {
     dir = repo_root,
     event = "VeryLazy",
     keys = {
-      { "<up>", "<cmd>Yazi<cr>" },
+      { "<up>", mode = { "n", "v" }, "<cmd>Yazi<cr>" },
       { "<c-up>", "<cmd>Yazi toggle<cr>" },
     },
     ---@type YaziConfig

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "prettier": "3.4.2",
     "prettier-plugin-packagejson": "2.5.6"
   },
-  "packageManager": "pnpm@9.15.3"
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }


### PR DESCRIPTION
If you select a file path in visual mode and then press your yazi
keymapping, yazi will open and hover the file at that path.

How is this useful?

- sometimes you don't want to open a file in neovim because it will
  start LSP servers, other plugins, or other things that you don't need
  for your task
- you want to use yazi to move or rename the file, or copy its contents

NOTE: To use this feature, you will need to add a visual mode mapping
for yazi. You can find an example of this for lazy.nvim in the README
file.