### PR TITLE
feat: support `winborder` setting on Neovim nightly (0.11+)

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -23,6 +23,18 @@ function M.default()
     relpath = "realpath"
   end
 
+  local border = "rounded"
+  pcall(function()
+    -- Neovim 0.11 supports configuring floating window borders for all plugins
+    -- centrally with the "winborder" setting. Older Neovim versions do not
+    -- have this available, so we need to prevent the "Unknown option
+    -- 'winborder'" error which happens if the option is not available.
+    -- https://github.com/neovim/neovim/pull/31074
+    if vim.o.winborder ~= "" then
+      border = vim.o.winborder
+    end
+  end)
+
   local jobstart_has_term = M.JOBSTART_HAS_TERM()
 
   ---@type YaziConfig
@@ -93,7 +105,7 @@ function M.default()
 
     floating_window_scaling_factor = 0.9,
     yazi_floating_window_winblend = 0,
-    yazi_floating_window_border = "rounded",
+    yazi_floating_window_border = border,
   }
 end
 


### PR DESCRIPTION
Neovim 0.11 supports configuring floating window borders for all plugins centrally with the "winborder" setting. If this is set, it is used by default. Otherwise the previous behaviour is preserved.

https://github.com/neovim/neovim/pull/31074