### PR TITLE
refactor: get YaziActiveContext from YaziProcess:start

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -50,7 +50,7 @@ function M.yazi(config, input_path, args)
   local win = require("yazi.window").YaziFloatingWindow.new(config)
   win:open_and_display()
 
-  local yazi_process = YaziProcess:start(config, paths, {
+  local yazi_process, context = YaziProcess:start(config, paths, {
     on_maybe_started = function(yazi)
       if not (args and args.reveal_path) then
         return
@@ -155,13 +155,6 @@ function M.yazi(config, input_path, args)
   })
 
   config.hooks.yazi_opened(path.filename, win.content_buffer, config)
-
-  ---@type YaziActiveContext
-  local context = {
-    api = yazi_process.api,
-    input_path = path,
-    ya_process = yazi_process.ya_process,
-  }
 
   local yazi_buffer = win.content_buffer
   if config.set_keymappings_function ~= nil then

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -22,6 +22,7 @@ YaziProcess.__index = YaziProcess
 ---@param config YaziConfig
 ---@param paths Path[]
 ---@param callbacks yazi.Callbacks
+---@return YaziProcess, YaziActiveContext
 function YaziProcess:start(config, paths, callbacks)
   os.remove(config.chosen_file_path)
 
@@ -77,7 +78,14 @@ function YaziProcess:start(config, paths, callbacks)
   self.ya_process:start()
   callbacks.on_maybe_started(self)
 
-  return self
+  ---@type YaziActiveContext
+  local context = {
+    api = self.api,
+    ya_process = self.ya_process,
+    yazi_job_id = self.yazi_job_id,
+    input_path = paths[1],
+  }
+  return self, context
 end
 
 function YaziProcess:nvim_0_10_termopen(config, on_exit, yazi_cmd)


### PR DESCRIPTION
Previously it was constructed in the yazi function, which is perhaps needlessly complicated.