### PR TITLE
refactor: combine rename/move event handling into a single function

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -69,6 +69,12 @@ function M.yazi(config, input_path)
         )
       )
 
+      -- this is the legacy implementation used when
+      -- `future_features.process_events_live = false`. When that is used,
+      -- events should be processed in ya_process.lua and should not be
+      -- processed a second time here.
+      assert(#events == 0 or not config.future_features.process_events_live)
+
       yazi_event_handling.process_events_emitted_from_yazi(events)
 
       if last_directory == nil then

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -225,11 +225,9 @@ function YaProcess:process_events(events, forwarded_event_kinds)
           end
 
           if self.config.future_features.process_events_live == true then
-            vim.schedule(function()
-              require("yazi.event_handling.yazi_event_handling").process_events_emitted_from_yazi(
-                events
-              )
-            end)
+            require("yazi.event_handling.yazi_event_handling").process_events_emitted_from_yazi(
+              events
+            )
           end
         end)
       elseif forwarded_event_kinds[event.type] ~= nil then


### PR DESCRIPTION
refactor: remove extra vim.schedule in ya_process

refactor: assert events aren't processed twice