### PR TITLE
Clarify that Neovim 0.11.0 or later is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For previewing images with yazi, see Yazi's documentation related to Neovim
 
 First, make sure you have the requirements:
 
-- Neovim 0.10.2 or later (nightly)
+- Neovim 0.11.0 or later (nightly)
 - yazi [0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) or later
 - New features might require a recent version of yazi (see
   [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md))

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -24,9 +24,9 @@ return {
     local msg = string.format("Running yazi.nvim version %s", yazi.version)
     vim.health.info(msg)
 
-    if vim.fn.has("nvim-0.10.0") ~= 1 then
+    if vim.fn.has("nvim-0.11.0") ~= 1 then
       vim.health.warn(
-        "yazi.nvim requires Neovim >= 0.10.0. You might have unexpected issues."
+        "yazi.nvim requires Neovim >= 0.11.0. You might have unexpected issues."
       )
     end
 


### PR DESCRIPTION
# chore: healthcheck warns that nvim-0.11.0 is required

# docs: README specifies Neovim 0.11.0 or later is required

---

Mentioned in https://github.com/mikavilpas/yazi.nvim/issues/919