### PR TITLE
refactor!: remove 0.11 nightly termopen fallback logic

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -2,17 +2,6 @@
 
 local M = {}
 
--- https://github.com/ibhagwan/fzf-lua/issues/1732#issuecomment-2601200097
----@return boolean
-function M.JOBSTART_HAS_TERM()
-  local ok, msg = pcall(function()
-    return vim.fn.jobstart("", { term = 1 })
-  end)
-  return not ok
-    and msg:match([[Vim:E475: Invalid argument: 'term' must be Boolean]])
-      ~= nil
-end
-
 function M.default()
   local openers = require("yazi.openers")
 
@@ -35,14 +24,12 @@ function M.default()
     end
   end)
 
-  local jobstart_has_term = M.JOBSTART_HAS_TERM()
-
   ---@type YaziConfig
   return {
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
     future_features = {
-      nvim_0_10_termopen_fallback = jobstart_has_term,
+      use_nvim_0_10_termopen = vim.fn.has("nvim-0.11") ~= 1,
       process_events_live = true,
     },
     open_multiple_tabs = false,

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -36,10 +36,7 @@ function YaziProcess:start(config, paths, callbacks)
   local yazi_cmd = self.ya_process:get_yazi_command(paths)
   Log:debug(string.format("Opening yazi with the command: (%s).", yazi_cmd))
 
-  if
-    vim.fn.has("nvim-0.11") == 1
-    and config.future_features.nvim_0_10_termopen_fallback
-  then
+  if not config.future_features.use_nvim_0_10_termopen then
     Log:debug("Using nvim-0.11 jobstart to start yazi.")
     self.yazi_job_id = vim.fn.jobstart(yazi_cmd, {
       term = true,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -25,7 +25,7 @@
 ---@field public future_features? yazi.OptInFeatures # Features that are not yet stable, but can be tested by the user. These features might change or be removed in the future. They may also become built-in features that are on by default, making it unnecessary to opt into using them.
 
 ---@class(exact) yazi.OptInFeatures
----@field nvim_0_10_termopen_fallback? boolean # Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart` (https://github.com/neovim/neovim/pull/31343). By default on nightly, this option is `false` and `jobstart` is used. Some users have reported issues with this, and can set this to `true` to keep using the old `termopen` for the time being.
+---@field use_nvim_0_10_termopen? boolean # Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart` (https://github.com/neovim/neovim/pull/31343). By default on nightly, this option is `false` and `jobstart` is used. Some users have reported issues with this, and can set this to `true` to keep using the old `termopen` for the time being.
 ---@field process_events_live? boolean # By default, this is `true`, which means yazi.nvim processes events before yazi has been closed. If this is `false`, events are processed in a batch when the user closes yazi. If this is `true`, events are processed immediately.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled


### PR DESCRIPTION
BREAKING CHANGE: If you're using an old nightly Neovim version (older than 2 months) and cannot open yazi.nvim after this, you should update your nightly Neovim. If that is not possible, you can set `future_features.use_nvim_0_10_termopen=true` in your config to work around the issue. I will keep that around for a while, but eventually it might be removed.

Some background information:

This was introduced in
- https://github.com/neovim/neovim/pull/31343 (Dec 19, 2024)
- https://github.com/mikavilpas/yazi.nvim/pull/652 (Jan 6, 2025)

But then it produced issues due to outdated nightly versions that were fixed here
- https://github.com/mikavilpas/yazi.nvim/pull/696 (Jan 23, 2025)

The workaround was originally copied from
https://github.com/ibhagwan/fzf-lua/issues/1732#issuecomment-2601200097 (Jan 19, 2025)