### PR TITLE
ci: follow pnpm/action-setup's cache usage instructions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: pnpm/action-setup@v4.0.0
+        with:
+          # https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time
+          run_install: false
       - uses: actions/setup-node@v4.1.0
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,9 @@ jobs:
           luarocks_version: "3.11.1"
 
       - uses: pnpm/action-setup@v4.0.0
+        with:
+          # https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time
+          run_install: false
       - uses: actions/setup-node@v4.1.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
This might help speed up the jobs a bit, although it has not been an issue so far.