### PR TITLE
test: poll for yazi readiness and hover states

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -7,12 +7,7 @@ import { inspect } from "util"
 
 const __dirname = fileURLToPath(new URL(".", import.meta.resolve(".")))
 
-const yaziLogFile = path.join(
-  __dirname,
-  "test-environment",
-  ".repro",
-  "yazi.log",
-)
+const yaziLogFile = path.resolve(__dirname, "test-environment/.repro/yazi.log")
 
 console.log(`yaziLogFile: ${yaziLogFile}`)
 

--- a/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
+++ b/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
@@ -1,5 +1,5 @@
 import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
-import { yaziText } from "./utils/yazi-utils"
+import { assertYaziIsReady, yaziText } from "./utils/yazi-utils"
 
 // NOTE: cypress doesn't support the tab key, but control+i seems to work fine
 // https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
@@ -42,7 +42,7 @@ describe("revealing another open split (buffer) in yazi", () => {
 
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains(yaziText)
 
       // Switch to the other buffers' directories in yazi. This should make
@@ -95,7 +95,7 @@ describe("revealing another open split (buffer) in yazi", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains(yaziText)
 
       cy.typeIntoTerminal("{control+i}")

--- a/integration-tests/cypress/e2e/hover-highlights.cy.ts
+++ b/integration-tests/cypress/e2e/hover-highlights.cy.ts
@@ -8,6 +8,7 @@ import {
   isNotHoveredInNeovim,
   lightBackgroundColors,
 } from "./utils/hover-utils"
+import { assertYaziIsReady } from "./utils/yazi-utils"
 
 describe("highlighting the buffer with 'hover' events", () => {
   beforeEach(() => {
@@ -33,7 +34,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // yazi should be visible now
       cy.contains(nvim.dir.contents["file2.txt"].name)
@@ -112,7 +113,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
       // start yazi - the initial file should be highlighted
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("-- TERMINAL --")
 
       // yazi should be visible now
@@ -145,7 +146,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
         // start yazi
         cy.typeIntoTerminal("{upArrow}")
-        nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+        assertYaziIsReady(nvim)
 
         // yazi should be visible now
         cy.contains(nvim.dir.contents["file2.txt"].name)
@@ -184,7 +185,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
         // start yazi
         cy.typeIntoTerminal("{upArrow}")
-        nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+        assertYaziIsReady(nvim)
 
         // yazi should be visible now
         cy.contains(nvim.dir.contents["file2.txt"].name)
@@ -221,7 +222,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // yazi should be visible now
       cy.contains(nvim.dir.contents["file2.txt"].name)
@@ -258,7 +259,7 @@ describe("highlighting the buffer with 'hover' events", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // yazi should be visible now
       cy.contains("subdirectory" satisfies MyTestDirectoryFile)
@@ -305,7 +306,7 @@ describe("highlighting the buffer with 'hover' events", () => {
       cy.contains(view.rightFile.text)
 
       nvim.runExCommand({ command: `:Yazi cwd` })
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // before doing anything, both files should be unhovered (have the
       // default background color)

--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -1,6 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify } from "@tui-sandbox/library/dist/src/client/color-utilities"
 import type { MyTestDirectoryFile } from "MyTestDirectory"
+import { assertYaziIsReady } from "./utils/yazi-utils"
 
 describe("reading events", () => {
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe("reading events", () => {
       cy.contains("If you see this text, Neovim is ready!")
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // move to the parent directory. This should make yazi send the "cd" event,
       // indicating that the directory was changed
@@ -53,7 +54,7 @@ describe("reading events", () => {
 
       // start yazi and wait for it to display contents
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("subdirectory" satisfies MyTestDirectoryFile)
 
       // start file deletion
@@ -106,7 +107,7 @@ describe("reading events", () => {
 
       // start yazi and wait for it to display contents
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("subdirectory" satisfies MyTestDirectoryFile)
 
       // start file deletion
@@ -150,7 +151,7 @@ describe("'rename' events", () => {
 
       // start yazi and wait for the current file to be highlighted
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains(nvim.dir.contents["initial-file.txt"].name).should(
         "have.css",
         "background-color",
@@ -179,7 +180,7 @@ describe("'rename' events", () => {
       cy.contains("E13").should("not.exist")
 
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("dir with spaces" satisfies MyTestDirectoryFile)
       cy.typeIntoTerminal("r")
       cy.contains("Rename:")
@@ -217,7 +218,7 @@ describe("'rename' events", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("other-subdirectory" satisfies MyTestDirectoryFile)
 
       cy.typeIntoTerminal("r")
@@ -257,7 +258,7 @@ describe("'rename' events", () => {
 
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // wait for yazi to start
       cy.contains("other-subdirectory" satisfies MyTestDirectoryFile)
@@ -304,7 +305,7 @@ describe("'rename' events", () => {
 
       // start yazi and wait for it to be ready
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("config-modifications" satisfies MyTestDirectoryFile)
 
       // start file renaming
@@ -346,7 +347,7 @@ describe("'rename' events", () => {
 
       // start yazi and wait for it to be ready
       cy.typeIntoTerminal("{upArrow}")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       cy.contains("config-modifications" satisfies MyTestDirectoryFile)
 
       // move to another directory
@@ -389,7 +390,7 @@ describe("'rename' events", () => {
         // they want to subscribe to. These are emitted as YaziDDSCustom events.
         cy.contains("If you see this text, Neovim is ready!")
         cy.typeIntoTerminal("{upArrow}")
-        nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+        assertYaziIsReady(nvim)
         cy.contains(nvim.dir.contents["file2.txt"].name)
 
         // publish the custom MyMessageNoData event that we subscribed to in

--- a/integration-tests/cypress/e2e/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/toggling.cy.ts
@@ -1,5 +1,6 @@
 import { flavors } from "@catppuccin/palette"
 import { hoverFileAndVerifyItsHovered, rgbify } from "./utils/hover-utils"
+import { assertYaziIsReady } from "./utils/yazi-utils"
 
 describe("toggling yazi to pseudo-continue the previous session", () => {
   beforeEach(() => {
@@ -69,7 +70,7 @@ describe("toggling yazi to pseudo-continue the previous session", () => {
       // toggle yazi and set up a session that hovers a directory
       cy.typeIntoTerminal("{upArrow}")
       cy.log("yazi should be visible, showing other files")
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
       hoverFileAndVerifyItsHovered(nvim, "dir with spaces/file1.txt")
 
       // yazi should be visible, showing other files

--- a/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
@@ -1,5 +1,5 @@
 import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
-import { yaziText } from "./utils/yazi-utils"
+import { assertYaziIsReady, yaziText } from "./utils/yazi-utils"
 
 // The yazi keymappings need to be defined in the yazi config. The test
 // environment contains the mapping in the .config/yazi/keymap.toml file
@@ -45,7 +45,7 @@ describe("revealing another open split (buffer) in yazi", () => {
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
       cy.contains(yaziText)
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       // Switch to the other buffers' directories in yazi. This should make
       // yazi send a hover event for the new, highlighted file.
@@ -86,7 +86,7 @@ describe("revealing another open split (buffer) in yazi", () => {
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
       cy.contains(yaziText)
-      nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+      assertYaziIsReady(nvim)
 
       cy.typeIntoTerminal("I")
       nvim.runExCommand({ command: "messages" }).then((result) => {


### PR DESCRIPTION
Should reduce test flakiness - sometimes yazi and ya take a bit longer to start up. We don't want to start executing the test actions in these cases, because the results are unpredictable.