### PR TITLE
docs: clarify that snacks is a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This is the preferred installation method.
 {
   "mikavilpas/yazi.nvim",
   event = "VeryLazy",
+  dependencies = { "folke/snacks.nvim", lazy = true },
   keys = {
     -- 👇 in this section, choose your own keymappings!
     {


### PR DESCRIPTION
Adding it explicitly is optional if you're using lazy.nvim and maybe also for rocks.nvim, but it's a good idea to make it very clear that it's a dependency for users.

Closes https://github.com/mikavilpas/yazi.nvim/issues/774