### PR TITLE
fix: crash when pressing tab if visible-buffer is nil

### DIFF
--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -64,8 +64,11 @@ function YaziOpenerActions.select_current_file_and_close_yazi(config, callbacks)
   callbacks.api:open()
 end
 
----@param visible_buffer YaziVisibleBuffer
+---@param visible_buffer? YaziVisibleBuffer
 local function show_visible_buffer(visible_buffer)
+  if not visible_buffer then
+    return "nil"
+  end
   local renameable_buffer = visible_buffer.renameable_buffer
   return renameable_buffer.path:make_relative(vim.uv.cwd())
 end


### PR DESCRIPTION
```rs
   Error  14:24:28 msg_show.lua_error vim.schedule callback: ...mikavilpas/git/yazi.nvim/lua/yazi/keybinding_helpers.lua:72: attempt to index local 'visible_buffer' (a nil value)
stack traceback:
	...mikavilpas/git/yazi.nvim/lua/yazi/keybinding_helpers.lua:72: in function 'show_visible_buffer'
	...mikavilpas/git/yazi.nvim/lua/yazi/keybinding_helpers.lua:153: in function 'cycle_open_buffers'
	...azi.nvim/lua/yazi/event_handling/yazi_event_handling.lua:123: in function 'process_events_emitted_from_yazi'
	...mikavilpas/git/yazi.nvim/lua/yazi/process/ya_process.lua:244: in function <...mikavilpas/git/yazi.nvim/lua/yazi/process/ya_process.lua:242>
```