### PR TITLE
ci: try to fix fzf not found error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set up dependencies
         run: |
           # ripgrep is a dependency of telescope and fzf-lua
+          sudo apt-get update
           sudo apt-get install ripgrep
           rg --version
 


### PR DESCRIPTION
https://github.com/mikavilpas/yazi.nvim/actions/runs/15942244922/job/44971856978?pr=1011

```sh
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/f/fzf/fzf_0.44.1-1ubuntu0.2_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
146
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```