### PR TITLE
fix: not being able to cycle buffers with `tab` after `:Yazi cwd`

### DIFF
--- a/integration-tests/cypress/e2e/utils/hover-utils.ts
+++ b/integration-tests/cypress/e2e/utils/hover-utils.ts
@@ -42,6 +42,17 @@ export function isNotHoveredInNeovim(text: string): void {
   )
 }
 
+export function isHoveredInNeovimWithSameDirectory(
+  text: string,
+  color?: string,
+): void {
+  cy.contains(text).should(
+    "have.css",
+    "background-color",
+    color ?? darkBackgroundColors.hoveredInSameDirectory,
+  )
+}
+
 /** HACK in CI, there can be timing issues where the first hover event is
  * lost. Right now we work around this by selecting another file first, then
  * hovering the desired file.

--- a/lua/yazi/buffer_highlighting/window_highlight.lua
+++ b/lua/yazi/buffer_highlighting/window_highlight.lua
@@ -82,12 +82,6 @@ end
 function WindowHighlight:reset_to_normal()
   if vim.api.nvim_win_is_valid(self.window_id) then
     -- Revert winhighlight to its old value
-    Log:debug(
-      string.format(
-        "Disposing of the DisposableHighlight for window_id %s",
-        self.window_id
-      )
-    )
     vim.api.nvim_set_option_value("winhighlight", self.first_winhighlight, {
       win = self.window_id,
     })

--- a/lua/yazi/buffer_highlighting/window_highlight.lua
+++ b/lua/yazi/buffer_highlighting/window_highlight.lua
@@ -68,10 +68,6 @@ function WindowHighlight:set_highlight(
     vim.api.nvim_set_hl(0, highlight_name, color)
   end
 
-  Log:debug(
-    string.format("Setting winhighlight for window_id %s", self.window_id)
-  )
-
   vim.api.nvim_set_option_value(
     "winhighlight",
     "Normal:" .. highlight_name,

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -64,6 +64,12 @@ function YaziOpenerActions.select_current_file_and_close_yazi(config, callbacks)
   callbacks.api:open()
 end
 
+---@param visible_buffer YaziVisibleBuffer
+local function show_visible_buffer(visible_buffer)
+  local renameable_buffer = visible_buffer.renameable_buffer
+  return renameable_buffer.path:make_relative(vim.uv.cwd())
+end
+
 ---@param _config YaziConfig
 ---@param context YaziActiveContext
 ---@diagnostic disable-next-line: unused-local
@@ -71,9 +77,6 @@ function YaziOpenerActions.cycle_open_buffers(_config, context)
   assert(context.input_path, "No input path found")
   assert(context.input_path.filename, "No input path filename found")
 
-  local current_cycle_position = (
-    context.cycled_file and context.cycled_file.path
-  ) or context.input_path
   local visible_buffers = utils.get_visible_open_buffers()
 
   if #visible_buffers == 0 then
@@ -86,54 +89,94 @@ function YaziOpenerActions.cycle_open_buffers(_config, context)
     return
   end
 
-  for i, buffer in ipairs(visible_buffers) do
-    if
-      buffer.renameable_buffer:matches_exactly(current_cycle_position.filename)
-    then
-      local other_buffers = vim.list_slice(visible_buffers, i + 1)
-      other_buffers = vim.list_extend(other_buffers, visible_buffers, 1, i - 1)
-      local next_buffer = vim.iter(other_buffers):find(function(b)
-        return b.renameable_buffer.path.filename
-          ~= current_cycle_position.filename
-      end)
+  Log:debug(
+    string.format(
+      "Looking at visible_buffers: %s",
+      vim.inspect(vim.tbl_map(show_visible_buffer, visible_buffers))
+    )
+  )
 
-      if #visible_buffers == 1 then
-        next_buffer = buffer
-      end
+  ---@type YaziVisibleBuffer | nil
+  local next_buffer = nil
 
-      if not next_buffer then
+  -- find out what the currently highlighted buffer is, and what is the next
+  -- buffer to be highlighted
+  local current_cycle_position = (
+    context.cycled_file and context.cycled_file.path
+  )
+  if not current_cycle_position and context.input_path:is_dir() then
+    Log:debug(
+      string.format(
+        'No current cycle position found for path: "%s" (%s), so will use the first buffer "%s".',
+        context.input_path,
+        vim.inspect(current_cycle_position),
+        show_visible_buffer(visible_buffers[1])
+      )
+    )
+
+    next_buffer = visible_buffers[1]
+  else
+    local current = (
+      current_cycle_position and current_cycle_position:absolute()
+    ) or context.input_path:absolute()
+    assert(current, "No current cycle position found")
+
+    for i, buffer in ipairs(visible_buffers) do
+      if buffer.renameable_buffer:matches_exactly(current) then
+        local other_buffers = vim.list_slice(visible_buffers, i + 1)
+        other_buffers =
+          vim.list_extend(other_buffers, visible_buffers, 1, i - 1)
+        next_buffer = vim.iter(other_buffers):find(function(b)
+          ---@cast b YaziVisibleBuffer
+          local this = b.renameable_buffer.path:absolute()
+          return this ~= current
+        end)
+
         Log:debug(
           string.format(
-            'Could not find next buffer for path: "%s".',
-            context.input_path
+            "Current cycled buffer: %s (index %s), next buffer: %s",
+            show_visible_buffer(buffer),
+            i,
+            show_visible_buffer(next_buffer)
           )
         )
-        return
+        break
       end
-
-      local nextfile = next_buffer.renameable_buffer.path.filename
-      Log:debug(
-        string.format(
-          'Found buffer for path: "%s", will open the next buffer: "%s"',
-          context.input_path,
-          nextfile
-        )
-      )
-
-      -- make sure the type is a string, because plenary thinks it is `string|unknown`
-      assert(type(nextfile) == "string", "Expected filename to be a string")
-      context.api:reveal(nextfile)
-      context.cycled_file = next_buffer.renameable_buffer
-      return
     end
+  end
+
+  if not next_buffer then
+    Log:debug(
+      string.format(
+        'Could not find next buffer for path: "%s".',
+        context.input_path
+      )
+    )
+    return
+  end
+
+  local nextfile = next_buffer.renameable_buffer.path.filename
+  if not nextfile then
+    Log:debug(
+      string.format(
+        'Could not find cycle_open_buffers for path: "%s"',
+        context.input_path
+      )
+    )
+    return
   end
 
   Log:debug(
     string.format(
-      'Could not find cycle_open_buffers for path: "%s"',
-      context.input_path
+      'Found buffer for path: "%s", will reveal the next buffer: "%s"',
+      context.input_path,
+      nextfile
     )
   )
+
+  -- make sure the type is a string, because plenary thinks it is `string|unknown`
+  context.api:reveal(next_buffer.renameable_buffer.path:absolute())
+  context.cycled_file = next_buffer.renameable_buffer
 end
 
 ---@param config YaziConfig

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -21,7 +21,11 @@ end
 ---@return vim.SystemObj
 function YaziProcessApi:reveal(path)
   require("yazi.log"):debug(
-    string.format("Using ya to reveal path: '%s'", path)
+    string.format(
+      "Using 'ya emit-to %s' to reveal path: '%s'",
+      self.yazi_id,
+      path
+    )
   )
   return vim.system(
     { "ya", "emit-to", self.yazi_id, "reveal", "--str", path },


### PR DESCRIPTION
# fix: not being able to cycle buffers with `tab` after `:Yazi cwd`

Issue
=====

After `:Yazi cwd`, the `tab` keybinding (for `cycle_open_buffers`) does
nothing.

The old implementation of cycling buffers depended on the initial file
that was opened - it was incorrectly presumed that the buffer is one of
the currently open buffers. This is not true when opening a directory.

Solution
========

Pick the first window as the initial target (the buffer to switch focus
to) when `:Yazi cwd` is used.

Closes https://github.com/mikavilpas/yazi.nvim/issues/914


# refactor: remove useless debug log

# refactor: clarify yazi_process_api log message

