### PR TITLE
fix: sending `i` on startup activating yazi actions

### DIFF
--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -135,6 +135,12 @@ Cypress.Commands.add(
   },
 )
 
+Cypress.Commands.add("nvim_isRunning", () => {
+  return cy.window().then(async (_) => {
+    return !!testNeovim
+  })
+})
+
 Cypress.Commands.add(
   "startTerminalApplication",
   (args: StartTerminalGenericArguments) => {
@@ -216,6 +222,10 @@ declare global {
       nvim_runExCommand(
         input: ExCommandClientInput,
       ): Chainable<RunExCommandOutput>
+
+      /** Returns true if neovim is running. Useful to conditionally run
+       * afterEach actions based on whether it's running. */
+      nvim_isRunning(): Chainable<boolean>
 
       terminal_runBlockingShellCommand(
         input: MyBlockingCommandClientInput,

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@catppuccin/palette": "1.7.1",
-    "cypress": "14.2.1",
+    "cypress": "14.3.0",
     "wait-on": "8.0.3",
     "zod": "3.24.2"
   },
@@ -21,7 +21,7 @@
     "@types/tinycolor2": "1.4.6",
     "concurrently": "9.1.2",
     "eslint": "9.24.0",
-    "eslint-config-prettier": "10.1.1",
+    "eslint-config-prettier": "10.1.2",
     "eslint-plugin-no-only-tests": "3.3.0",
     "tinycolor2": "1.6.0",
     "type-fest": "4.39.1",

--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -47,14 +47,6 @@ function M.hijack_netrw(yazi_augroup)
 
       Log:debug(string.format("Opening yazi for directory %s", file))
       require("yazi").yazi(M.config, file)
-
-      -- HACK: for some reason, the cursor is not in insert mode when opening
-      -- yazi from the command line with `neovim .`, so just simulate
-      -- pressing "i" to enter insert mode :) It did nothing when when I
-      -- tried using vim.cmd('startinsert') or vim.cmd('normal! i')
-      if vim.fn.mode(true) == "t" then
-        vim.api.nvim_feedkeys("i", "n", false)
-      end
     end)
   end
 

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -162,6 +162,14 @@ function YaziFloatingWindow:open_and_display()
   -- the terminal window opens which-key and ignores the keypress.
   vim.keymap.set("t", "<esc>", "<esc>", { buffer = yazi_buffer })
 
+  -- HACK: for some reason, the cursor is not in insert mode when opening
+  -- yazi from the command line with `neovim .`, so just simulate
+  -- pressing "i" to enter insert mode :) It did nothing when when I
+  -- tried using vim.cmd('startinsert') or vim.cmd('normal! i')
+  if vim.fn.mode(true) == "t" then
+    vim.api.nvim_feedkeys("i", "n", false)
+  end
+
   return self
 end
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 1.7.1
         version: 1.7.1
       cypress:
-        specifier: 14.2.1
-        version: 14.2.1
+        specifier: 14.3.0
+        version: 14.3.0
       wait-on:
         specifier: 8.0.3
         version: 8.0.3
@@ -44,7 +44,7 @@ importers:
         version: 9.24.0
       '@tui-sandbox/library':
         specifier: 10.2.0
-        version: 10.2.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.39.1)(typescript@5.8.3)
+        version: 10.2.0(cypress@14.3.0)(prettier@3.5.3)(type-fest@4.39.1)(typescript@5.8.3)
       '@types/node':
         specifier: 22.14.0
         version: 22.14.0
@@ -58,8 +58,8 @@ importers:
         specifier: 9.24.0
         version: 9.24.0
       eslint-config-prettier:
-        specifier: 10.1.1
-        version: 10.1.1(eslint@9.24.0)
+        specifier: 10.1.2
+        version: 10.1.2(eslint@9.24.0)
       eslint-plugin-no-only-tests:
         specifier: 3.3.0
         version: 3.3.0
@@ -839,8 +839,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@14.2.1:
-    resolution: {integrity: sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==}
+  cypress@14.3.0:
+    resolution: {integrity: sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -1011,8 +1011,8 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-config-prettier@10.1.1:
-    resolution: {integrity: sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==}
+  eslint-config-prettier@10.1.2:
+    resolution: {integrity: sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -2740,7 +2740,7 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@tui-sandbox/library@10.2.0(cypress@14.2.1)(prettier@3.5.3)(type-fest@4.39.1)(typescript@5.8.3)':
+  '@tui-sandbox/library@10.2.0(cypress@14.3.0)(prettier@3.5.3)(type-fest@4.39.1)(typescript@5.8.3)':
     dependencies:
       '@catppuccin/palette': 1.7.1
       '@trpc/client': 11.0.2(@trpc/server@11.0.2(typescript@5.8.3))(typescript@5.8.3)
@@ -2751,7 +2751,7 @@ snapshots:
       command-exists: 1.2.9
       core-js: 3.41.0
       cors: 2.8.5
-      cypress: 14.2.1
+      cypress: 14.3.0
       dree: 5.1.5
       express: 5.1.0
       neovim: 5.3.0
@@ -3225,7 +3225,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@14.2.1:
+  cypress@14.3.0:
     dependencies:
       '@cypress/request': 3.0.8
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -3433,7 +3433,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.1(eslint@9.24.0):
+  eslint-config-prettier@10.1.2(eslint@9.24.0):
     dependencies:
       eslint: 9.24.0
 


### PR DESCRIPTION
# fix: sending `i` on startup activating yazi actions

This was introduced in https://github.com/mikavilpas/yazi.nvim/pull/321
but has caused issues. Sometimes neovim sends the `i` keypress to yazi,
and if the user has a mapping for this key, it will be triggered.

Try to work around this issue by sending the `i` keypress earlier.

Closes https://github.com/mikavilpas/yazi.nvim/issues/809


