### PR TITLE
refactor!: remove nvim-0.10 termopen fallback completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,13 +331,6 @@ return {
     },
 
     future_features = {
-      -- Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart`
-      -- (https://github.com/neovim/neovim/pull/31343). By default on nightly,
-      -- this option is `false` and `jobstart` is used. Some users have
-      -- reported issues with this, and can set this to `true` to keep using
-      -- the old `termopen` for the time being.
-      nvim_0_10_termopen_fallback = false,
-
       -- By default, this is `true`, which means yazi.nvim processes events
       -- before yazi has been closed. If this is `false`, events are processed
       -- in a batch when the user closes yazi. If this is `true`, events are

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -29,7 +29,6 @@ function M.default()
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
     future_features = {
-      use_nvim_0_10_termopen = vim.fn.has("nvim-0.11") ~= 1,
       process_events_live = true,
     },
     open_multiple_tabs = false,

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -25,7 +25,6 @@
 ---@field public future_features? yazi.OptInFeatures # Features that are not yet stable, but can be tested by the user. These features might change or be removed in the future. They may also become built-in features that are on by default, making it unnecessary to opt into using them.
 
 ---@class(exact) yazi.OptInFeatures
----@field use_nvim_0_10_termopen? boolean # Neovim nightly 0.11 has deprecated `termopen` in favor of `jobstart` (https://github.com/neovim/neovim/pull/31343). By default on nightly, this option is `false` and `jobstart` is used. Some users have reported issues with this, and can set this to `true` to keep using the old `termopen` for the time being.
 ---@field process_events_live? boolean # By default, this is `true`, which means yazi.nvim processes events before yazi has been closed. If this is `false`, events are processed in a batch when the user closes yazi. If this is `true`, events are processed immediately.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier-plugin-organize-imports": "4.1.0",
     "prettier-plugin-packagejson": "2.5.10"
   },
-  "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f",
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",


### PR DESCRIPTION
# refactor!: remove nvim-0.10 termopen fallback completely

This is a follow-up to https://github.com/mikavilpas/yazi.nvim/pull/847
where this was toggled off by default.

Reasoning:

- It is 3 neovim releases old based on the date of the PR that added it
  (https://github.com/neovim/neovim/pull/31343)

- I don't see anyone using this
  https://github.com/search?q=use_nvim_0_10_termopen&type=code


# chore: bump pnpm from 10.9.0 to 10.10.0

