### PR TITLE
Don't hijack when using a protocol netrw should handle

### DIFF
--- a/lua/yazi/hijack_netrw.lua
+++ b/lua/yazi/hijack_netrw.lua
@@ -11,6 +11,11 @@ function M.hijack_netrw(yazi_augroup)
       return
     end
 
+    -- don't hijack if using a protocol that netrw should handle (e.g. scp, ftp)
+    if string.find(vim.api.nvim_buf_get_name(bufnr), "://") then
+      return
+    end
+
     local winid = vim.api.nvim_get_current_win()
     local dir_bufnr = vim.api.nvim_get_current_buf()
 


### PR DESCRIPTION
Hi, I like using yazi with the `open_for_directories` setting, but netrw is still needed for handling opening files with protocols like scp, ftp, etc. I'm not sure if this is the best way to fix this, but I just added some logic to check whether the filename corresponding to the buffer contains `://` which would be in a transfer protocol that netrw should handle.

For example, opening a file such as `scp://user@server//path/to/file.txt` should not use yazi, since this would just open yazi in the cwd that your local nvim has.