### PR TITLE
refactor: provide relative paths to grep_in_selected_files

### DIFF
--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -194,28 +194,32 @@ function YaziOpenerActions.grep_in_selected_files(config, chosen_files)
   end
 
   local plenary_path = require("plenary.path")
+
+  ---@type Path[]
   local paths = {}
   for _, path in ipairs(chosen_files) do
     table.insert(paths, plenary_path:new(path))
   end
 
+  -- pickers typically work with file paths relative to the cwd
   ---@type string[]
-  local files = {}
+  local files_relative = {}
   for _, path in ipairs(paths) do
-    files[#files + 1] = path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
+    files_relative[#files_relative + 1] =
+      path:make_relative(vim.uv.cwd()):gsub(" ", "\\ ")
   end
 
   if config.integrations.grep_in_selected_files == "telescope" then
     require("telescope.builtin").live_grep({
       search = "",
-      prompt_title = string.format("Grep in %d paths", #files),
-      search_dirs = files,
+      prompt_title = string.format("Grep in %d paths", #files_relative),
+      search_dirs = files_relative,
     })
   elseif config.integrations.grep_in_selected_files == "fzf-lua" then
-    require("fzf-lua").live_grep({ search_paths = files })
+    require("fzf-lua").live_grep({ search_paths = files_relative })
   else
     -- the user has a custom implementation. Call it.
-    config.integrations.grep_in_selected_files(paths)
+    config.integrations.grep_in_selected_files(paths, files_relative)
   end
 end
 

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -56,7 +56,7 @@
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
 ---@field public grep_in_directory? "telescope" | "fzf-lua" | fun(directory: string): nil "implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`"
----@field public grep_in_selected_files? "telescope" | "fzf-lua" | fun(selected_files: Path[]): nil "called to grep on files that were selected in yazi. Defaults to `"telescope"`"
+---@field public grep_in_selected_files? "telescope" | "fzf-lua" | fun(selected_files: Path[], relative_paths: string[]): nil "called to grep on files that were selected in yazi. Defaults to `"telescope"`"
 ---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil "called to start a replacement operation on some directory; by default uses grug-far.nvim"
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil "called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim"
 ---@field public resolve_relative_path_application? string "the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS"


### PR DESCRIPTION
This simplifies the implementation of the `grep_in_selected_files` integrations, as currently they will need to copy paste code to implement the most common use case (using relative_paths).

Solves https://github.com/mikavilpas/yazi.nvim/issues/703