### PR TITLE
test: disable yazi.nvim log truncation in test output

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -3,6 +3,7 @@ import fs from "fs"
 import { readFile, rm } from "fs/promises"
 import path from "path"
 import { fileURLToPath } from "url"
+import { inspect } from "util"
 
 const __dirname = fileURLToPath(new URL(".", import.meta.resolve(".")))
 
@@ -48,7 +49,10 @@ export default defineConfig({
         async showYaziLog(): Promise<null> {
           try {
             const log = await readFile(yaziLogFile, "utf-8")
-            console.log(`${yaziLogFile}`, log.split("\n"))
+            console.log(
+              `${yaziLogFile}`,
+              inspect(log.split("\n"), { maxArrayLength: null, colors: true }),
+            )
             return null
           } catch (err) {
             console.error(err)


### PR DESCRIPTION
It can hide important details about the test run.