### PR TITLE
fix: quickfix items not being processable with `:cfdo 1t1`

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -213,8 +213,8 @@ describe("opening files", () => {
       cy.contains("-- TERMINAL --").should("not.exist")
 
       // items in the quickfix list should now be visible
-      cy.contains(`${nvim.dir.contents["file2.txt"].name}||`)
-      cy.contains(`${nvim.dir.contents["file3.txt"].name}||`)
+      cy.contains(`${nvim.dir.contents["file2.txt"].name}|1 col 1|`)
+      cy.contains(`${nvim.dir.contents["file3.txt"].name}|1 col 1|`)
     })
   })
 

--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -46,9 +46,12 @@ function M.send_files_to_quickfix_list(chosen_files)
         path = file .. "/"
       end
 
+      ---@type vim.quickfix.entry
       return {
         filename = path,
         text = path,
+        col = 1,
+        lnum = 1,
       }
     end, chosen_files),
   })


### PR DESCRIPTION
That command should duplicate the first line (`:t` is the same as `:copy`)

Closes https://github.com/mikavilpas/yazi.nvim/issues/857