### PR TITLE
refactor: remove fallbacks for missing winborder option

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,7 +21,7 @@
     "@types/tinycolor2": "1.4.6",
     "concurrently": "9.1.2",
     "eslint": "9.26.0",
-    "eslint-config-prettier": "10.1.3",
+    "eslint-config-prettier": "10.1.5",
     "eslint-plugin-no-only-tests": "3.3.0",
     "tinycolor2": "1.6.0",
     "type-fest": "4.41.0",

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -6,16 +6,9 @@ function M.default()
   local openers = require("yazi.openers")
 
   local border = "rounded"
-  pcall(function()
-    -- Neovim 0.11 supports configuring floating window borders for all plugins
-    -- centrally with the "winborder" setting. Older Neovim versions do not
-    -- have this available, so we need to prevent the "Unknown option
-    -- 'winborder'" error which happens if the option is not available.
-    -- https://github.com/neovim/neovim/pull/31074
-    if vim.o.winborder ~= "" then
-      border = vim.o.winborder
-    end
-  end)
+  if vim.o.winborder ~= "" then
+    border = vim.o.winborder
+  end
 
   ---@type YaziConfig
   return {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "markdownlint-cli2": "0.17.2",
     "prettier": "3.5.3",
     "prettier-plugin-organize-imports": "4.1.0",
-    "prettier-plugin-packagejson": "2.5.11"
+    "prettier-plugin-packagejson": "2.5.12"
   },
   "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(prettier@3.5.3)(typescript@5.8.3)
       prettier-plugin-packagejson:
-        specifier: 2.5.11
-        version: 2.5.11(prettier@3.5.3)
+        specifier: 2.5.12
+        version: 2.5.12(prettier@3.5.3)
 
   integration-tests:
     dependencies:
@@ -58,8 +58,8 @@ importers:
         specifier: 9.26.0
         version: 9.26.0
       eslint-config-prettier:
-        specifier: 10.1.3
-        version: 10.1.3(eslint@9.26.0)
+        specifier: 10.1.5
+        version: 10.1.5(eslint@9.26.0)
       eslint-plugin-no-only-tests:
         specifier: 3.3.0
         version: 3.3.0
@@ -1012,8 +1012,8 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-config-prettier@10.1.3:
-    resolution: {integrity: sha512-vDo4d9yQE+cS2tdIT4J02H/16veRvkHgiLDRpej+WL67oCfbOb97itZXn8wMPJ/GsiEBVjrjs//AVNw2Cp1EcA==}
+  eslint-config-prettier@10.1.5:
+    resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -1965,8 +1965,8 @@ packages:
       vue-tsc:
         optional: true
 
-  prettier-plugin-packagejson@2.5.11:
-    resolution: {integrity: sha512-BJpXSrQhrewmeRxe1e/BYrWyrBG4yc+RaearWGdNwcUnHZQUffFVqPsXyB7tQA7WFeBRgh3wadXb9p2BPuLKvw==}
+  prettier-plugin-packagejson@2.5.12:
+    resolution: {integrity: sha512-IMBkjSNMaMx8QpmYD/5Y7gXn1hRBMY91EF29MotVSI6bT7SCDFZ7bXL9EeumEXn7tjUFYoN8D0fTs0XpxmYg8A==}
     peerDependencies:
       prettier: '>= 1.16.0'
     peerDependenciesMeta:
@@ -2181,8 +2181,8 @@ packages:
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
 
-  sort-package-json@3.2.0:
-    resolution: {integrity: sha512-jadbj4vvIlevL578X5+1qVX/Nn9Jk7/U+cLVjR1IqfDFo3ISY0eoyksd3ylyTwGunlEMUgbTRYowLr0CkSxcQw==}
+  sort-package-json@3.2.1:
+    resolution: {integrity: sha512-rTfRdb20vuoAn7LDlEtCqOkYfl2X+Qze6cLbNOzcDpbmKEhJI30tTN44d5shbKJnXsvz24QQhlCm81Bag7EOKg==}
     hasBin: true
 
   source-map@0.6.1:
@@ -3464,7 +3464,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.3(eslint@9.26.0):
+  eslint-config-prettier@10.1.5(eslint@9.26.0):
     dependencies:
       eslint: 9.26.0
 
@@ -4678,9 +4678,9 @@ snapshots:
       prettier: 3.5.3
       typescript: 5.8.3
 
-  prettier-plugin-packagejson@2.5.11(prettier@3.5.3):
+  prettier-plugin-packagejson@2.5.12(prettier@3.5.3):
     dependencies:
-      sort-package-json: 3.2.0
+      sort-package-json: 3.2.1
       synckit: 0.11.4
     optionalDependencies:
       prettier: 3.5.3
@@ -4952,7 +4952,7 @@ snapshots:
 
   sort-object-keys@1.1.3: {}
 
-  sort-package-json@3.2.0:
+  sort-package-json@3.2.1:
     dependencies:
       detect-indent: 7.0.1
       detect-newline: 4.0.1

--- a/spec/yazi/yazi_config_spec.lua
+++ b/spec/yazi/yazi_config_spec.lua
@@ -1,58 +1,30 @@
 local assert = require("luassert")
 local reset = require("spec.yazi.helpers.reset")
 
-local winborder_available = pcall(function()
-  -- it's only available for nightly 0.11+, see
-  -- https://github.com/neovim/neovim/pull/31074
-  --
-  -- will fail on stable neovim right now, so use pcall to avoid an error
-  return vim.o.winborder
-end)
-
-local function if_winborder_supported(fn)
-  -- prevent tests failing on stable
-  if winborder_available then
-    fn()
-  else
-    print("`vim.o.winborder` is not supported, skipping")
-  end
-end
-
 describe("the default config", function()
   before_each(function()
     reset.clear_all_buffers()
     reset.close_all_windows()
-    if_winborder_supported(function()
-      vim.o.winborder = "solid"
-    end)
+    vim.o.winborder = "solid"
   end)
 
   describe("`yazi_floating_window_border`", function()
     it("sets it to the default value if not set", function()
-      if_winborder_supported(function()
-        vim.o.winborder = ""
-        local config = require("yazi.config").default()
-        assert.same("rounded", config.yazi_floating_window_border)
-      end)
+      vim.o.winborder = ""
+      local config = require("yazi.config").default()
+      assert.same("rounded", config.yazi_floating_window_border)
     end)
 
     it("allows customizing it with the `vim.o.winborder` option", function()
-      if_winborder_supported(function()
-        vim.o.winborder = "single"
-        local config = require("yazi.config").default()
-        assert.same("single", config.yazi_floating_window_border)
-      end)
+      vim.o.winborder = "single"
+      local config = require("yazi.config").default()
+      assert.same("single", config.yazi_floating_window_border)
     end)
 
     it("yazi.setup() allows customizing it", function()
-      if_winborder_supported(function()
-        vim.o.winborder = "double"
-        require("yazi").setup({ yazi_floating_window_border = "single" })
-        assert.same(
-          "single",
-          require("yazi").config.yazi_floating_window_border
-        )
-      end)
+      vim.o.winborder = "double"
+      require("yazi").setup({ yazi_floating_window_border = "single" })
+      assert.same("single", require("yazi").config.yazi_floating_window_border)
     end)
   end)
 end)


### PR DESCRIPTION
yazi.nvim supports the `winborder` option added in Neovim 0.11. Back when this feature was added, it was not available in stable Neovim, so I added protections to prevent errors when the option was not available.

Now that Neovim 0.11 is the minimum supported version, we can remove these fallbacks and simplify the code.