### PR TITLE
fix: don't restore the previous buffer when yazi is closed

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -44,7 +44,6 @@ function M.yazi(config, input_path, args)
   local path = paths[1]
 
   local prev_win = vim.api.nvim_get_current_win()
-  local prev_buf = vim.api.nvim_get_current_buf()
 
   config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
 
@@ -142,7 +141,7 @@ function M.yazi(config, input_path, args)
         string.format("Resolved the last_directory to %s", last_directory)
       )
 
-      utils.on_yazi_exited(prev_win, prev_buf, win, config, selected_files, {
+      utils.on_yazi_exited(prev_win, win, config, selected_files, {
         last_directory = last_directory,
       })
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -454,19 +454,11 @@ function M.rename_or_close_buffer(instruction)
 end
 
 ---@param prev_win integer
----@param prev_buf integer
 ---@param window YaziFloatingWindow
 ---@param config YaziConfig
 ---@param selected_files string[]
 ---@param state YaziClosedState
-function M.on_yazi_exited(
-  prev_win,
-  prev_buf,
-  window,
-  config,
-  selected_files,
-  state
-)
+function M.on_yazi_exited(prev_win, window, config, selected_files, state)
   vim.cmd("silent! :checktime")
 
   window:close()
@@ -475,10 +467,6 @@ function M.on_yazi_exited(
     -- sanity check: make sure the previous window and buffer are still valid
     if not vim.api.nvim_win_is_valid(prev_win) then
       return
-    end
-
-    if vim.api.nvim_buf_is_valid(prev_buf) then
-      vim.api.nvim_set_current_buf(prev_buf)
     end
   end
 

--- a/spec/yazi/relative_path_spec.lua
+++ b/spec/yazi/relative_path_spec.lua
@@ -19,7 +19,7 @@ describe("relative_path", function()
   before_each(function()
     snapshot = assert:snapshot()
     -- use the defaults, which set realpath and grealpath depending on the OS
-    yazi.setup()
+    yazi.setup({})
 
     stub(vim.fn, "executable", function(command)
       if command == "realpath" or command == "grealpath" then


### PR DESCRIPTION
# fix: don't restore the previous buffer when yazi is closed

Sometimes when using vertical splits, I noticed that when yazi is
closed, one of the splits switches to a different buffer. I was unable
to reproduce this issue consistently, but I have had this happen every
once in a while for the last two weeks.

It seems like I added some logic to on_yazi_exited that restores the
previous buffer, but I don't think that's necessary - it does not seem
to be doing anything.

I'm hoping this will resolve the issue and not cause any (untested)
features to break, but I think it should be quite safe.

# refactor(tests): fix missing argument warning

Did not cause any issues though

