### PR TITLE
fix: `:Yazi toggle` not being able to hover a directory

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/toggling.cy.ts
@@ -1,3 +1,6 @@
+import { flavors } from "@catppuccin/palette"
+import { rgbify } from "./utils/hover-utils"
+
 describe("toggling yazi to pseudo-continue the previous session", () => {
   beforeEach(() => {
     cy.visit("/")
@@ -50,6 +53,44 @@ describe("toggling yazi to pseudo-continue the previous session", () => {
 
       // yazi should be visible, showing other files
       cy.contains(nvim.dir.contents["file2.txt"].name)
+    })
+  })
+
+  it("can toggle yazi, hovering a directory", () => {
+    // by default in yazi, starting and hovering a directory is not supported.
+    // Yazi displays the contents of the directory instead of hovering the
+    // directory. We work around this by sending a "reveal" event to yazi to
+    // hover the directory instead.
+    cy.startNeovim({ filename: "dir with spaces/file1.txt" }).then((nvim) => {
+      // wait until text on the start screen is visible
+      cy.contains("this is the first file")
+
+      // toggle yazi and set up a session that hovers a directory
+      cy.typeIntoTerminal("{upArrow}")
+
+      // yazi should be visible, showing other files
+      cy.contains(nvim.dir.contents["file2.txt"].name)
+
+      // move to the upper directory level. This will focus "dir with spaces"
+      cy.typeIntoTerminal("h")
+      cy.contains("dir with spaces").should(
+        "have.css",
+        "background-color",
+        rgbify(flavors.macchiato.colors.blue.rgb),
+      )
+
+      // close yazi
+      cy.contains("NOR")
+      cy.typeIntoTerminal("q")
+      cy.contains("NOR").should("not.exist")
+
+      // toggle yazi again. It should hover the same directory.
+      cy.typeIntoTerminal("{control+upArrow}")
+      cy.contains("dir with spaces").should(
+        "have.css",
+        "background-color",
+        rgbify(flavors.macchiato.colors.blue.rgb),
+      )
     })
   })
 })

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -18,8 +18,12 @@ end
 --- Tell yazi to focus (hover on) the given path.
 ---@see https://yazi-rs.github.io/docs/configuration/keymap#manager.reveal
 ---@param path string
+---@return vim.SystemObj
 function YaziProcessApi:reveal(path)
-  vim.system(
+  require("yazi.log"):debug(
+    string.format("Using ya to reveal path: '%s'", path)
+  )
+  return vim.system(
     { "ya", "emit-to", self.yazi_id, "reveal", "--str", path },
     { timeout = 1000 }
   )

--- a/spec/yazi/helpers/fake_yazi_process.lua
+++ b/spec/yazi/helpers/fake_yazi_process.lua
@@ -23,10 +23,10 @@ end
 
 -- Fake yazi process that instantly exits with the mocked data that was set up
 -- before.
----@param on_exit fun(code: integer, selected_files: string[], events: YaziEvent[], hovered_url: string | nil, last_cwd: Path | nil)
+---@param callbacks yazi.Callbacks
 ---@diagnostic disable-next-line: unused-local
-function M:start(_, _, on_exit)
-  on_exit(
+function M:start(_, _, callbacks)
+  callbacks.on_exit(
     M.mocks.code,
     M.mocks.selected_files,
     M.mocks.events,

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -285,7 +285,7 @@ describe("opening yazi in a terminal", function()
       require("yazi.process.yazi_process"):start(
         config,
         { path },
-        function() end
+        { on_exit = function() end, on_maybe_started = function() end }
       )
 
       local call = jobstart_spy.calls[#jobstart_spy.calls]


### PR DESCRIPTION
Issue
=====

When using `:Yazi toggle` after previously having hovered a directory, yazi is reopened hovering the contents of the directory instead of the directory itself.

Solution
========

Wait for yazi to start, and use `ya reveal` to make yazi focus on the directory. This takes 50-100ms of time which is very slightly janky, but it's much better to have an 80% solution than a 0% solution.

Closes https://github.com/mikavilpas/yazi.nvim/issues/727