### PR TITLE
fix: not being able live delete buffers without snacks.bufdelete

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -200,7 +200,7 @@ function YaProcess:process_events(events, forwarded_event_kinds)
       )
       self.cwd = event.url
     else
-      if self.config.future_features.process_events_live == nil then
+      if not self.config.future_features.process_events_live then
         -- these events will be processed when yazi exits
         self.events[#self.events + 1] = event
       end

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -397,7 +397,9 @@ function M.bufdelete(bufnr)
   if ok then
     return bufdelete.delete({ buf = bufnr, force = true, wipe = true })
   else
-    vim.api.nvim_buf_delete(bufnr, { force = true })
+    vim.api.nvim_buf_call(bufnr, function()
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end
 end
 


### PR DESCRIPTION
Closes https://github.com/mikavilpas/yazi.nvim/issues/744