### PR TITLE
fix(ui): correctly center floating window when cmdheight=0

### DIFF
--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -74,8 +74,13 @@ local function get_window_dimensions(config)
     height = size(vim.o.lines, config.floating_window_scaling_factor.height)
     width = size(vim.o.columns, config.floating_window_scaling_factor.width)
   end
+ 
+  local total_lines = vim.o.lines
+  if vim.o.cmdheight == 0 then
+    total_lines = total_lines - 1
+  end
 
-  local row = math.floor((vim.o.lines - height) / 2)
+  local row = math.floor((total_lines - height) / 2)
   local col = math.floor((vim.o.columns - width) / 2)
 
   return {

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -74,7 +74,7 @@ local function get_window_dimensions(config)
     height = size(vim.o.lines, config.floating_window_scaling_factor.height)
     width = size(vim.o.columns, config.floating_window_scaling_factor.width)
   end
- 
+
   local total_lines = vim.o.lines
   if vim.o.cmdheight == 0 then
     total_lines = total_lines - 1


### PR DESCRIPTION
Floating windows were misaligned vertically when `cmdheight` was set to 0, as is common when using plugins like `noice.nvim`. This change adjusts the row offset calculation by subtracting a line from the total height, ensuring proper centering even when the command line is hidden.