### PR TITLE
feat: allow a yazi keymap to cycle through open buffers

### DIFF
--- a/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
+++ b/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
@@ -1,9 +1,8 @@
 import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
+import { yaziText } from "./utils/yazi-utils"
 
 // NOTE: cypress doesn't support the tab key, but control+i seems to work fine
 // https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
-
-const yaziText = "NOR"
 
 describe("revealing another open split (buffer) in yazi", () => {
   beforeEach(() => {

--- a/integration-tests/cypress/e2e/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/utils/yazi-utils.ts
@@ -3,6 +3,8 @@ import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 
 const darkTheme = flavors.macchiato.colors
 
+export const yaziText = "NOR"
+
 export function isFileSelectedInYazi(text: string): void {
   cy.contains(text).should(
     "have.css",

--- a/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
@@ -1,0 +1,73 @@
+import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
+import { yaziText } from "./utils/yazi-utils"
+
+// The yazi keymappings need to be defined in the yazi config. The test
+// environment contains the mapping in the .config/yazi/keymap.toml file
+describe("revealing another open split (buffer) in yazi", () => {
+  beforeEach(() => {
+    cy.visit("/")
+  })
+
+  it(`can react to the "NvimCycleBuffer" event`, () => {
+    // This event signifies yazi.nvim should cycle_open_buffers, which makes
+    // yazi focus the next visible neovim split as the current file.
+    //
+    const view = {
+      leftFile: { text: "ello from file_1.txt" },
+      centerFile: { text: "This is file_2.txt" },
+      rightFile: { text: "You are looking at file_3.txt" },
+    } as const
+
+    cy.startNeovim({
+      filename: {
+        openInVerticalSplits: [
+          "highlights/file_1.txt",
+          "highlights/file_2.txt",
+          "highlights/file_3.txt",
+        ],
+      },
+      startupScriptModifications: [
+        "modify_yazi_config_and_add_hovered_buffer_background.lua",
+      ],
+    }).then((_nvim) => {
+      // sanity check to make sure the files are open
+      cy.contains(view.leftFile.text)
+      cy.contains(view.centerFile.text)
+      cy.contains(view.rightFile.text)
+
+      // before doing anything, both files should be unhovered (have the
+      // default background color)
+      isNotHoveredInNeovim(view.leftFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
+
+      // start yazi and wait for it to be visible
+      cy.typeIntoTerminal("{upArrow}")
+      cy.contains(yaziText)
+
+      // Switch to the other buffers' directories in yazi. This should make
+      // yazi send a hover event for the new, highlighted file.
+      //
+      cy.typeIntoTerminal("I")
+      isNotHoveredInNeovim(view.leftFile.text)
+      isHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
+
+      cy.typeIntoTerminal("I")
+      isHoveredInNeovim(view.rightFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.leftFile.text)
+
+      cy.typeIntoTerminal("I")
+      isHoveredInNeovim(view.leftFile.text)
+      isNotHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
+
+      // tab once more to make sure it wraps around
+      cy.typeIntoTerminal("I")
+      isNotHoveredInNeovim(view.leftFile.text)
+      isHoveredInNeovim(view.centerFile.text)
+      isNotHoveredInNeovim(view.rightFile.text)
+    })
+  })
+})

--- a/integration-tests/test-environment/.config/yazi/keymap.toml
+++ b/integration-tests/test-environment/.config/yazi/keymap.toml
@@ -17,3 +17,7 @@ run = """shell "ya pub-to 0 MyMessageWithData --json '{\\"somedata\\": 123}'""""
 [[manager.prepend_keymap]]
 on = "i"
 run = """quit"""
+
+[[manager.prepend_keymap]]
+on = "I"
+run = """shell "ya pub-to 0 NvimCycleBuffer""""

--- a/integration-tests/test-environment/config-modifications/notify_custom_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_custom_events.lua
@@ -1,7 +1,15 @@
 ---@module "yazi"
 
-require("yazi").config.forwarded_dds_events =
-  { "MyMessageNoData", "MyMessageWithData" }
+do
+  local config = require("yazi").config
+  assert(config, "yazi.config is not set")
+
+  config.forwarded_dds_events = vim.tbl_extend(
+    "force",
+    config.forwarded_dds_events or {},
+    { "MyMessageNoData", "MyMessageWithData" }
+  )
+end
 
 vim.api.nvim_create_autocmd("User", {
   pattern = "YaziDDSCustom",

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -50,7 +50,7 @@ function M.yazi(config, input_path, args)
   local win = require("yazi.window").YaziFloatingWindow.new(config)
   win:open_and_display()
 
-  local yazi_process, context = YaziProcess:start(config, paths, {
+  local yazi_process, yazi_context = YaziProcess:start(config, paths, {
     on_maybe_started = function(yazi)
       if not (args and args.reveal_path) then
         return
@@ -100,7 +100,8 @@ function M.yazi(config, input_path, args)
       selected_files,
       events,
       hovered_url,
-      last_directory
+      last_directory,
+      context
     )
       if exit_code ~= 0 then
         print(
@@ -127,7 +128,11 @@ function M.yazi(config, input_path, args)
       -- processed a second time here.
       assert(#events == 0 or not config.future_features.process_events_live)
 
-      yazi_event_handling.process_events_emitted_from_yazi(events)
+      yazi_event_handling.process_events_emitted_from_yazi(
+        events,
+        config,
+        context
+      )
 
       if last_directory == nil then
         if path:is_file() then
@@ -158,11 +163,11 @@ function M.yazi(config, input_path, args)
 
   local yazi_buffer = win.content_buffer
   if config.set_keymappings_function ~= nil then
-    config.set_keymappings_function(yazi_buffer, config, context)
+    config.set_keymappings_function(yazi_buffer, config, yazi_context)
   end
 
   if config.keymaps ~= false then
-    require("yazi.config").set_keymappings(yazi_buffer, config, context)
+    require("yazi.config").set_keymappings(yazi_buffer, config, yazi_context)
   end
 
   win.on_resized = function(event)

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -93,6 +93,7 @@ function M.default()
     floating_window_scaling_factor = 0.9,
     yazi_floating_window_winblend = 0,
     yazi_floating_window_border = border,
+    forwarded_dds_events = { "NvimCycleBuffer" },
   }
 end
 

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -79,7 +79,9 @@ local function handle_rename_move_bulk_event(event_data)
 end
 
 ---@param events YaziEvent[]
-function M.process_events_emitted_from_yazi(events)
+---@param config YaziConfig
+---@param context YaziActiveContext
+function M.process_events_emitted_from_yazi(events, config, context)
   for i, event in ipairs(events) do
     if event.type == "rename" then
       ---@cast event YaziRenameEvent
@@ -111,6 +113,9 @@ function M.process_events_emitted_from_yazi(events)
       local remaining_events = vim.list_slice(events, i)
       ---@cast event YaziTrashEvent
       M.process_delete_event(event, remaining_events)
+    elseif event.type == "cycle-buffer" then
+      ---@cast event YaziNvimCycleBufferEvent
+      require("yazi.keybinding_helpers").cycle_open_buffers(config, context)
     end
   end
 end

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -64,7 +64,7 @@
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 ---@field public hovered_buffer_in_same_directory? vim.api.keyset.highlight # the color of a buffer that is in the same directory as the hovered buffer
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent
 
 ---@class (exact) YaziPreviousState # describes the previous state of yazi when it was closed; the last known state
 ---@field public last_hovered? string
@@ -114,6 +114,9 @@
 ---@class (exact) YaziBulkEvent "Like `rename` and `move` but for bulk renaming"
 ---@field public type "bulk"
 ---@field public changes table<string, string> # a table of old paths to new paths
+
+---@class (exact) YaziNvimCycleBufferEvent # yazi commands yazi.nvim to cycle to the next buffer
+---@field public type "cycle-buffer"
 
 ---@class (exact) YaziCustomDDSEvent "A custom event that is emitted by yazi. It could be coming from yazi itself, or a yazi plugin that uses custom events."
 ---@field public yazi_id string

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -214,7 +214,13 @@ function M.parse_events(event_lines)
     local type = parts[1]
 
     -- selene: allow(if_same_then_else)
-    if type == "rename" then
+    if type == "NvimCycleBuffer" then
+      ---@type YaziNvimCycleBufferEvent
+      local event = {
+        type = "cycle-buffer",
+      }
+      table.insert(events, event)
+    elseif type == "rename" then
       -- example of a rename event:
 
       -- rename,1712242143209837,1712242143209837,{"tab":0,"from":"/Users/mikavilpas/git/yazi/LICENSE","to":"/Users/mikavilpas/git/yazi/LICENSE2"}


### PR DESCRIPTION
# feat: allow a yazi keymap to cycle through open buffers

Issue
=====

By default, the `<tab>` key in yazi.nvim is used to cycle through the
open buffers. This is done in a way that prevents using the `<tab>` key
for any yazi actions.

Most of the time this does not cause issues, but in some cases the
`<tab>` key is very important. For example, if a subshell is opened in
yazi using this mapping:

```toml
[manager]
keymap = {
  { on = [":"], run = "shell 'fish' --block --confirm" }
}
```
(https://github.com/mikavilpas/dotfiles/blob/96f734f27f449783b0a1884623e27fc567849d50/.config/yazi/keymap.toml?plain=1#L116)

In this case, the subshell has no access to the `<tab>` key. For example,
this disables tab completion in the user's shell.

Solution
========

Allow users to work around this by manually defining a yazi keymap that
sends an event to yazi.nvim. Yazi.nvim will then react to the event and
execute the cycle_open_buffers action.

To enable this mapping, look at how the integration tests define the
keymapping in
https://github.com/mikavilpas/yazi.nvim/blob/main/integration-tests/test-environment/.config/yazi/keymap.toml?plain=1


# refactor: move yaziText to utils to share it

