### PR TITLE
fix: renaming a file to its old name closed the buffer

### DIFF
--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -337,8 +337,13 @@ function M.get_open_buffers()
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     local path = vim.api.nvim_buf_get_name(bufnr)
     local type = vim.api.nvim_get_option_value("buftype", { buf = bufnr })
+    local is_listed =
+      vim.api.nvim_get_option_value("buflisted", { buf = bufnr })
 
-    local is_ordinary_file = path ~= vim.NIL and path ~= "" and type == ""
+    local is_ordinary_file = path ~= vim.NIL
+      and path ~= ""
+      and type == ""
+      and is_listed
     if is_ordinary_file then
       local renameable_buffer = RenameableBuffer.new(bufnr, path)
       open_buffers[#open_buffers + 1] = renameable_buffer
@@ -403,7 +408,7 @@ function M.rename_or_close_buffer(instruction)
   -- It causes an error to try to rename to a buffer that's already open.
   if M.is_buffer_open(instruction.path.filename) then
     pcall(function()
-      vim.api.nvim_buf_delete(instruction.bufnr, { force = true })
+      M.bufdelete(instruction.bufnr)
     end)
   end
 

--- a/spec/yazi/delete_spec.lua
+++ b/spec/yazi/delete_spec.lua
@@ -1,6 +1,7 @@
 local assert = require("luassert")
 local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 local reset = require("spec.yazi.helpers.reset")
+local buffers = require("spec.yazi.helpers.buffers")
 
 describe("process_delete_event", function()
   before_each(function()
@@ -8,7 +9,7 @@ describe("process_delete_event", function()
   end)
 
   it("deletes a buffer that matches the delete event exactly", function()
-    local buffer = vim.fn.bufadd("/abc/def")
+    local buffer = buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziDeleteEvent
     local event = {
@@ -27,7 +28,7 @@ describe("process_delete_event", function()
   end)
 
   it("deletes a buffer that matches the parent directory", function()
-    local buffer = vim.fn.bufadd("/abc/def")
+    local buffer = buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziDeleteEvent
     local event = {
@@ -46,7 +47,7 @@ describe("process_delete_event", function()
   end)
 
   it("doesn't delete a buffer that doesn't match the delete event", function()
-    vim.fn.bufadd("/abc/def")
+    buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziDeleteEvent
     local event = {
@@ -65,7 +66,7 @@ describe("process_delete_event", function()
   end)
 
   it("doesn't delete a buffer that was renamed to in a later event", function()
-    vim.fn.bufadd("/def/file")
+    buffers.add_listed_buffer("/def/file")
 
     ---@type YaziDeleteEvent
     local delete_event = {

--- a/spec/yazi/helpers/buffers.lua
+++ b/spec/yazi/helpers/buffers.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+function M.add_listed_buffer(path)
+  local buffer = vim.fn.bufadd(path)
+  vim.api.nvim_set_option_value("buflisted", true, { buf = buffer })
+  return buffer
+end
+
+return M

--- a/spec/yazi/move_spec.lua
+++ b/spec/yazi/move_spec.lua
@@ -1,6 +1,7 @@
 local assert = require("luassert")
 local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 local reset = require("spec.yazi.helpers.reset")
+local buffers = require("spec.yazi.helpers.buffers")
 
 describe("get_buffers_that_need_renaming_after_yazi_exited", function()
   before_each(function()
@@ -15,8 +16,8 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     }
 
     -- simulate buffers being opened
-    vim.fn.bufadd("/my-tmp/file1")
-    vim.fn.bufadd("/my-tmp/file_A")
+    buffers.add_listed_buffer("/my-tmp/file1")
+    buffers.add_listed_buffer("/my-tmp/file_A")
 
     local instructions =
       yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
@@ -40,7 +41,7 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
       }
 
       -- simulate the buffer being opened
-      vim.fn.bufadd("/my-tmp/dir1/file")
+      buffers.add_listed_buffer("/my-tmp/dir1/file")
 
       local instructions =
         yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
@@ -61,7 +62,7 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     }
 
     -- simulate the buffer being opened
-    vim.fn.bufadd("/my-tmp/dir1/file")
+    buffers.add_listed_buffer("/my-tmp/dir1/file")
 
     local instructions =
       yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(

--- a/spec/yazi/rename_spec.lua
+++ b/spec/yazi/rename_spec.lua
@@ -2,6 +2,7 @@ local assert = require("luassert")
 local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 local utils = require("yazi.utils")
 local reset = require("spec.yazi.helpers.reset")
+local buffers = require("spec.yazi.helpers.buffers")
 
 describe("get_buffers_that_need_renaming_after_yazi_exited", function()
   before_each(function()
@@ -16,8 +17,8 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     }
 
     -- simulate buffers being opened
-    vim.fn.bufadd("/my-tmp/file1")
-    vim.fn.bufadd("/my-tmp/file_A")
+    buffers.add_listed_buffer("/my-tmp/file1")
+    buffers.add_listed_buffer("/my-tmp/file_A")
 
     local rename_instructions =
       yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
@@ -41,7 +42,7 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
       }
 
       -- simulate the buffer being opened
-      vim.fn.bufadd("/my-tmp/dir1/file")
+      buffers.add_listed_buffer("/my-tmp/dir1/file")
 
       local rename_instructions =
         yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
@@ -62,7 +63,7 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     }
 
     -- simulate the buffer being opened
-    vim.fn.bufadd("/my-tmp/dir1/file")
+    buffers.add_listed_buffer("/my-tmp/dir1/file")
 
     local rename_instructions =
       yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
@@ -79,8 +80,8 @@ describe("process_events_emitted_from_yazi", function()
   end)
 
   it("closes a buffer that was renamed to another open buffer", function()
-    vim.fn.bufadd("/my-tmp/file1")
-    vim.fn.bufadd("/my-tmp/file2")
+    buffers.add_listed_buffer("/my-tmp/file1")
+    buffers.add_listed_buffer("/my-tmp/file2")
 
     ---@type YaziRenameEvent
     local event = {
@@ -102,8 +103,8 @@ describe("process_events_emitted_from_yazi", function()
   end)
 
   it("closes a buffer that was moved to another open buffer", function()
-    vim.fn.bufadd("/my-tmp/file1")
-    vim.fn.bufadd("/my-tmp/file2")
+    buffers.add_listed_buffer("/my-tmp/file1")
+    buffers.add_listed_buffer("/my-tmp/file2")
 
     ---@type YaziMoveEvent
     local event = {

--- a/spec/yazi/trash_spec.lua
+++ b/spec/yazi/trash_spec.lua
@@ -2,6 +2,7 @@ local assert = require("luassert")
 local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 local reset = require("spec.yazi.helpers.reset")
 local stub = require("luassert.stub")
+local buffers = require("spec.yazi.helpers.buffers")
 
 describe("process_trash_event", function()
   local snapshot
@@ -20,7 +21,7 @@ describe("process_trash_event", function()
   end)
 
   it("deletes a buffer that matches the trash event exactly", function()
-    local buffer = vim.fn.bufadd("/abc/def")
+    local buffer = buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziTrashEvent
     local event = {
@@ -40,7 +41,7 @@ describe("process_trash_event", function()
   end)
 
   it("deletes a buffer that matches the parent directory", function()
-    local buffer = vim.fn.bufadd("/abc/def")
+    local buffer = buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziTrashEvent
     local event = {
@@ -60,7 +61,7 @@ describe("process_trash_event", function()
   end)
 
   it("doesn't delete a buffer that doesn't match the trash event", function()
-    vim.fn.bufadd("/abc/def")
+    buffers.add_listed_buffer("/abc/def")
 
     ---@type YaziTrashEvent
     local event = {
@@ -75,7 +76,7 @@ describe("process_trash_event", function()
   end)
 
   it("doesn't delete a buffer that was renamed to in a later event", function()
-    vim.fn.bufadd("/def/file")
+    buffers.add_listed_buffer("/def/file")
 
     ---@type YaziTrashEvent
     local delete_event = {


### PR DESCRIPTION
Issue
=====

When renaming a file to a new name and back to its old name (a->b->a), the buffer/split is closed after the second rename.

This is caused by the buffer remaining as an unlisted buffer after the first rename. When the buffer is renamed back to its original name, the code thought that the buffer was already open and closed it.

Solution
========

Don't consider unlisted buffers as open buffers, avoiding the problem.