### PR TITLE
refactor!: don't install snacks.nvim automatically

### DIFF
--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -7,7 +7,6 @@ import type {
   GenericTerminalBrowserApi,
 } from "@tui-sandbox/library/dist/src/browser/neovim-client"
 import type {
-  BlockingCommandClientInput,
   ExCommandClientInput,
   LuaCodeClientInput,
 } from "@tui-sandbox/library/dist/src/server/server"
@@ -18,6 +17,7 @@ import type {
   StartNeovimGenericArguments,
   TestDirectory,
 } from "@tui-sandbox/library/dist/src/server/types"
+import type { BlockingCommandClientInput } from "@tui-sandbox/library/src/server/blockingCommandInputSchema"
 import type { StartTerminalGenericArguments } from "@tui-sandbox/library/src/server/terminal/TerminalTestApplication"
 import type { OverrideProperties } from "type-fest"
 import type {
@@ -33,7 +33,7 @@ export type TerminalTestApplicationContext = {
   /** Runs a shell command in a blocking manner, waiting for the command to
    * finish before returning. Requires the terminal to be running. */
   runBlockingShellCommand(
-    input: BlockingCommandClientInput,
+    input: MyBlockingCommandClientInput,
   ): Cypress.Chainable<BlockingShellCommandOutput>
 
   /** The test directory, providing type-safe access to its file and directory structure */
@@ -49,7 +49,7 @@ export type NeovimContext = {
   /** Runs a shell command in a blocking manner, waiting for the command to
    * finish before returning. Requires neovim to be running. */
   runBlockingShellCommand(
-    input: BlockingCommandClientInput,
+    input: MyBlockingCommandClientInput,
   ): Cypress.Chainable<BlockingShellCommandOutput>
 
   /** Runs a shell command in a blocking manner, waiting for the command to
@@ -162,6 +162,11 @@ before(function () {
   cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
 })
 
+export type MyBlockingCommandClientInput = OverrideProperties<
+  BlockingCommandClientInput,
+  { cwdRelative?: MyTestDirectoryFile | undefined }
+>
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -180,7 +185,7 @@ declare global {
       /** Runs a shell command in a blocking manner, waiting for the command to
        * finish before returning. Requires neovim to be running. */
       nvim_runBlockingShellCommand(
-        input: BlockingCommandClientInput,
+        input: MyBlockingCommandClientInput,
       ): Chainable<BlockingShellCommandOutput>
 
       nvim_runLuaCode(input: LuaCodeClientInput): Chainable<RunLuaCodeOutput>
@@ -193,7 +198,7 @@ declare global {
       ): Chainable<RunExCommandOutput>
 
       terminal_runBlockingShellCommand(
-        input: BlockingCommandClientInput,
+        input: MyBlockingCommandClientInput,
       ): Chainable<BlockingShellCommandOutput>
     }
   }

--- a/lazy.lua
+++ b/lazy.lua
@@ -15,7 +15,7 @@ return {
   --
   -- https://github.com/nvim-lua/plenary.nvim/
   { "nvim-lua/plenary.nvim", lazy = true },
-  { "folke/snacks.nvim", lazy = true },
+  -- { "folke/snacks.nvim", lazy = true },
 
   --
   -- TODO enable after https://github.com/nvim-neorocks/nvim-busted-action/issues/4 is resolved

--- a/repro.lua
+++ b/repro.lua
@@ -32,6 +32,7 @@ local plugins = {
   {
     "mikavilpas/yazi.nvim",
     event = "VeryLazy",
+    dependencies = { "folke/snacks.nvim", lazy = true },
     keys = {
       {
         "<leader>-",


### PR DESCRIPTION
BREAKING CHANGE: to migrate, you may need to add snacks.nvim as a
dependency manually if your neovim does not already have it from another
source. You can copy it from the instructions in the readme file.

Issue
=====

Previously, snacks.nvim was installed automatically. This was done so
that users don't have to add it as a dependency manually. This caused
confusion for users:

- https://github.com/mikavilpas/yazi.nvim/issues/774
- https://github.com/mikavilpas/yazi.nvim/issues/783

It was also found that it's not possible to not install snacks.nvim if
it's added this way. This seems to bother some users.

Solution
========

As snacks.nvim is not a hard dependency yet, we can still require
installing it manually. This way, some users can choose to remove it if
they don't want it.

It might become a hard dependency in the future, though.

Closes https://github.com/mikavilpas/yazi.nvim/issues/783