### PR TITLE
refactor(types): correctly allow passing a partial YaziConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This is the preferred installation method.
       desc = "Resume the last yazi session",
     },
   },
-  ---@type YaziConfig
+  ---@type YaziConfig | {}
   opts = {
     -- if you want to open yazi instead of netrw, see below for more info
     open_for_directories = false,
@@ -186,7 +186,7 @@ You can optionally configure yazi.nvim by setting any of the options below.
 {
   -- ... other lazy.nvim configuration from above
 
-  ---@type YaziConfig
+  ---@type YaziConfig | {}
   opts = {
     -- Below is the default configuration. It is optional to set these values.
     -- You can customize the configuration for each yazi call by passing it to

--- a/lazy.lua
+++ b/lazy.lua
@@ -28,7 +28,7 @@ return {
 
   {
     "mikavilpas/yazi.nvim",
-    ---@type YaziConfig
+    ---@type YaziConfig | {}
     opts = {},
     cmd = {
       "Yazi",

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -12,7 +12,7 @@ M.previous_state = {}
 
 ---@alias yazi.Arguments {reveal_path: string}
 
----@param config? YaziConfig?
+---@param config? YaziConfig | {}
 ---@param input_path? string
 ---@param args? yazi.Arguments
 function M.yazi(config, input_path, args)
@@ -186,7 +186,7 @@ end
 
 -- Open yazi, continuing from the previously hovered file. If no previous file
 -- was hovered, open yazi with the default path.
----@param config? YaziConfig?
+---@param config? YaziConfig | {}
 function M.toggle(config)
   local path = M.previous_state and M.previous_state.last_hovered or nil
 
@@ -207,7 +207,7 @@ end
 
 M.config = configModule.default()
 
----@param opts YaziConfig?
+---@param opts YaziConfig | {}
 function M.setup(opts)
   M.config =
     vim.tbl_deep_extend("force", configModule.default(), M.config, opts or {})

--- a/repro.lua
+++ b/repro.lua
@@ -50,7 +50,7 @@ local plugins = {
         desc = "Resume the last yazi session",
       },
     },
-    ---@type YaziConfig
+    ---@type YaziConfig | {}
     opts = {
       open_for_directories = false,
       log_level = vim.log.levels.DEBUG,


### PR DESCRIPTION
Issue
=====

When using lua_ls types, the lua LSP would complain when using the public yazi functions. They were meant to allow passing a partial YaziConfig, but the type definition required everything to be present.

The behaviour is that any overrides to the default config are used when calling the apis.

Solution
========

Allow passing a partial YaziConfig to the public functions.