### PR TITLE
test: force test yazi to exit with `i` to test it's not sent

### DIFF
--- a/integration-tests/test-environment/.config/yazi/keymap.toml
+++ b/integration-tests/test-environment/.config/yazi/keymap.toml
@@ -13,3 +13,7 @@ run = """shell 'ya pub-to 0 MyMessageNoData'"""
 [[manager.prepend_keymap]]
 on = "<C-h>"
 run = """shell "ya pub-to 0 MyMessageWithData --json '{\\"somedata\\": 123}'""""
+
+[[manager.prepend_keymap]]
+on = "i"
+run = """quit"""


### PR DESCRIPTION
In the pr below, I tried to fix a bug where yazi.nvim would send `i` to yazi.
https://github.com/mikavilpas/yazi.nvim/pull/876

This commit adds a yazi keymap for `i` to test that it's not sent. Sending it would cause yazi to exit, which would fail any test that expects yazi to be running.