### PR TITLE
docs: remove recommendation for lazy loading snacks.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ you need to install the dependencies yourself. Also see the discussion in
 {
   "mikavilpas/yazi.nvim",
   event = "VeryLazy",
-  dependencies = { "folke/snacks.nvim", lazy = true },
+  dependencies = {
+    -- check the installation instructions at
+    -- https://github.com/folke/snacks.nvim
+    "folke/snacks.nvim"
+  },
   keys = {
     -- 👇 in this section, choose your own keymappings!
     {

--- a/repro.lua
+++ b/repro.lua
@@ -32,7 +32,15 @@ local plugins = {
   {
     "mikavilpas/yazi.nvim",
     event = "VeryLazy",
-    dependencies = { "folke/snacks.nvim", lazy = true },
+    dependencies = {
+      {
+        -- https://github.com/folke/snacks.nvim
+        "folke/snacks.nvim",
+        lazy = false,
+        priority = 1000,
+        opts = {},
+      },
+    },
     keys = {
       {
         "<leader>-",


### PR DESCRIPTION
# docs: remove recommendation for lazy loading snacks.nvim

Issue
=====

Lazy loading snacks.nvim causes the following error:

```vim
:checkhealth snacks

- ⚠️ WARNING `snacks.nvim` should not be lazy-loaded. Add `lazy=false` to the plugin spec
```

This has caused issues for at least one user (see the issue below).

Solution
========

Don't lazy load snacks and avoid the error.

Closes https://github.com/mikavilpas/yazi.nvim/issues/866

