### PR TITLE
chore(eslint): migrate eslint to avoid pnpm dep hoisting issue

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/reading-events.cy.ts
@@ -343,7 +343,6 @@ describe("'rename' events", () => {
           luaCode: `return _G.yazi_closed_successfully_hook_test_results`,
         })
         .should((result) => {
-          debugger
           assert(result.value)
           assert(typeof result.value === "object")
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any

--- a/integration-tests/eslint.config.mjs
+++ b/integration-tests/eslint.config.mjs
@@ -1,18 +1,10 @@
-import { FlatCompat } from "@eslint/eslintrc"
-import js from "@eslint/js"
+import eslintConfigPrettier from "eslint-config-prettier"
 import noOnlyTests from "eslint-plugin-no-only-tests"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-})
+import eslint from "@eslint/js"
+import tseslint from "typescript-eslint"
 
-export default [
+export default tseslint.config(
   {
     ignores: [
       "**/vite.config.js",
@@ -23,11 +15,11 @@ export default [
       "cypress/support/tui-sandbox.ts",
     ],
   },
-  ...compat.extends(
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/strict-type-checked",
-    "prettier",
-  ),
+
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  tseslint.configs.strictTypeChecked,
+
   {
     plugins: {
       "no-only-tests": noOnlyTests,
@@ -96,4 +88,7 @@ export default [
       "@typescript-eslint/no-unused-vars": "off",
     },
   },
-]
+
+  // should be the last item
+  eslintConfigPrettier,
+)

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -15,17 +15,17 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
+    "@eslint/js": "9.20.0",
     "@tui-sandbox/library": "9.0.1",
     "@types/node": "22.13.1",
     "@types/tinycolor2": "1.4.6",
-    "@typescript-eslint/eslint-plugin": "8.23.0",
-    "@typescript-eslint/parser": "8.23.0",
     "concurrently": "9.1.2",
     "eslint": "9.20.0",
     "eslint-config-prettier": "10.0.1",
     "eslint-plugin-no-only-tests": "3.3.0",
     "tinycolor2": "1.6.0",
     "type-fest": "4.33.0",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "typescript-eslint": "8.23.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: 3.24.1
         version: 3.24.1
     devDependencies:
+      '@eslint/js':
+        specifier: 9.20.0
+        version: 9.20.0
       '@tui-sandbox/library':
         specifier: 9.0.1
         version: 9.0.1(cypress@14.0.2)(prettier@3.4.2)(type-fest@4.33.0)(typescript@5.7.3)
@@ -48,12 +51,6 @@ importers:
       '@types/tinycolor2':
         specifier: 1.4.6
         version: 1.4.6
-      '@typescript-eslint/eslint-plugin':
-        specifier: 8.23.0
-        version: 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(typescript@5.7.3)
-      '@typescript-eslint/parser':
-        specifier: 8.23.0
-        version: 8.23.0(eslint@9.20.0)(typescript@5.7.3)
       concurrently:
         specifier: 9.1.2
         version: 9.1.2
@@ -75,6 +72,9 @@ importers:
       typescript:
         specifier: 5.7.3
         version: 5.7.3
+      typescript-eslint:
+        specifier: 8.23.0
+        version: 8.23.0(eslint@9.20.0)(typescript@5.7.3)
 
 packages:
 
@@ -2344,6 +2344,13 @@ packages:
 
   typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
+
+  typescript-eslint@8.23.0:
+    resolution: {integrity: sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -5085,6 +5092,16 @@ snapshots:
       mime-types: 2.1.35
 
   typed-query-selector@2.12.0: {}
+
+  typescript-eslint@8.23.0(eslint@9.20.0)(typescript@5.7.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.23.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.23.0(eslint@9.20.0)(typescript@5.7.3)
+      eslint: 9.20.0
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.7.3: {}
 


### PR DESCRIPTION
Issue
=====

Eslint cannot be run after a clean install.

```sh
[Running: fd node_modules --no-ignore --prune -x rm -rf && pnpm i && cd integration-tests && pnpm eslint]
Scope: all 2 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +607
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 607, reused 607, downloaded 0, added 607, done

devDependencies:
+ @umbrelladocs/linkspector 0.3.13
+ markdownlint-cli2 0.17.2
+ prettier 3.4.2
+ prettier-plugin-organize-imports 4.1.0
+ prettier-plugin-packagejson 2.5.8

Done in 4.8s

> @yazi.nvim/integration-tests@0.0.0 eslint /Users/mikavilpas/git/yazi.nvim/integration-tests
> eslint --max-warnings=0 .

Oops! Something went wrong! :(

ESLint: 9.20.0

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/eslintrc' imported from /Users/mikavilpas/git/yazi.nvim/integration-tests/eslint.config.mjs
Did you mean to import "@eslint/eslintrc/dist/eslintrc.cjs"?
    at packageResolve (node:internal/modules/esm/resolve:857:9)
    at moduleResolve (node:internal/modules/esm/resolve:926:18)
    at defaultResolve (node:internal/modules/esm/resolve:1056:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:654:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:603:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:586:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:242:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49)
 ELIFECYCLE  Command failed with exit code 2.
[Command exited with 2, lasted 11.133123792s]
```

Solution
========

- Migrate the eslint config to the new flat config system.
- remove "legacy" typescript-eslint setup

Here is the PR where the breaking change was done
- https://github.com/pnpm/pnpm/issues/8378

More information about the "flat config"
- https://eslint.org/blog/2022/08/new-config-system-part-2/

Other references I used
- https://github.com/pnpm/pnpm/issues/8378
- https://typescript-eslint.io/packages/typescript-eslint/#migrating-from-legacy-config-setups
- https://github.com/sveltejs/cli/issues/374
- https://github.com/sveltejs/cli/pull/375
- https://github.com/nuxt/eslint/issues/539
- https://github.com/pnpm/pnpm/issues/9052