### PR TITLE
refactor: consolidate retry logic to its own module

### DIFF
--- a/lua/yazi/process/retry.lua
+++ b/lua/yazi/process/retry.lua
@@ -1,0 +1,32 @@
+local retry = {}
+
+---@class yazi.RetryParams
+---@field action fun(retries_remaining: integer): unknown # the action to retry. Raises an error if the retry fails
+---@field retries integer # number of retries to attempt if the action fails
+---@field delay integer # delay in ms before retrying
+---@field on_failure fun(fail_result: unknown, retries_remaining: integer) # called when a poll fails
+---@field on_final_failure fun(fail_result: unknown) # called when all retries fail, before exiting
+
+---@async
+---@param params yazi.RetryParams
+function retry.retry(params)
+  local retries_remaining = params.retries
+  local function try()
+    local success, result = pcall(params.action, retries_remaining)
+
+    if not success then
+      retries_remaining = retries_remaining - 1
+      if retries_remaining == 0 then
+        params.on_final_failure(result)
+        return
+      end
+
+      params.on_failure(result, retries_remaining)
+      vim.defer_fn(try, params.delay)
+    end
+  end
+
+  try()
+end
+
+return retry

--- a/spec/yazi/retry_spec.lua
+++ b/spec/yazi/retry_spec.lua
@@ -1,0 +1,64 @@
+local assert = require("luassert")
+local match = require("luassert.match")
+local spy = require("luassert.spy")
+
+local retry = require("yazi.process.retry")
+
+describe("retry", function()
+  it("retries the action if it fails", function()
+    local action_call_count = 0
+    local action = spy.new(function()
+      action_call_count = action_call_count + 1
+      error("Action failed, so that it will be retried")
+    end)
+    local on_failure = spy.new(function() end)
+    local on_final_failure = spy.new(function() end)
+
+    retry.retry({
+      action = action --[[@as fun(): unknown]],
+      retries = 15,
+      delay = 1,
+      on_failure = on_failure --[[@as fun(fail_result: unknown, retries_remaining: integer)]],
+      on_final_failure = on_final_failure --[[@as fun(fail_result: unknown)]],
+    })
+
+    vim.wait(2000, function()
+      return action_call_count == 15
+    end, 50)
+    assert.spy(action).was.called(15)
+    assert.spy(on_failure).was.called(14)
+
+    assert.spy(on_final_failure).was.called(1)
+    assert
+      .spy(on_failure).was
+      .called_with(match.matches("Action failed, so that it will be retried", 1, true), 1)
+  end)
+
+  it("exits as soon as the action succeeds", function()
+    local action_call_count = 0
+    local action = spy.new(function()
+      action_call_count = action_call_count + 1
+    end)
+    local on_failure = spy.new(function() end)
+    local on_final_failure = spy.new(function() end)
+
+    retry.retry({
+      action = action --[[@as fun(): unknown]],
+      retries = 15,
+      delay = 1,
+      on_failure = on_failure --[[@as fun(fail_result: unknown, retries_remaining: integer)]],
+      on_final_failure = on_final_failure --[[@as fun(fail_result: unknown)]],
+    })
+
+    vim.wait(1000, function()
+      local success = pcall(function()
+        assert.spy(action).was.called(1)
+      end)
+      return success
+    end, 50)
+
+    assert.spy(action).was.called(1)
+    assert.spy(on_failure).was.not_called()
+    assert.spy(on_final_failure).was.not_called()
+  end)
+end)

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -2,8 +2,6 @@ local assert = require("luassert")
 local ya_process = require("yazi.process.ya_process")
 local spy = require("luassert.spy")
 
-require("plenary.async").tests.add_to_env()
-
 describe("the get_yazi_command() function", function()
   it("specifies opening multiple tabs when enabled in the config", function()
     local config = require("yazi.config").default()


### PR DESCRIPTION
# refactor: consolidate retry logic to its own module

# test: don't use plenary.async as there is no need for it

