### PR TITLE
fix: publishing move events to other nvim plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
+      - run: pnpm tui neovim prepare
+        working-directory: integration-tests
 
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.22.0",
-    "@tui-sandbox/library": "9.6.0",
+    "@tui-sandbox/library": "10.0.0",
     "@types/node": "22.13.10",
     "@types/tinycolor2": "1.4.6",
     "concurrently": "9.1.2",

--- a/lua/yazi/event_handling/nvim_event_handling.lua
+++ b/lua/yazi/event_handling/nvim_event_handling.lua
@@ -19,8 +19,16 @@ function M.emit_renamed_or_moved_event(event)
     changes = {},
   }
 
-  if event.type == "move" or event.type == "rename" then
-    event_data.changes[event.data.from] = event.data.to
+  if event.type == "move" then
+    ---@type YaziMoveEvent
+    local move_event = event
+    for _, item in ipairs(move_event.data.items) do
+      event_data.changes[item.from] = item.to
+    end
+  elseif event.type == "rename" then
+    ---@type YaziRenameEvent
+    local rename_event = event
+    event_data.changes[rename_event.data.from] = rename_event.data.to
   elseif event.type == "bulk" then
     event_data.changes = event.changes
   end

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -72,6 +72,7 @@ end
 local function handle_rename_move_bulk_event(event_data)
   local rename_instructions =
     M.get_buffers_that_need_renaming_after_yazi_exited(event_data)
+
   for _, instruction in ipairs(rename_instructions) do
     utils.rename_or_close_buffer(instruction)
   end
@@ -86,8 +87,10 @@ function M.process_events_emitted_from_yazi(events)
 
       handle_rename_move_bulk_event(event.data)
     elseif event.type == "move" then
-      ---@cast event YaziMoveEvent
-      for _, item in ipairs(event.data.items) do
+      ---@type YaziMoveEvent
+      local move_event = event
+
+      for _, item in ipairs(move_event.data.items) do
         lsp_rename.file_renamed(item.from, item.to)
 
         handle_rename_move_bulk_event(item)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 9.22.0
         version: 9.22.0
       '@tui-sandbox/library':
-        specifier: 9.6.0
-        version: 9.6.0(cypress@14.1.0)(prettier@3.5.3)(type-fest@4.37.0)(typescript@5.8.2)
+        specifier: 10.0.0
+        version: 10.0.0(cypress@14.1.0)(prettier@3.5.3)(type-fest@4.37.0)(typescript@5.8.2)
       '@types/node':
         specifier: 22.13.10
         version: 22.13.10
@@ -374,19 +374,19 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@trpc/client@11.0.0-rc.824':
-    resolution: {integrity: sha512-3JMsgiMrCEeblrzu7ScTjipYaeEmegbnM5ZPmqqkPIbXcnth/TwH5tRr+nQbLSU/NGkWJWsjgEq7bM0BV17sJw==}
+  '@trpc/client@11.0.0-rc.828':
+    resolution: {integrity: sha512-pV2bELnPqH7S2R1wBH6OB7lOi61ELt8CEcvHuxVM2YhL4hP408tzKT0YvNBo4GVqc8So/1ncpXJyRJQG0o6rsQ==}
     peerDependencies:
-      '@trpc/server': 11.0.0-rc.824+b21849468
+      '@trpc/server': 11.0.0-rc.828+322552736
       typescript: '>=5.7.2'
 
-  '@trpc/server@11.0.0-rc.824':
-    resolution: {integrity: sha512-6u6CZ/x+oe2bZDhOo5h0wonbMU3svPe8hs6Dr2ymrU+23NAHE6tHtROAX+dKrMzup9KJcqyAabuFRYHy2H0tjw==}
+  '@trpc/server@11.0.0-rc.828':
+    resolution: {integrity: sha512-+dvcIcE5QPy52cz4rqwfUqk+WQDYAH3Xri+u2t0NdzIoo78fnL14if8oSZXAPU1bCmWGyR1k/0m5rSQ7AZaKlQ==}
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@9.6.0':
-    resolution: {integrity: sha512-a6hJWFSEifk0zV2L+b6ScxigRPiCuiE2npXIuKH/hqhgGEqGvkUoQqliZ+l3zrKp0XgtVHbuwGh58SkmeKfRAQ==}
+  '@tui-sandbox/library@10.0.0':
+    resolution: {integrity: sha512-3yyrI354YirnW+WZHfs0Ma4aHhON8af/4IAeOkEn85rg41bgSI4TA+L5PgOzW1AkIOYcSeWPeZp8k02nOeOOiQ==}
     hasBin: true
     peerDependencies:
       cypress: ^13 || ^14
@@ -2774,20 +2774,20 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@trpc/client@11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.8.2))(typescript@5.8.2)':
+  '@trpc/client@11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)':
     dependencies:
-      '@trpc/server': 11.0.0-rc.824(typescript@5.8.2)
+      '@trpc/server': 11.0.0-rc.828(typescript@5.8.2)
       typescript: 5.8.2
 
-  '@trpc/server@11.0.0-rc.824(typescript@5.8.2)':
+  '@trpc/server@11.0.0-rc.828(typescript@5.8.2)':
     dependencies:
       typescript: 5.8.2
 
-  '@tui-sandbox/library@9.6.0(cypress@14.1.0)(prettier@3.5.3)(type-fest@4.37.0)(typescript@5.8.2)':
+  '@tui-sandbox/library@10.0.0(cypress@14.1.0)(prettier@3.5.3)(type-fest@4.37.0)(typescript@5.8.2)':
     dependencies:
       '@catppuccin/palette': 1.7.1
-      '@trpc/client': 11.0.0-rc.824(@trpc/server@11.0.0-rc.824(typescript@5.8.2))(typescript@5.8.2)
-      '@trpc/server': 11.0.0-rc.824(typescript@5.8.2)
+      '@trpc/client': 11.0.0-rc.828(@trpc/server@11.0.0-rc.828(typescript@5.8.2))(typescript@5.8.2)
+      '@trpc/server': 11.0.0-rc.828(typescript@5.8.2)
       '@xterm/addon-attach': 0.11.0(@xterm/xterm@5.5.0)
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/xterm': 5.5.0

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -179,8 +179,12 @@ describe("process_events()", function()
             timestamp = "2021-09-01T12:00:00Z",
             id = "rename_123",
             data = {
-              from = "/tmp/old_path",
-              to = "/tmp/new_path",
+              items = {
+                {
+                  from = "/tmp/old_path",
+                  to = "/tmp/new_path",
+                },
+              },
             },
           },
         }
@@ -194,6 +198,7 @@ describe("process_events()", function()
         })
 
         ya:process_events(events, {})
+
         vim.wait(2000, function()
           return #event_callback.calls > 0
         end)


### PR DESCRIPTION
fix: publishing move events to other nvim plugins

It would silently crash when trying to publish move events to other nvim
plugins. I don't think this is a huge issue since the feature does not
seem to be widely used.

It might be that it never actually worked for move events, but did work
for rename and bulk events.

For a description of this event publishing feature, see
https://github.com/mikavilpas/yazi.nvim/pull/495