### PR TITLE
ci: bump yazi to include `ya pub/emit` checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
           git: https://github.com/sxyazi/yazi
           # tag: v25.3.2
           commit:
-            # https://github.com/sxyazi/yazi/commit/bfad57d86f66
-            bfad57d86f66
+            # https://github.com/sxyazi/yazi/commit/37e8747c01b2
+            37e8747c01b2
 
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3.3.0
@@ -59,8 +59,8 @@ jobs:
           git: https://github.com/sxyazi/yazi
           # tag: v25.3.2
           commit:
-            # https://github.com/sxyazi/yazi/commit/bfad57d86f66
-            bfad57d86f66
+            # https://github.com/sxyazi/yazi/commit/37e8747c01b2
+            37e8747c01b2
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@v1.1.0


### PR DESCRIPTION
When emitting an event, `ya pub` and `ya emit` now check that the receiver yazi is present as well as has the ability to receive the event that is being sent.

- https://github.com/sxyazi/yazi/issues/2680#event-17459001261
- https://github.com/sxyazi/yazi/pull/2697