### PR TITLE
ci: bump the integration-tests yazi version from v0.4.2 to v25.2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           # yazi-fm is the `yazi` executable
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
-          tag: v0.4.2
+          tag: v25.2.7
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98
@@ -57,7 +57,7 @@ jobs:
           # yazi-cli is the `ya` command line interface
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
-          tag: v0.4.2
+          tag: v25.2.7
           # commit:
           #   # https://github.com/sxyazi/yazi/commit/d72f90356b98
           #   d72f90356b98


### PR DESCRIPTION
https://github.com/sxyazi/yazi/releases/tag/v25.2.7 is out, let's test against that!