### PR TITLE
feat: allow processing all yazi events as soon as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ You can optionally configure yazi.nvim by setting any of the options below.
       -- reported issues with this, and can set this to `true` to keep using
       -- the old `termopen` for the time being.
       nvim_0_10_termopen_fallback = false,
+
+      -- By default, this is `false`, which means yazi.nvim processes events in
+      -- a batch when the user closes yazi. If this is `true`, events are
+      -- processed immediately.
+      process_events_live = false,
     },
   },
 }

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -60,7 +60,9 @@ local plugins = {
       clipboard_register = '"',
       -- allows logging debug data, which can be shown in CI when cypress tests fail
       log_level = vim.log.levels.DEBUG,
-      future_features = {},
+      future_features = {
+        process_events_live = true,
+      },
       integrations = {
         grep_in_directory = "telescope",
       },

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -31,6 +31,7 @@ function M.default()
     open_for_directories = false,
     future_features = {
       nvim_0_10_termopen_fallback = jobstart_has_term,
+      process_events_live = false,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -26,6 +26,7 @@
 
 ---@class(exact) yazi.OptInFeatures
 ---@field nvim_0_10_termopen_fallback? boolean # Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart` (https://github.com/neovim/neovim/pull/31343). By default on nightly, this option is `false` and `jobstart` is used. Some users have reported issues with this, and can set this to `true` to keep using the old `termopen` for the time being.
+---@field process_events_live? boolean # By default, this is `false`, which means yazi.nvim processes events in a batch when the user closes yazi. If this is `true`, events are processed immediately.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -390,7 +390,7 @@ function M.bufdelete(bufnr)
     return require("snacks.bufdelete")
   end)
   if ok then
-    return bufdelete.delete({ buf = bufnr, force = true })
+    return bufdelete.delete({ buf = bufnr, force = true, wipe = true })
   else
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end


### PR DESCRIPTION
Issue
=====

Some yazi events are processed only when yazi exits. These include the following events:
- `rename` (a file was renamed)
- `bulk` (files were renamed using yazi's bulk rename feature)
- `move` (a file was moved)
- `delete` (you guessed it, a file was deleted)

The reason for this is that at the time I added support for handling these event types, yazi was not yet able to provide event information before it was completely closed.

Solution
========

Add a new configuration option, `process_events_live`, which defaults to `false` for now. When this option is `true`, all event types are processed as soon as possible.

It's recommended to add the https://github.com/folke/snacks.nvim plugin so that yazi.nvim can use it to delete buffers. By default, Neovim closes split windows when a buffer is deleted. I find this annoying, but snacks solves this well.

If this feature works well, this might become the default behavior in the future.