### PR TITLE
refactor: don't parse and store dds event timestamps

### DIFF
--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -74,13 +74,11 @@
 
 ---@class (exact) YaziRenameEvent
 ---@field public type "rename"
----@field public timestamp string
 ---@field public id string
 ---@field public data YaziEventDataRenameOrMove
 
 ---@class (exact) YaziMoveEvent
 ---@field public type "move"
----@field public timestamp string
 ---@field public id string
 ---@field public data {items: YaziEventDataRenameOrMove[]}
 
@@ -90,19 +88,16 @@
 
 ---@class (exact) YaziDeleteEvent
 ---@field public type "delete"
----@field public timestamp string
 ---@field public id string
 ---@field public data {urls: string[]}
 
 ---@class (exact) YaziTrashEvent
 ---@field public type "trash"
----@field public timestamp string
 ---@field public id string
 ---@field public data {urls: string[]}
 
 ---@class (exact) YaziChangeDirectoryEvent
 ---@field public type "cd"
----@field public timestamp string
 ---@field public id string
 ---@field public url string
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -212,6 +212,7 @@ function M.parse_events(event_lines)
   for _, line in ipairs(event_lines) do
     local parts = vim.split(line, ",")
     local type = parts[1]
+    local yazi_id = parts[3]
 
     -- selene: allow(if_same_then_else)
     if type == "NvimCycleBuffer" then
@@ -224,30 +225,24 @@ function M.parse_events(event_lines)
       -- example of a rename event:
 
       -- rename,1712242143209837,1712242143209837,{"tab":0,"from":"/Users/mikavilpas/git/yazi/LICENSE","to":"/Users/mikavilpas/git/yazi/LICENSE2"}
-      local timestamp = parts[2]
-      local id = parts[3]
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziRenameEvent
       local event = {
         type = type,
-        timestamp = timestamp,
-        id = id,
+        id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
     elseif type == "move" then
       -- example of a move event:
       -- move,1712854829131439,1712854829131439,{"items":[{"from":"/tmp/test/test","to":"/tmp/test"}]}
-      local timestamp = parts[2]
-      local id = parts[3]
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziMoveEvent
       local event = {
         type = type,
-        timestamp = timestamp,
-        id = id,
+        id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -265,15 +260,12 @@ function M.parse_events(event_lines)
     elseif type == "delete" then
       -- example of a delete event:
       -- delete,1712766606832135,1712766606832135,{"urls":["/tmp/test-directory/test_2"]}
-      local timestamp = parts[2]
-      local id = parts[3]
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziDeleteEvent
       local event = {
         type = type,
-        timestamp = timestamp,
-        id = id,
+        id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -281,15 +273,12 @@ function M.parse_events(event_lines)
       -- example of a trash event:
       -- trash,1712766606832135,1712766606832135,{"urls":["/tmp/test-directory/test_2"]}
 
-      local timestamp = parts[2]
-      local id = parts[3]
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziTrashEvent
       local event = {
         type = type,
-        timestamp = timestamp,
-        id = id,
+        id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -297,15 +286,12 @@ function M.parse_events(event_lines)
       -- example of a change directory (cd) event:
       -- cd,1716307611001689,1716307611001689,{"tab":0,"url":"/tmp/test-directory"}
 
-      local timestamp = parts[2]
-      local id = parts[3]
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziChangeDirectoryEvent
       local event = {
         type = type,
-        timestamp = timestamp,
-        id = id,
+        id = yazi_id,
         url = vim.json.decode(data_string)["url"],
       }
       table.insert(events, event)
@@ -313,7 +299,6 @@ function M.parse_events(event_lines)
       -- example of a hover event:
       -- hover,0,1720375364822700,{"tab":0,"url":"/tmp/test-directory/test"}
       local data_string = table.concat(parts, ",", 4, #parts)
-      local yazi_id = parts[3]
       local json = vim.json.decode(data_string, {
         luanil = {
           array = true,
@@ -338,7 +323,6 @@ function M.parse_events(event_lines)
       -- It could look like this (with optional data at the end)
       -- MyMessageNoData,0,1731774290298033,
       local data_string = table.concat(parts, ",", 4, #parts)
-      local yazi_id = parts[3]
 
       ---@type YaziCustomDDSEvent
       local event = {

--- a/spec/yazi/delete_spec.lua
+++ b/spec/yazi/delete_spec.lua
@@ -14,7 +14,6 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc/def" } },
     }
@@ -33,7 +32,6 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc" } },
     }
@@ -52,7 +50,6 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc/ghi" } },
     }
@@ -71,7 +68,6 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local delete_event = {
       type = "delete",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/def/file" } },
     }
@@ -79,7 +75,6 @@ describe("process_delete_event", function()
     ---@type YaziRenameEvent
     local rename_event = {
       type = "rename",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { from = "/def/other-file", to = "/def/file" },
     }

--- a/spec/yazi/read_events_spec.lua
+++ b/spec/yazi/read_events_spec.lua
@@ -12,7 +12,6 @@ describe("parsing yazi event file events", function()
     assert.are.same(events, {
       {
         type = "rename",
-        timestamp = "1712242143209837",
         id = "1712242143209837",
         data = {
           tab = 0,
@@ -33,7 +32,6 @@ describe("parsing yazi event file events", function()
     assert.are.same(events, {
       {
         type = "delete",
-        timestamp = "1712766606832135",
         id = "1712766606832135",
         data = {
           urls = { "/tmp/test-directory/test_2" },

--- a/spec/yazi/rename_spec.lua
+++ b/spec/yazi/rename_spec.lua
@@ -90,7 +90,6 @@ describe("process_events_emitted_from_yazi", function()
         from = "/my-tmp/file1",
         to = "/my-tmp/file2",
       },
-      timestamp = "2021-09-01T00:00:00Z",
       id = "123",
     }
 
@@ -110,7 +109,6 @@ describe("process_events_emitted_from_yazi", function()
     local event = {
       type = "move",
       id = "123",
-      timestamp = "2021-09-01T00:00:00Z",
       data = {
         items = {
           {

--- a/spec/yazi/trash_spec.lua
+++ b/spec/yazi/trash_spec.lua
@@ -40,7 +40,6 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc/def" } },
     }
@@ -60,7 +59,6 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc" } },
     }
@@ -80,7 +78,6 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/abc/ghi" } },
     }
@@ -95,7 +92,6 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local delete_event = {
       type = "trash",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { urls = { "/def/file" } },
     }
@@ -103,7 +99,6 @@ describe("process_trash_event", function()
     ---@type YaziRenameEvent
     local rename_event = {
       type = "rename",
-      timestamp = "1712766606832135",
       id = "1712766606832135",
       data = { from = "/def/other-file", to = "/def/file" },
     }

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -87,7 +87,6 @@ describe("process_events()", function()
       ya:process_events({
         {
           type = "cd",
-          timestamp = "2021-09-01T12:00:00Z",
           id = "cd_123",
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
@@ -101,13 +100,11 @@ describe("process_events()", function()
       ya:process_events({
         {
           type = "cd",
-          timestamp = "2021-09-01T12:00:00Z",
           id = "cd_123",
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
         {
           type = "cd",
-          timestamp = "2021-09-01T12:00:00Z",
           id = "cd_123",
           url = "/tmp/directory",
         } --[[@as YaziChangeDirectoryEvent]],
@@ -133,7 +130,6 @@ describe("process_events()", function()
         local events = {
           {
             type = "rename",
-            timestamp = "2021-09-01T12:00:00Z",
             id = "rename_123",
             data = {
               from = "/tmp/old_path",
@@ -176,7 +172,6 @@ describe("process_events()", function()
         local events = {
           {
             type = "move",
-            timestamp = "2021-09-01T12:00:00Z",
             id = "rename_123",
             data = {
               items = {


### PR DESCRIPTION
They are not used for anything and are not needed.