### PR TITLE
ci: bump yazi to latest nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
           git: https://github.com/sxyazi/yazi
           # tag: v25.3.2
           commit:
-            # https://github.com/sxyazi/yazi/commit/0082d1181afc1211c9c190782db6e81663b6f0d8
-            0082d1181afc1211c9c190782db6e81663b6f0d8
+            # https://github.com/sxyazi/yazi/commit/bfad57d86f66
+            bfad57d86f66
 
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3.3.0
@@ -59,8 +59,8 @@ jobs:
           git: https://github.com/sxyazi/yazi
           # tag: v25.3.2
           commit:
-            # https://github.com/sxyazi/yazi/commit/0082d1181afc1211c9c190782db6e81663b6f0d8
-            0082d1181afc1211c9c190782db6e81663b6f0d8
+            # https://github.com/sxyazi/yazi/commit/bfad57d86f66
+            bfad57d86f66
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@v1.1.0

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -52,6 +52,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("add_command_to_count_open_buffers.lua"),
           type: z.literal("file"),
         }),
+        "add_command_to_reveal_a_file.lua": z.object({
+          name: z.literal("add_command_to_reveal_a_file.lua"),
+          type: z.literal("file"),
+        }),
         "disable_a_keybinding.lua": z.object({
           name: z.literal("disable_a_keybinding.lua"),
           type: z.literal("file"),
@@ -248,6 +252,7 @@ export const testDirectoryFiles = z.enum([
   ".config/yazi",
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
+  "config-modifications/add_command_to_reveal_a_file.lua",
   "config-modifications/disable_a_keybinding.lua",
   "config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua",
   "config-modifications/modify_yazi_config_and_highlight_buffers_in_same_directory.lua",

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -56,6 +56,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("add_command_to_reveal_a_file.lua"),
           type: z.literal("file"),
         }),
+        "add_yazi_context_assertions.lua": z.object({
+          name: z.literal("add_yazi_context_assertions.lua"),
+          type: z.literal("file"),
+        }),
         "disable_a_keybinding.lua": z.object({
           name: z.literal("disable_a_keybinding.lua"),
           type: z.literal("file"),
@@ -253,6 +257,7 @@ export const testDirectoryFiles = z.enum([
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications/add_command_to_reveal_a_file.lua",
+  "config-modifications/add_yazi_context_assertions.lua",
   "config-modifications/disable_a_keybinding.lua",
   "config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua",
   "config-modifications/modify_yazi_config_and_highlight_buffers_in_same_directory.lua",

--- a/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
+++ b/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
@@ -26,8 +26,9 @@ describe("revealing another open split (buffer) in yazi", () => {
       },
       startupScriptModifications: [
         "modify_yazi_config_and_add_hovered_buffer_background.lua",
+        "add_yazi_context_assertions.lua",
       ],
-    }).then((_nvim) => {
+    }).then((nvim) => {
       // sanity check to make sure the files are open
       cy.contains(view.leftFile.text)
       cy.contains(view.centerFile.text)
@@ -41,6 +42,7 @@ describe("revealing another open split (buffer) in yazi", () => {
 
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
+      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
       cy.contains(yaziText)
 
       // Switch to the other buffers' directories in yazi. This should make
@@ -84,14 +86,16 @@ describe("revealing another open split (buffer) in yazi", () => {
         ],
       },
       startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
         "modify_yazi_config_and_add_hovered_buffer_background.lua",
       ],
-    }).then((_nvim) => {
+    }).then((nvim) => {
       isNotHoveredInNeovim(view.leftAndCenterFile.text)
       isNotHoveredInNeovim(view.rightFile.text)
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
+      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
       cy.contains(yaziText)
 
       cy.typeIntoTerminal("{control+i}")

--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -287,9 +287,12 @@ describe("opening files", () => {
     })
 
     it("can rename a buffer that's open in Neovim", () => {
-      cy.startNeovim().then((nvim) => {
+      cy.startNeovim({
+        startupScriptModifications: ["add_yazi_context_assertions.lua"],
+      }).then((nvim) => {
         cy.contains("If you see this text, Neovim is ready!")
         cy.typeIntoTerminal("{upArrow}")
+        nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
         isFileNotSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
         // select only the current file to make the test easier
         cy.typeIntoTerminal("v")

--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -314,7 +314,7 @@ describe("opening files", () => {
         cy.typeIntoTerminal("q")
 
         // the file should now be renamed - ask neovim to confirm this
-        nvim.runExCommand({ command: "buffers" }).then((result) => {
+        nvim.runExCommand({ command: "buffers" }).and((result) => {
           expect(result.value).to.contain("renamed-file.txt")
         })
       })

--- a/integration-tests/cypress/e2e/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/toggling.cy.ts
@@ -1,33 +1,28 @@
 import { flavors } from "@catppuccin/palette"
-import { rgbify } from "./utils/hover-utils"
+import { hoverFileAndVerifyItsHovered, rgbify } from "./utils/hover-utils"
 
 describe("toggling yazi to pseudo-continue the previous session", () => {
   beforeEach(() => {
     cy.visit("/")
   })
 
-  function hoverAnotherFileToEnsureHoverEventIsReceivedInCI(file: string) {
-    // select another file (hacky)
-    cy.typeIntoTerminal("gg")
-
-    // select the desired file so that a new hover event is sent
-    cy.typeIntoTerminal(`/${file}{enter}`)
-  }
-
   it("can restore yazi hovering on the previously hovered file", () => {
-    cy.startNeovim({ filename: "initial-file.txt" }).then((nvim) => {
+    cy.startNeovim({
+      filename: "initial-file.txt",
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "add_command_to_reveal_a_file.lua",
+      ],
+    }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
 
-      // select another file. This should send a hover event, which should be
-      // saved as the "last hovered file"
-
-      hoverAnotherFileToEnsureHoverEventIsReceivedInCI(
-        nvim.dir.contents["file2.txt"].name,
-      )
+      // This should send a hover event, which should be saved as the "last
+      // hovered file"
+      hoverFileAndVerifyItsHovered(nvim, "file2.txt")
 
       // close yazi
       cy.typeIntoTerminal("q")
@@ -61,23 +56,27 @@ describe("toggling yazi to pseudo-continue the previous session", () => {
     // Yazi displays the contents of the directory instead of hovering the
     // directory. We work around this by sending a "reveal" event to yazi to
     // hover the directory instead.
-    cy.startNeovim({ filename: "dir with spaces/file1.txt" }).then((nvim) => {
+    cy.startNeovim({
+      filename: "dir with spaces/file1.txt",
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "add_command_to_reveal_a_file.lua",
+      ],
+    }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("this is the first file")
 
       // toggle yazi and set up a session that hovers a directory
       cy.typeIntoTerminal("{upArrow}")
+      cy.log("yazi should be visible, showing other files")
+      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      hoverFileAndVerifyItsHovered(nvim, "dir with spaces/file1.txt")
 
       // yazi should be visible, showing other files
       cy.contains(nvim.dir.contents["file2.txt"].name)
 
-      // move to the upper directory level. This will focus "dir with spaces"
-      cy.typeIntoTerminal("h")
-      cy.contains("dir with spaces").should(
-        "have.css",
-        "background-color",
-        rgbify(flavors.macchiato.colors.blue.rgb),
-      )
+      // focus "dir with spaces" in the parent directory
+      hoverFileAndVerifyItsHovered(nvim, "dir with spaces")
 
       // close yazi
       cy.contains("NOR")

--- a/integration-tests/cypress/e2e/utils/hover-utils.ts
+++ b/integration-tests/cypress/e2e/utils/hover-utils.ts
@@ -1,4 +1,8 @@
 import { flavors } from "@catppuccin/palette"
+import type { RunLuaCodeOutput } from "@tui-sandbox/library/src/server/types"
+import type { NeovimContext } from "cypress/support/tui-sandbox"
+import type { MyTestDirectoryFile } from "MyTestDirectory"
+import { assertYaziIsReady } from "./yazi-utils"
 
 const darkTheme = flavors.macchiato.colors
 const lightTheme = flavors.latte.colors
@@ -36,4 +40,35 @@ export function isNotHoveredInNeovim(text: string): void {
     "background-color",
     darkBackgroundColors.normal,
   )
+}
+
+/** HACK in CI, there can be timing issues where the first hover event is
+ * lost. Right now we work around this by selecting another file first, then
+ * hovering the desired file.
+ */
+export function hoverFileAndVerifyItsHovered(
+  nvim: NeovimContext,
+  file: MyTestDirectoryFile,
+): Cypress.Chainable<RunLuaCodeOutput> {
+  assertYaziIsReady(nvim)
+  // select another file (hacky) by going to the parent directory
+  cy.typeIntoTerminal("h")
+
+  const path = nvim.dir.rootPathAbsolute + "/" + file
+  return nvim
+    .runLuaCode({
+      luaCode: `return Yazi_reveal_path("${path}")`,
+    })
+    .then(() => assertYaziIsHovering(nvim, file))
+}
+
+export function assertYaziIsHovering(
+  nvim: NeovimContext,
+  file: MyTestDirectoryFile,
+): Cypress.Chainable<RunLuaCodeOutput> {
+  const path = `${nvim.dir.rootPathAbsolute}/${file}`
+  return nvim.waitForLuaCode({
+    luaAssertion: `Yazi_is_hovering("${path}")`,
+    timeoutMs: 5000,
+  })
 }

--- a/integration-tests/cypress/e2e/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/utils/yazi-utils.ts
@@ -1,5 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
+import type { RunLuaCodeOutput } from "@tui-sandbox/library/src/server/types"
+import type { NeovimContext } from "cypress/support/tui-sandbox"
 
 const darkTheme = flavors.macchiato.colors
 
@@ -27,4 +29,10 @@ export function isFileNotSelectedInYazi(text: string): void {
     "background-color",
     rgbify(darkTheme.base.rgb),
   )
+}
+
+export function assertYaziIsReady(
+  nvim: NeovimContext,
+): Cypress.Chainable<RunLuaCodeOutput> {
+  return nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
 }

--- a/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
@@ -27,9 +27,10 @@ describe("revealing another open split (buffer) in yazi", () => {
         ],
       },
       startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
         "modify_yazi_config_and_add_hovered_buffer_background.lua",
       ],
-    }).then((_nvim) => {
+    }).then((nvim) => {
       // sanity check to make sure the files are open
       cy.contains(view.leftFile.text)
       cy.contains(view.centerFile.text)
@@ -44,6 +45,7 @@ describe("revealing another open split (buffer) in yazi", () => {
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
       cy.contains(yaziText)
+      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
 
       // Switch to the other buffers' directories in yazi. This should make
       // yazi send a hover event for the new, highlighted file.

--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -1,0 +1,17 @@
+-- selene: allow(unused_variable)
+function Yazi_reveal_path(path)
+  local yazi = require("yazi")
+
+  ---@type YaziActiveContext | nil
+  local context = yazi.active_contexts:peek()
+
+  local Log = require("yazi.log")
+  if context then
+    Log:debug("Revealing path in yazi context: " .. vim.inspect(path))
+    context.api:reveal(path)
+  else
+    Log:debug("No active yazi context found")
+  end
+end
+
+print("Yazi: Loaded custom command to reveal a file")

--- a/integration-tests/test-environment/config-modifications/add_yazi_context_assertions.lua
+++ b/integration-tests/test-environment/config-modifications/add_yazi_context_assertions.lua
@@ -1,0 +1,37 @@
+---@module "yazi"
+
+local yazi = require("yazi")
+
+-- selene: allow(unused_variable)
+---@param path string
+function Yazi_is_hovering(path)
+  ---@type YaziActiveContext
+  local current = assert(
+    yazi.active_contexts:peek(),
+    "No active context found. Is yazi running?."
+  )
+
+  local yazi_id = current.ya_process.yazi_id
+  local hovered = current.ya_process.hovered_url
+
+  assert(
+    hovered == path,
+    string.format(
+      "Expected yazi '%s' to be hovering '%s', but found '%s'",
+      yazi_id,
+      path,
+      hovered
+    )
+  )
+end
+
+-- selene: allow(unused_variable)
+function Yazi_is_ready()
+  ---@type YaziActiveContext
+  local current = assert(
+    yazi.active_contexts:peek(),
+    "No active context found. Is yazi running?."
+  )
+  local ready, details = current.ya_process:is_ready()
+  assert(ready, "Yazi is not ready yet. Details: " .. vim.inspect(details))
+end

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -10,6 +10,8 @@ M.version = "10.1.1" -- x-release-please-version
 ---@type YaziPreviousState
 M.previous_state = {}
 
+M.active_contexts = vim.ringbuf(2)
+
 ---@alias yazi.Arguments {reveal_path: string}
 
 ---@param config? YaziConfig | {}
@@ -158,6 +160,8 @@ function M.yazi(config, input_path, args)
       end
     end,
   })
+
+  M.active_contexts:push(yazi_context)
 
   config.hooks.yazi_opened(path.filename, win.content_buffer, config)
 

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -114,6 +114,7 @@ function M.process_events_emitted_from_yazi(events, config, context)
       ---@cast event YaziTrashEvent
       M.process_delete_event(event, remaining_events)
     elseif event.type == "cycle-buffer" then
+      require("yazi.log"):debug("YaziNvimCycleBufferEvent received")
       ---@cast event YaziNvimCycleBufferEvent
       require("yazi.keybinding_helpers").cycle_open_buffers(config, context)
     end

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -90,12 +90,6 @@ function YaziOpenerActions.cycle_open_buffers(_config, context)
     if
       buffer.renameable_buffer:matches_exactly(current_cycle_position.filename)
     then
-      Log:debug(
-        string.format(
-          'Found buffer for path: "%s", will open the next buffer',
-          context.input_path
-        )
-      )
       local other_buffers = vim.list_slice(visible_buffers, i + 1)
       other_buffers = vim.list_extend(other_buffers, visible_buffers, 1, i - 1)
       local next_buffer = vim.iter(other_buffers):find(function(b)
@@ -118,6 +112,13 @@ function YaziOpenerActions.cycle_open_buffers(_config, context)
       end
 
       local nextfile = next_buffer.renameable_buffer.path.filename
+      Log:debug(
+        string.format(
+          'Found buffer for path: "%s", will open the next buffer: "%s"',
+          context.input_path,
+          nextfile
+        )
+      )
 
       -- make sure the type is a string, because plenary thinks it is `string|unknown`
       assert(type(nextfile) == "string", "Expected filename to be a string")

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -64,7 +64,7 @@
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 ---@field public hovered_buffer_in_same_directory? vim.api.keyset.highlight # the color of a buffer that is in the same directory as the hovered buffer
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent | YaziHeyEvent
 
 ---@class (exact) YaziPreviousState # describes the previous state of yazi when it was closed; the last known state
 ---@field public last_hovered? string
@@ -105,6 +105,10 @@
 ---@field public yazi_id string
 ---@field public type "hover"
 ---@field public url string
+
+---@class (exact) YaziHeyEvent
+---@field public yazi_id string
+---@field public type "hey"
 
 ---@class (exact) YaziBulkEvent "Like `rename` and `move` but for bulk renaming"
 ---@field public type "bulk"

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -309,12 +309,22 @@ function M.parse_events(event_lines)
       -- sometimes ya sends a hover event without a url, not sure why
       ---@type string | nil
       local url = json["url"]
-
-      ---@type YaziHoverEvent
+      if url ~= nil then
+        ---@type YaziHoverEvent
+        local event = {
+          yazi_id = yazi_id,
+          type = type,
+          url = url or "",
+        }
+        table.insert(events, event)
+      end
+    elseif type == "hey" then
+      -- example of a hey event:
+      -- hey,0,69016966727041,{"peers":{"1745849494365272":{"abilities":["hey"]},"69016966727041":{"abilities":["dds-emit","@yank","extract"]},"1745849492676175":{"abilities":["hover","move","hey","bulk","cd","delete","rename","trash","NvimCycleBuffer"]}},"version":"25.4.8 VERGEN_IDEMPOTENT_OUTPUT"}
+      ---@type YaziHeyEvent
       local event = {
         yazi_id = yazi_id,
         type = type,
-        url = url or "",
       }
       table.insert(events, event)
     else

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier-plugin-organize-imports": "4.1.0",
     "prettier-plugin-packagejson": "2.5.10"
   },
-  "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677",
+  "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -90,7 +90,7 @@ describe("process_events()", function()
           id = "cd_123",
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
-      }, {})
+      }, {}, {})
 
       assert.are.same("/tmp", ya.cwd)
     end)
@@ -108,7 +108,7 @@ describe("process_events()", function()
           id = "cd_123",
           url = "/tmp/directory",
         } --[[@as YaziChangeDirectoryEvent]],
-      }, {})
+      }, {}, {} --[[@as YaziActiveContext]])
 
       assert.are.same("/tmp/directory", ya.cwd)
     end)
@@ -213,7 +213,12 @@ describe("process_events()", function()
       "gets published when YaziBulkEvent events are received from yazi",
       function()
         local config = require("yazi.config").default()
-        local ya = ya_process.new(config, "yazi_id_123")
+        local ya = ya_process.new(
+          config,
+          "yazi_id_123",
+          function() end,
+          "/tmp/new_path1"
+        )
 
         ---@type YaziBulkEvent[]
         local events = {
@@ -282,11 +287,10 @@ describe("opening yazi in a terminal", function()
       local jobstart_spy = spy.new(function() end)
       vim.fn.jobstart = jobstart_spy
 
-      require("yazi.process.yazi_process"):start(
-        config,
-        { path },
-        { on_exit = function() end, on_maybe_started = function() end }
-      )
+      require("yazi.process.yazi_process"):start(config, { path }, {
+        on_exit = function() end,
+        on_ya_first_event = function() end,
+      })
 
       local call = jobstart_spy.calls[#jobstart_spy.calls]
       assert(call)


### PR DESCRIPTION
# fix: make toggling yazi more reliable

It looks like sometimes it takes a bit longer for yazi or ya to start up
and be ready to accept commands. This can cause issues in the
integration-tests which use yazi very fast after starting it up.

This commit applies these fixes:

- prevent errors from using `vim.system():wait()` in fast events. This
  is disallowed in neovim but can happen randomly with timing issues.

- toggle yazi to focus on the first file only after `ya` has
  successfully received its first output. This seems to be the most
  reliable way to detect when yazi is ready to accept commands. I added
  support for internally listening to the `hey` event, which is emitted
  when yazi acknowledges the connection from ya. This seems to occur
  immediately after ya has started.

- increase the timeout for the `reveal` command to 15 retries (it was 5
  before). It now waits for 15*50ms which is roughly 750ms before
  aborting. This seems to help the integration-tests a lot, but should
  not have any effect on human users.

- add integration-test utilities to check if yazi is
  ready and if it's hovering a specific path. This should help reduce
  test flakiness due to random timing issues with neovim, yazi, and ya.

- make `YaProcess.hovered_url` presume the hovered file is the initial
  file if no hovered_url is provided. This needs to be done because ya
  will commonly drop the initial hover events due to the limitation that
  it needs to already have a running yazi to connect to. Otherwise the
  currently `hovered_url` cannot be determined reliably.


# feat(api): allow accessing the yazi context from the lua API

This is currently useful for making testing more reliable, but could be
useful for power users as well.

# chore: bump pnpm from 10.8.1 to 10.9.0

