### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ This is the preferred installation method.
       desc = "Open the file manager in nvim's working directory",
     },
     {
-      -- NOTE: this requires a version of yazi that includes
-      -- https://github.com/sxyazi/yazi/pull/1305 from 2024-07-18
       "<c-up>",
       "<cmd>Yazi toggle<cr>",
       desc = "Resume the last yazi session",

--- a/repro.lua
+++ b/repro.lua
@@ -13,7 +13,7 @@ end
 
 -- bootstrap lazy
 local lazypath = root .. "/plugins/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",

--- a/repro.lua
+++ b/repro.lua
@@ -45,8 +45,6 @@ local plugins = {
         desc = "Open the file manager in nvim's working directory",
       },
       {
-        -- NOTE: this requires a version of yazi that includes
-        -- https://github.com/sxyazi/yazi/pull/1305 from 2024-07-18
         "<c-up>",
         "<cmd>Yazi toggle<cr>",
         desc = "Resume the last yazi session",


### PR DESCRIPTION
# docs: remove old note about yazi version

The yazi version in the comment has been stable for around 6 months, so
it should be very safe to remove.

# refactor(repro): modernize really old things

- vim.loop has been deprecated in neovim 0.10.0
  https://github.com/neovim/neovim/blob/c7d13f2895fa657ff3d9d45741f9abec25072b56/runtime/doc/deprecated.txt#L113
- `:Yazi toggle` has been stable for around 6 months