### PR TITLE
fix: snacks.picker not being in insert mode when opened

### DIFF
--- a/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/using-ya-to-read-events/integrations.cy.ts
@@ -238,6 +238,15 @@ describe("snacks.picker integration (grep)", () => {
       cy.typeIntoTerminal("vk")
       cy.typeIntoTerminal("{control+s}")
 
+      // wait until the snacks.picker is visible
+      cy.contains("Grep")
+      cy.contains("0/0")
+
+      // snacks.picker should have started in insert mode
+      nvim.runLuaCode({ luaCode: `return vim.fn.mode()` }).should((result) => {
+        expect(result.value).to.equal("i")
+      })
+
       // snacks.picker should be open now. Don't test it for now because it
       // might be unstable. If you want to try it manually, you can verify
       // that it does not find the text in should-be-excluded-file

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -157,9 +157,16 @@ function YaziOpenerActions.grep_in_directory(config, chosen_file)
       search_paths = { last_directory },
     })
   elseif config.integrations.grep_in_directory == "snacks.picker" then
-    require("snacks.picker").grep({
-      dirs = { last_directory },
-    })
+    vim.defer_fn(function()
+      -- HACK something seems to exit insert mode when the picker is shown.
+      -- Wait a bit to hack around this.
+      require("snacks.picker").grep({
+        dirs = { last_directory },
+        on_show = function()
+          vim.cmd("startinsert")
+        end,
+      })
+    end, 50)
   else
     -- the user has a custom implementation. Call it.
     config.integrations.grep_in_directory(last_directory)
@@ -199,9 +206,13 @@ function YaziOpenerActions.grep_in_selected_files(config, chosen_files)
   elseif config.integrations.grep_in_selected_files == "fzf-lua" then
     require("fzf-lua").live_grep({ search_paths = files_relative })
   elseif config.integrations.grep_in_selected_files == "snacks.picker" then
-    require("snacks.picker").grep({
-      dirs = files_relative,
-    })
+    vim.defer_fn(function()
+      -- HACK something seems to exit insert mode when the picker is shown.
+      -- Wait a bit to hack around this.
+      require("snacks.picker").grep({
+        dirs = files_relative,
+      })
+    end, 50)
   else
     -- the user has a custom implementation. Call it.
     config.integrations.grep_in_selected_files(paths, files_relative)


### PR DESCRIPTION
This is not a good fix because it's based on happenstance timing, not logic. I'm hoping this issue can be avoided in the future by using https://github.com/mikavilpas/yazi.nvim/issues/593