### PR TITLE
test: lazy load lsp-file-operations to avoid fast event error

### DIFF
--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -2,8 +2,6 @@
 
 local utils = require("yazi.utils")
 local plenaryIterators = require("plenary.iterators")
-local lsp_delete = require("yazi.lsp.delete")
-local lsp_rename = require("yazi.lsp.rename")
 
 local M = {}
 
@@ -38,7 +36,7 @@ function M.process_delete_event(event, config, remaining_events)
               config.integrations.bufdelete_implementation,
               buffer.bufnr
             )
-            lsp_delete.file_deleted(buffer.path.filename)
+            require("yazi.lsp.delete").file_deleted(buffer.path.filename)
           end)
         end
       end
@@ -87,6 +85,7 @@ end
 ---@param config YaziConfig
 ---@param context YaziActiveContext
 function M.process_events_emitted_from_yazi(events, config, context)
+  local lsp_rename = require("yazi.lsp.rename")
   for i, event in ipairs(events) do
     if event.type == "rename" then
       ---@cast event YaziRenameEvent


### PR DESCRIPTION
Issue
=====

The error below was logged when running the unit tests with `just test`:

```rs
117 successes / 0 failures / 0 errors / 0 pending : 0.360738 seconds
Error executing callback:
.../site/pack/vendor/start/plenary.nvim/lua/plenary/log.lua:12: E5560: Vimscript function must not be called in a fast event context
stack traceback:
        [C]: in function 'getenv'
        .../site/pack/vendor/start/plenary.nvim/lua/plenary/log.lua:12: in main chunk
        [C]: in function 'require'
        ...embedded-lsp-file-operations/lsp-file-operations/log.lua:1: in main chunk
        [C]: in function 'require'
        ...bedded-lsp-file-operations/lsp-file-operations/utils.lua:4: in main chunk
        [C]: in function 'require'
        ...-lsp-file-operations/lsp-file-operations/will-delete.lua:2: in main chunk
        [C]: in function 'require'
        ./lua/yazi/lsp/delete.lua:1: in main chunk
        [C]: in function 'require'
        ./lua/yazi/event_handling/yazi_event_handling.lua:5: in main chunk
        [C]: in function 'require'
        ./lua/yazi/process/ya_process.lua:208: in function 'process_events'
        ./lua/yazi/process/ya_process.lua:191: in function 'handler'
        ...share/bob/nightly/share/nvim/runtime/lua/vim/_system.lua:172: in function <...share/bob/nightly/share/nvim/runtime/lua/vim/_system.lua:17
```

Solution
========

Lazy load `lsp-file-operations` to avoid the error.