### PR TITLE
docs: add note about snacks.nvim dependency as per 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ First, make sure you have the requirements:
 - yazi [0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) or later
 - New features might require a recent version of yazi (see
   [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md))
-- [snacks.nvim](https://github.com/folke/snacks.nvim)
+- [snacks.nvim](https://github.com/folke/snacks.nvim) (for usage with `process_events_live`)
 
 > [!TIP]
 >

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ First, make sure you have the requirements:
 - yazi [0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) or later
 - New features might require a recent version of yazi (see
   [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md))
-- [snacks.nvim](https://github.com/folke/snacks.nvim) (for usage with `process_events_live`)
+- [snacks.nvim](https://github.com/folke/snacks.nvim) (for usage with
+  `process_events_live`)
 
 > [!TIP]
 >

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ First, make sure you have the requirements:
 - yazi [0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) or later
 - New features might require a recent version of yazi (see
   [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md))
+- [snacks.nvim](https://github.com/folke/snacks.nvim)
 
 > [!TIP]
 >


### PR DESCRIPTION
As per [Release 8.0](https://github.com/mikavilpas/yazi.nvim/pull/770), [snacks.nvim](https://github.com/folke/snacks.nvim) is now a required dependency for usage of `process_events_live` therefore this PR adds this information in `README` to accomodate users not using `lazy.nvim` or `rocks.nvim`.