### PR TITLE
feat: allow emitting arbitrary yazi commands after yazi is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Neovim.
     technical explanation is available
     [here](documentation/for-developers/lsp-renaming.md).
 - Customizable keybindings
-- 🆕 Plugin management for Yazi plugins and flavors
+- Plugin management for Yazi plugins and flavors
   ([documentation](./documentation/plugin-management.md))
+- 🆕 Send custom commands to yazi
+  ([documentation](./documentation/emitting-commands-to-yazi.md))
 
 For previewing images with yazi, see Yazi's documentation related to Neovim
 [here](https://yazi-rs.github.io/docs/image-preview/#neovim).

--- a/documentation/emitting-commands-to-yazi.md
+++ b/documentation/emitting-commands-to-yazi.md
@@ -1,0 +1,31 @@
+# Emitting Commands to Yazi
+
+> [!NOTE]
+>
+> This is an advanced feature that requires some manual coding.
+
+When Yazi is running, it supports receiving instructions to execute yazi
+commands. These can be sent using `ya emit-to`:
+
+- <https://yazi-rs.github.io/docs/dds#ya-emit>
+
+The available commands are documented in the Yazi documentation:
+
+- <https://yazi-rs.github.io/docs/configuration/keymap>
+
+## Example: start yazi and immediately enter find mode
+
+```lua
+-- open yazi and immediately enter find mode ("Find next") in yazi
+vim.keymap.set("n", "<leader>r", function()
+  require("yazi").yazi({
+    ---@diagnostic disable-next-line: missing-fields
+    hooks = {
+      on_yazi_ready = function(_, _, process_api)
+        -- https://yazi-rs.github.io/docs/configuration/keymap/#manager.find
+        process_api:emit_to_yazi({ "find", "--smart" })
+      end,
+    },
+  })
+end)
+```

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -56,6 +56,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("add_command_to_reveal_a_file.lua"),
           type: z.literal("file"),
         }),
+        "add_keybinding_to_start_yazi_and_find.lua": z.object({
+          name: z.literal("add_keybinding_to_start_yazi_and_find.lua"),
+          type: z.literal("file"),
+        }),
         "add_yazi_context_assertions.lua": z.object({
           name: z.literal("add_yazi_context_assertions.lua"),
           type: z.literal("file"),
@@ -257,6 +261,7 @@ export const testDirectoryFiles = z.enum([
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications/add_command_to_reveal_a_file.lua",
+  "config-modifications/add_keybinding_to_start_yazi_and_find.lua",
   "config-modifications/add_yazi_context_assertions.lua",
   "config-modifications/disable_a_keybinding.lua",
   "config-modifications/modify_yazi_config_and_add_hovered_buffer_background.lua",

--- a/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
@@ -99,4 +99,22 @@ describe("revealing another open split (buffer) in yazi", () => {
       assertYaziIsHovering(nvim, "initial-file.txt")
     })
   })
+
+  it(`can use the "on_yazi_ready" hook to run code after yazi is ready`, () => {
+    cy.startNeovim({
+      filename: "initial-file.txt",
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "add_keybinding_to_start_yazi_and_find.lua",
+      ],
+    }).then((nvim) => {
+      cy.contains("If you see this text, Neovim is ready!")
+
+      // start yazi and wait for it to be visible
+      cy.typeIntoTerminal(" r")
+      assertYaziIsReady(nvim)
+
+      cy.contains("Find next:")
+    })
+  })
 })

--- a/integration-tests/test-environment/config-modifications/add_keybinding_to_start_yazi_and_find.lua
+++ b/integration-tests/test-environment/config-modifications/add_keybinding_to_start_yazi_and_find.lua
@@ -1,0 +1,12 @@
+-- open yazi and immediately enter find mode ("Find next") in yazi
+vim.keymap.set("n", "<leader>r", function()
+  require("yazi").yazi({
+    ---@diagnostic disable-next-line: missing-fields
+    hooks = {
+      on_yazi_ready = function(_, _, process_api)
+        -- https://yazi-rs.github.io/docs/configuration/keymap/#manager.find
+        process_api:emit_to_yazi({ "find", "--smart" })
+      end,
+    },
+  })
+end)

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -43,6 +43,7 @@ function M.default()
     set_keymappings_function = nil,
     hooks = {
       yazi_opened = function() end,
+      on_yazi_ready = function() end,
       yazi_closed_successfully = function() end,
       yazi_opened_multiple_files = openers.open_multiple_files,
     },

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -15,22 +15,30 @@ function YaziProcessApi.new(config, yazi_id)
   return self
 end
 
---- Tell yazi to focus (hover on) the given path.
----@see https://yazi-rs.github.io/docs/configuration/keymap#manager.reveal
----@param path string
+--- Emit a command to the yazi process.
+--- https://yazi-rs.github.io/docs/dds#ya-emit
+---@param args string[]
 ---@return vim.SystemObj
-function YaziProcessApi:reveal(path)
+function YaziProcessApi:emit_to_yazi(args)
   require("yazi.log"):debug(
     string.format(
-      "Using 'ya emit-to %s' to reveal path: '%s'",
+      "Using 'ya emit-to %s' with args: '%s'",
       self.yazi_id,
-      path
+      vim.inspect(args)
     )
   )
   return vim.system(
-    { "ya", "emit-to", self.yazi_id, "reveal", "--str", path },
+    { "ya", "emit-to", self.yazi_id, unpack(args) },
     { timeout = 1000 }
   )
+end
+
+--- Tell yazi to focus (hover on) the given path.
+--- https://yazi-rs.github.io/docs/configuration/keymap#manager.reveal
+---@param path string
+---@return vim.SystemObj
+function YaziProcessApi:reveal(path)
+  return self:emit_to_yazi({ "reveal", "--str", path })
 end
 
 --- Tell yazi to open the currently selected file(s).

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -49,6 +49,7 @@
 
 ---@class (exact) YaziConfigHooks
 ---@field public yazi_opened fun(preselected_path: string | nil, buffer: integer, config: YaziConfig):nil
+---@field public on_yazi_ready fun(buffer: integer, config: YaziConfig, process_api: YaziProcessApi):nil
 ---@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig, state: YaziClosedState): nil
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
 


### PR DESCRIPTION
When Yazi is running, it supports receiving instructions to execute yazi commands. These can be sent using `ya emit-to`:
- https://yazi-rs.github.io/docs/dds#ya-emit

Provide two things to take advantage of this:
- a new `on_yazi_ready` hook that is called when yazi is ready to receive commands
- a new `emit_to_yazi` method on the YaziProcessApi that allows sending commands to yazi.

This allows starting yazi in various interesting states, such as immediately entering find mode.

More detailed documentation can be found in the features section of the readme.

Closes https://github.com/mikavilpas/yazi.nvim/issues/944