### PR TITLE
feat!: process yazi events live by default (requires snacks.nvim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ This is the preferred installation method.
 }
 ```
 
-Notice that yazi.nvim adds some minimal dependencies for you automatically when
-using a plugin manager like lazy.nvim. To see which dependencies are installed,
-see [lazy.lua](./lazy.lua). If you are not using lazy.nvim (or
+Notice that yazi.nvim adds and lazy loads some minimal dependencies for you
+automatically when using a plugin manager like lazy.nvim. To see which
+dependencies are installed, see [lazy.lua](./lazy.lua). If you are not using
+lazy.nvim (or
 [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file)),
 you need to install the dependencies yourself. Also see the discussion in
 [issue 306](https://github.com/mikavilpas/yazi.nvim/issues/306) and examples of
@@ -183,7 +184,8 @@ These are the default keybindings that are available when yazi is open:
 You can optionally configure yazi.nvim by setting any of the options below.
 
 ```lua
-{
+
+return {
   -- ... other lazy.nvim configuration from above
 
   ---@type YaziConfig | {}
@@ -317,10 +319,11 @@ You can optionally configure yazi.nvim by setting any of the options below.
       -- the old `termopen` for the time being.
       nvim_0_10_termopen_fallback = false,
 
-      -- By default, this is `false`, which means yazi.nvim processes events in
-      -- a batch when the user closes yazi. If this is `true`, events are
+      -- By default, this is `true`, which means yazi.nvim processes events
+      -- before yazi has been closed. If this is `false`, events are processed
+      -- in a batch when the user closes yazi. If this is `true`, events are
       -- processed immediately.
-      process_events_live = false,
+      process_events_live = true,
     },
   },
 }

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -60,9 +60,7 @@ local plugins = {
       clipboard_register = '"',
       -- allows logging debug data, which can be shown in CI when cypress tests fail
       log_level = vim.log.levels.DEBUG,
-      future_features = {
-        process_events_live = true,
-      },
+      future_features = {},
       integrations = {
         grep_in_directory = "telescope",
       },

--- a/lazy.lua
+++ b/lazy.lua
@@ -15,6 +15,7 @@ return {
   --
   -- https://github.com/nvim-lua/plenary.nvim/
   { "nvim-lua/plenary.nvim", lazy = true },
+  { "folke/snacks.nvim", lazy = true },
 
   --
   -- TODO enable after https://github.com/nvim-neorocks/nvim-busted-action/issues/4 is resolved

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -31,7 +31,7 @@ function M.default()
     open_for_directories = false,
     future_features = {
       nvim_0_10_termopen_fallback = jobstart_has_term,
-      process_events_live = false,
+      process_events_live = true,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -26,7 +26,7 @@
 
 ---@class(exact) yazi.OptInFeatures
 ---@field nvim_0_10_termopen_fallback? boolean # Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart` (https://github.com/neovim/neovim/pull/31343). By default on nightly, this option is `false` and `jobstart` is used. Some users have reported issues with this, and can set this to `true` to keep using the old `termopen` for the time being.
----@field process_events_live? boolean # By default, this is `false`, which means yazi.nvim processes events in a batch when the user closes yazi. If this is `true`, events are processed immediately.
+---@field process_events_live? boolean # By default, this is `true`, which means yazi.nvim processes events before yazi has been closed. If this is `false`, events are processed in a batch when the user closes yazi. If this is `true`, events are processed immediately.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 


### PR DESCRIPTION
BREAKING CHANGE: This change now requires
https://github.com/folke/snacks.nvim to be installed. Users of [lazy.nvim](https://lazy.folke.io/) and
[rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim) should have this dependency automatically installed.

About a month ago, `process_events_live=false` was introduced an an opt-in feature in https://github.com/mikavilpas/yazi.nvim/pull/718. It allows processing yazi events, such as file renames, immediately instead of in a batch when yazi is closed.

If you are unable to install snacks.nvim, you can still disable this feature for some time by setting `future_features.process_events_live = false` in your yazi.nvim configuration, so that you have some time to migrate. See the README for more information.