### PR TITLE
feat(snacks): add copy relative path action to snacks.nvim picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ These are the default keybindings that are available when yazi is open:
       limited to those only
   - `<c-y>`: copy the relative path of the selected file(s) to the clipboard.
     Requires GNU `realpath` or `grealpath` on OSX
+    - also available for the snacks.nvim picker, see
+      [here](documentation/copy-relative-path-to-files.md) for more information
   - `<tab>`: make yazi jump to the open buffers in Neovim. See
     [#232](https://github.com/mikavilpas/yazi.nvim/pull/232) for more
     information
@@ -312,22 +314,38 @@ return {
       grep_in_directory = function(directory)
         -- the default implementation uses telescope if available, otherwise nothing
       end,
+
       grep_in_selected_files = function(selected_files)
         -- similar to grep_in_directory, but for selected files
       end,
+
       --- Similarly, search and replace in the files in the directory
       replace_in_directory = function(directory)
         -- default: grug-far.nvim
       end,
+
       replace_in_selected_files = function(selected_files)
         -- default: grug-far.nvim
       end,
+
       -- `grealpath` on OSX, (GNU) `realpath` otherwise
       resolve_relative_path_application = "",
+
       -- how to delete (close) a buffer. Defaults to `snacks.bufdelete` from
       -- https://github.com/folke/snacks.nvim, which maintains the window
       -- layout.
       bufdelete_implementation = "snacks-if-available",
+
+      -- add an action to a file picker to copy the relative path to the
+      -- selected file(s). The implementation is the same as for the
+      -- `copy_relative_path_to_selected_files` yazi.nvim keymap. Currently
+      -- only snacks.nvim is supported. Documentation can be found in the
+      -- keybindings section of the readme.
+      --
+      -- available options:
+      -- - nil (default, no action added)
+      -- - "snacks.picker" (snacks.nvim)
+      picker_add_copy_relative_path_action = nil,
     },
 
     future_features = {

--- a/documentation/copy-relative-path-to-files.md
+++ b/documentation/copy-relative-path-to-files.md
@@ -1,0 +1,52 @@
+# Copying the relative path to files
+
+## Usage with yazi
+
+When yazi is open, you can copy the relative path from the current file to other
+files or directories. By default it's mapped to `<c-y>` and requires GNU
+`realpath` or `grealpath` on OSX.
+
+## Usage with snacks.nvim
+
+If you use
+[snacks.nvim](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md),
+you can also copy relative file paths with the snacks.nvim picker. To do this,
+do the following in your config:
+
+- create a snacks.nvim keymap available in the picker, e.g. for `<C-y>` in
+  normal and insert mode
+- ```lua
+  ---@module "lazy"
+  ---@type LazySpec
+  return {
+    {
+      "folke/snacks.nvim",
+      priority = 1000,
+      lazy = false,
+      ---@type snacks.Config
+      opts = {
+        picker = {
+          win = {
+            input = {
+              keys = {
+                ["<C-y>"] = { "yazi_copy_relative_path", mode = { "n", "i" } },
+                -- 👆🏻 add this and customize the keybinding to suit your needs
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      "mikavilpas/yazi.nvim",
+      -- (more config keys here)
+      ---@type YaziConfig
+      opts = {
+        integrations = {
+          picker_add_copy_relative_path_action = "snacks.picker",
+          -- 👆🏻 add this
+        },
+      },
+    },
+  }
+  ```

--- a/integration-tests/cypress/e2e/lsp.cy.ts
+++ b/integration-tests/cypress/e2e/lsp.cy.ts
@@ -43,8 +43,8 @@ describe("rename events with LSP support", () => {
       // The LSP server asks for confirmation. Other LSPs don't seem to do
       // this, but it works...
       cy.contains("Do you want to modify the require path?")
-      cy.contains("1: Modify")
-      cy.typeIntoTerminal("1{enter}")
+      cy.contains("1. Modify")
+      cy.typeIntoTerminal("{enter}")
       cy.contains("Do you want to modify the require path?").should("not.exist")
 
       // go back to the init.lua file and verify the require path was updated
@@ -97,7 +97,7 @@ describe("rename events with LSP support", () => {
       // The LSP server asks for confirmation. Other LSPs don't seem to do
       // this, but it works...
       cy.contains("Do you want to modify the require path?")
-      cy.contains("1: Modify")
+      cy.contains("1. Modify")
       cy.typeIntoTerminal("1{enter}")
       cy.contains("Do you want to modify the require path?").should("not.exist")
 
@@ -154,7 +154,7 @@ describe("move events with LSP support", () => {
 
       // The LSP server should be asking for confirmation
       cy.contains("Do you want to modify the require path?")
-      cy.contains("1: Modify")
+      cy.contains("1. Modify")
       cy.typeIntoTerminal("1{enter}")
       cy.contains("Do you want to modify the require path?").should("not.exist")
 

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -65,6 +65,7 @@ local plugins = {
       future_features = {},
       integrations = {
         grep_in_directory = "telescope",
+        picker_add_copy_relative_path_action = "snacks.picker",
       },
     },
   },
@@ -82,7 +83,32 @@ local plugins = {
   { "ibhagwan/fzf-lua" },
   { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
   { "https://github.com/MagicDuck/grug-far.nvim", opts = {} },
-  { "folke/snacks.nvim", opts = {} },
+  {
+    "folke/snacks.nvim",
+    priority = 1000,
+    lazy = false,
+    ---@type snacks.Config
+    opts = {
+      picker = {
+        win = {
+          input = {
+            keys = {
+              ["<C-y>"] = { "yazi_copy_relative_path", mode = { "n", "i" } },
+            },
+          },
+        },
+      },
+    },
+    keys = {
+      {
+        "<leader><space>",
+        function()
+          Snacks.picker.smart()
+        end,
+        desc = "Smart Find Files",
+      },
+    },
+  },
   {
     "neovim/nvim-lspconfig",
     dependencies = {

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -257,6 +257,13 @@ function M.setup(opts)
     Log:debug("Hijacking netrw to open yazi for directories")
     require("yazi.hijack_netrw").hijack_netrw(yazi_augroup)
   end
+
+  if
+    M.config.integrations.picker_add_copy_relative_path_action
+    == "snacks.picker"
+  then
+    require("yazi.integrations.snacks_relative_path").setup_copy_relative_path_picker_action()
+  end
 end
 
 return M

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -83,6 +83,7 @@ function M.default()
           and "grealpath"
         or "realpath",
       bufdelete_implementation = "snacks-if-available",
+      picker_add_copy_relative_path_action = nil,
     },
 
     floating_window_scaling_factor = 0.9,

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -267,7 +267,7 @@ function M.set_keymappings(yazi_buffer, config, context)
           api = context.api,
           on_file_opened = function(chosen_file)
             local relative_path = require("yazi.utils").relative_path(
-              config,
+              config.integrations.resolve_relative_path_application,
               context.input_path.filename,
               chosen_file
             )
@@ -279,7 +279,7 @@ function M.set_keymappings(yazi_buffer, config, context)
             for _, path in ipairs(chosen_files) do
               relative_paths[#relative_paths + 1] =
                 require("yazi.utils").relative_path(
-                  config,
+                  config.integrations.resolve_relative_path_application,
                   context.input_path.filename,
                   path
                 )

--- a/lua/yazi/integrations/snacks_relative_path.lua
+++ b/lua/yazi/integrations/snacks_relative_path.lua
@@ -1,0 +1,67 @@
+local M = {}
+
+--
+function M.setup_copy_relative_path_picker_action()
+  local snacks_picker = require("snacks.picker")
+
+  local yazi_copy_relative_path = "yazi_copy_relative_path"
+  if snacks_picker.actions[yazi_copy_relative_path] then
+    require("yazi.log"):debug(
+      string.format(
+        "snacks.picker already has the key '%s'. Not overriding it.",
+        yazi_copy_relative_path
+      )
+    )
+    return
+  end
+
+  ---@param picker snacks.Picker
+  snacks_picker.actions[yazi_copy_relative_path] = function(picker)
+    local Log = require("yazi.log")
+    local config = require("yazi").config
+    assert(
+      config.clipboard_register,
+      "clipboard_register is nil, cannot copy to it"
+    )
+    assert(
+      config.integrations.resolve_relative_path_application,
+      "resolve_relative_path_application is nil, cannot copy with it"
+    )
+
+    local current_file_dir = vim.fn.expand("#:p:h")
+    if current_file_dir == nil then
+      error("no current_file_dir, cannot do anything")
+    end
+    local cwd = picker.finder.filter.cwd
+    assert(cwd, "cwd is nil")
+
+    local selected_files = picker:selected({ fallback = true })
+
+    ---@type string[]
+    local relative_paths = {}
+    for _, selected_file in ipairs(selected_files) do
+      local full_path = vim.fs.joinpath(cwd, assert(selected_file.file))
+      local relative_path = require("yazi.utils").relative_path(
+        config.integrations.resolve_relative_path_application,
+        current_file_dir,
+        full_path
+      )
+      table.insert(relative_paths, relative_path)
+    end
+    local text = table.concat(relative_paths, "\n")
+
+    vim.fn.setreg(config.clipboard_register, text)
+
+    Log:debug(
+      string.format(
+        "Copied relative paths to the register '%s': %s",
+        config.clipboard_register,
+        vim.inspect(relative_paths)
+      )
+    )
+
+    picker:close()
+  end
+end
+
+return M

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -59,6 +59,7 @@
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil # called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim
 ---@field public resolve_relative_path_application? string # the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS
 ---@field public bufdelete_implementation? YaziBufdeleteImpl # how to delete (close) a buffer. Defaults to `snacks.bufdelete` from https://github.com/folke/snacks.nvim, which maintains the window layout.
+---@field public picker_add_copy_relative_path_action? "snacks.picker" # add an action to a file picker to copy the relative path to the selected file(s). The implementation is the same as for the `copy_relative_path_to_selected_files` yazi.nvim keymap. Currently only snacks.nvim is supported. Documentation can be found in the keybindings section of the readme. The default is `nil`, which means no action is added.
 
 ---@alias YaziBufdeleteImpl
 ---| "snacks-if-available" # the implementation from https://github.com/folke/snacks.nvim, which maintains the window layout. If not available, falls back to the builtin implementation in `vim.api.nvim_buf_delete()`, which does not maintain the window layout.

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -3,15 +3,15 @@ local plenary_path = require("plenary.path")
 
 local M = {}
 
----@param config YaziConfig
+---@param realpath_application string
 ---@param current_file_dir string
 ---@param selected_file string
 ---@return string
-function M.relative_path(config, current_file_dir, selected_file)
-  local command = config.integrations.resolve_relative_path_application
+function M.relative_path(realpath_application, current_file_dir, selected_file)
+  local command = realpath_application
   assert(
     command ~= nil,
-    "resolve_relative_path_application must be set. Please report this as a bug."
+    "realpath_application must be set. Please report this as a bug."
   )
 
   if vim.fn.executable(command) == 0 then

--- a/spec/yazi/relative_path_spec.lua
+++ b/spec/yazi/relative_path_spec.lua
@@ -41,12 +41,16 @@ describe("relative_path", function()
   end)
 
   -- test basic cases, not necessarily the entire feature set of GNU realpath
+  local realpath_application =
+    yazi.config.integrations.resolve_relative_path_application
+  assert(realpath_application)
 
   it("returns the relative path from a directory to a subdirectory", function()
     local subdirectory = vim.fs.joinpath(base_dir, "subdirectory")
 
     vim.fn.mkdir(subdirectory)
-    local result = utils.relative_path(yazi.config, base_dir, subdirectory)
+    local result =
+      utils.relative_path(realpath_application, base_dir, subdirectory)
 
     assert.are.same("subdirectory", result)
   end)
@@ -55,7 +59,7 @@ describe("relative_path", function()
     local subfile = vim.fs.joinpath(base_dir, "subfile")
     create_file(subfile)
 
-    local result = utils.relative_path(yazi.config, base_dir, subfile)
+    local result = utils.relative_path(realpath_application, base_dir, subfile)
 
     assert.are.same("subfile", result)
   end)
@@ -70,7 +74,7 @@ describe("relative_path", function()
     local subdirectory = vim.fs.joinpath(base_dir, "subdirectory")
     vim.fn.mkdir(subdirectory)
 
-    local result = utils.relative_path(yazi.config, file, subdirectory)
+    local result = utils.relative_path(realpath_application, file, subdirectory)
 
     assert.are.same("subdirectory", result)
   end)


### PR DESCRIPTION
# feat(snacks): add copy relative path action to snacks.nvim picker (#938)

yazi.nvim has had the ability to copy the relative path to files for a
while now (default `<c-y>`). This commit adds the ability to do the same in
the snacks.nvim picker. It's not enabled by default.

When the snacks.nvim picker is open, you can press your keybinding for
this, and it will copy the relative paths to the selected file(s) to the
clipboard register.

To learn how to use this, you can read the documentation in the readme
file.


# refactor: `relative_path()` only requires the realpath application

Not the entire yazi config.


