### PR TITLE
refactor: make snacks.nvim optional by bundling snacks.bufdelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Neovim.
     [snacks.picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md):
     you can grep/search in the directory yazi is in. Select some files to limit
     the search to those files only.
-  - Using
+  - Using a bundled version of
     [snacks.bufdelete](https://github.com/folke/snacks.nvim/blob/main/docs/bufdelete.md)
-    to have yazi close buffers and preserve the window layout. This is
-    recommended!
+    to have yazi close buffers and preserve the window layout. This happens when
+    files that are open are deleted in yazi.
   - For [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim): you can
     search and replace in the directory yazi is in
   - Copy the relative path from the start file to the currently hovered file.
@@ -66,8 +66,6 @@ First, make sure you have the requirements:
 - yazi [0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) or later
 - New features might require a recent version of yazi (see
   [installing-yazi-from-source.md](documentation/installing-yazi-from-source.md))
-- [snacks.nvim](https://github.com/folke/snacks.nvim) (for usage with
-  `process_events_live`)
 
 > [!TIP]
 >
@@ -95,9 +93,7 @@ you need to install the dependencies yourself. Also see the discussion in
   "mikavilpas/yazi.nvim",
   event = "VeryLazy",
   dependencies = {
-    -- check the installation instructions at
-    -- https://github.com/folke/snacks.nvim
-    "folke/snacks.nvim"
+    { "nvim-lua/plenary.nvim", lazy = true },
   },
   keys = {
     -- 👇 in this section, choose your own keymappings!
@@ -310,6 +306,9 @@ return {
       -- when yazi opened multiple files. The default is to send them to the
       -- quickfix list, but if you want to change that, you can define it here
       yazi_opened_multiple_files = function(chosen_files, config, state) end,
+
+      -- This function is called when yazi is ready to process events.
+      on_yazi_ready = function(buffer, config, process_api) end,
     },
 
     -- highlight buffers in the same directory as the hovered buffer
@@ -337,10 +336,11 @@ return {
       -- `grealpath` on OSX, (GNU) `realpath` otherwise
       resolve_relative_path_application = "",
 
-      -- how to delete (close) a buffer. Defaults to `snacks.bufdelete` from
-      -- https://github.com/folke/snacks.nvim, which maintains the window
-      -- layout.
-      bufdelete_implementation = "snacks-if-available",
+      -- how to delete (close) a buffer. Defaults to a bundled version of
+      -- `snacks.bufdelete`, copied from https://github.com/folke/snacks.nvim,
+      -- which maintains the window layout. See the `types.lua` file for more
+      -- information for the available options.
+      bufdelete_implementation = "bundled-snacks",
 
       -- add an action to a file picker to copy the relative path to the
       -- selected file(s). The implementation is the same as for the
@@ -359,7 +359,7 @@ return {
       -- before yazi has been closed. If this is `false`, events are processed
       -- in a batch when the user closes yazi. If this is `true`, events are
       -- processed immediately.
-      process_events_live = true,
+      process_events_live2 = true,
     },
   },
 }

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -56,6 +56,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("add_command_to_reveal_a_file.lua"),
           type: z.literal("file"),
         }),
+        "add_command_to_show_loaded_packages.lua": z.object({
+          name: z.literal("add_command_to_show_loaded_packages.lua"),
+          type: z.literal("file"),
+        }),
         "add_keybinding_to_start_yazi_and_find.lua": z.object({
           name: z.literal("add_keybinding_to_start_yazi_and_find.lua"),
           type: z.literal("file"),
@@ -265,6 +269,7 @@ export const testDirectoryFiles = z.enum([
   ".config",
   "config-modifications/add_command_to_count_open_buffers.lua",
   "config-modifications/add_command_to_reveal_a_file.lua",
+  "config-modifications/add_command_to_show_loaded_packages.lua",
   "config-modifications/add_keybinding_to_start_yazi_and_find.lua",
   "config-modifications/add_yazi_context_assertions.lua",
   "config-modifications/disable_a_keybinding.lua",

--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -57,6 +57,17 @@ describe("reading events", () => {
       assertYaziIsReady(nvim)
       cy.contains("subdirectory" satisfies MyTestDirectoryFile)
 
+      nvim
+        .runLuaCode({
+          luaCode: `return require("yazi").config.integrations.bufdelete_implementation`,
+        })
+        .then((result) => {
+          // sanity check: make sure the default bufdelete_implementation is
+          // set as expected for this test
+          assert(result.value)
+          expect(result.value).eql("bundled-snacks")
+        })
+
       // start file deletion
       cy.typeIntoTerminal("d")
       cy.contains("Trash 1 selected file?")
@@ -89,7 +100,10 @@ describe("reading events", () => {
 
     cy.startNeovim({
       filename: { openInVerticalSplits: ["initial-file.txt", "file2.txt"] },
-      startupScriptModifications: ["add_yazi_context_assertions.lua"],
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "add_command_to_show_loaded_packages.lua",
+      ],
     }).then((nvim) => {
       // the default file should already be open
       cy.contains(nvim.dir.contents["initial-file.txt"].name)
@@ -110,6 +124,17 @@ describe("reading events", () => {
       assertYaziIsReady(nvim)
       cy.contains("subdirectory" satisfies MyTestDirectoryFile)
 
+      nvim
+        .runLuaCode({
+          luaCode: `return require("yazi").config.integrations.bufdelete_implementation`,
+        })
+        .then((result) => {
+          // sanity check: make sure the default bufdelete_implementation is
+          // set as expected for this test
+          assert(result.value)
+          expect(result.value).eql("bundled-snacks")
+        })
+
       // start file deletion
       cy.typeIntoTerminal("D")
       cy.contains("Permanently delete 1 selected file?")
@@ -125,10 +150,9 @@ describe("reading events", () => {
       cy.get(nvim.dir.contents["initial-file.txt"].name).should("not.exist")
       cy.contains("If you see this text, Neovim is ready").should("not.exist")
 
-      // make sure two windows are open. The test environment uses snacks.nvim
-      // which should make sure the window layout is preserved when closing
-      // the deleted buffer. The default in neovim is to also close the
-      // window.
+      // make sure two windows are open. The window layout should be preserved
+      // when closing the deleted buffer. The default in neovim is to also
+      // close the window.
       nvim.runExCommand({ command: `echo winnr("$")` }).then((result) => {
         expect(result.value).to.match(/2/)
       })

--- a/integration-tests/test-environment/config-modifications/add_command_to_show_loaded_packages.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_show_loaded_packages.lua
@@ -1,0 +1,14 @@
+-- selene: allow(unused_variable)
+function Yazi_show_loaded_packages(path)
+  local modules = {}
+  for k, _ in pairs(package.loaded) do
+    if k:sub(1, 4) == "yazi" then
+      table.insert(modules, k)
+    end
+  end
+  table.sort(modules)
+
+  return modules
+end
+
+print("Yazi: Loaded custom command to show loaded packages.")

--- a/lazy.lua
+++ b/lazy.lua
@@ -15,17 +15,6 @@ return {
   --
   -- https://github.com/nvim-lua/plenary.nvim/
   { "nvim-lua/plenary.nvim", lazy = true },
-  -- { "folke/snacks.nvim", lazy = true },
-
-  --
-  -- TODO enable after https://github.com/nvim-neorocks/nvim-busted-action/issues/4 is resolved
-  --
-  -- {
-  --   -- Neovim plugin that adds support for file operations using built-in LSP
-  --   -- https://github.com/antosha417/nvim-lsp-file-operations
-  --   'antosha417/nvim-lsp-file-operations',
-  --   lazy = true,
-  -- },
 
   {
     "mikavilpas/yazi.nvim",

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -139,17 +139,21 @@ function M.yazi(config, input_path, args)
         )
       )
 
-      -- this is the legacy implementation used when
-      -- `future_features.process_events_live = false`. When that is used,
-      -- events should be processed in ya_process.lua and should not be
-      -- processed a second time here.
-      assert(#events == 0 or not config.future_features.process_events_live)
+      do
+        -- process events.
+        --
+        -- This is the legacy implementation used when
+        -- `future_features.process_events_live2 = false`. When that is used,
+        -- events should be processed in ya_process.lua and should not be
+        -- processed a second time here.
+        assert(#events == 0 or not config.future_features.process_events_live2)
 
-      yazi_event_handling.process_events_emitted_from_yazi(
-        events,
-        config,
-        context
-      )
+        yazi_event_handling.process_events_emitted_from_yazi(
+          events,
+          config,
+          context
+        )
+      end
 
       if last_directory == nil then
         if path:is_file() then

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -15,7 +15,7 @@ function M.default()
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
     future_features = {
-      process_events_live = true,
+      process_events_live2 = true,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,
@@ -77,7 +77,7 @@ function M.default()
       resolve_relative_path_application = vim.uv.os_uname().sysname == "Darwin"
           and "grealpath"
         or "realpath",
-      bufdelete_implementation = "snacks-if-available",
+      bufdelete_implementation = "bundled-snacks",
       picker_add_copy_relative_path_action = nil,
       pick_window_implementation = "snacks.picker",
     },

--- a/lua/yazi/health.lua
+++ b/lua/yazi/health.lua
@@ -35,7 +35,7 @@ return {
     end
 
     -- example data:
-    -- Yazi 0.3.1 (4112bf4 2024-08-15)
+    -- Yazi 25.6.11 (8657e6b6 2025-06-29)
     local raw_version = vim.fn.system("yazi --version")
 
     -- parse the version
@@ -74,7 +74,7 @@ return {
     end
 
     -- example data:
-    -- Ya 0.3.1 (4112bf4 2024-08-15)
+    -- Ya 25.6.11 (8657e6b6 2025-06-29)
     local raw_ya_version = vim.fn.system("ya --version") or ""
     local ya_semver = raw_ya_version:match("[Yy]a (%w+%.%w+%.%w+)")
     if ya_semver == nil then
@@ -110,17 +110,6 @@ return {
       vim.health.info(
         "You have enabled `open_for_directories` in your config. Because of this, please make sure you are loading yazi when Neovim starts."
       )
-    end
-
-    if config.future_features.process_events_live then
-      local ok = pcall(function()
-        return require("snacks")
-      end)
-      if not ok then
-        vim.health.warn(
-          "The `snacks` library is not found. Please install it to enable the `process_events_live` feature."
-        )
-      end
     end
 
     local resolver = config.integrations.resolve_relative_path_application

--- a/lua/yazi/integrations/snacks_bufdelete.lua
+++ b/lua/yazi/integrations/snacks_bufdelete.lua
@@ -1,0 +1,117 @@
+---@diagnostic disable: duplicate-doc-field, duplicate-set-field, param-type-mismatch
+---@class snacks.bufdelete
+---@overload fun(buf?: number|snacks.bufdelete.Opts)
+local M = setmetatable({}, {
+  __call = function(t, ...)
+    return t.delete(...)
+  end,
+})
+
+M.meta = {
+  desc = "Delete buffers without disrupting window layout",
+}
+
+---@class snacks.bufdelete.Opts
+---@field buf? number Buffer to delete. Defaults to the current buffer
+---@field file? string Delete buffer by file name. If provided, `buf` is ignored
+---@field force? boolean Delete the buffer even if it is modified
+---@field filter? fun(buf: number): boolean Filter buffers to delete
+---@field wipe? boolean Wipe the buffer instead of deleting it (see `:h :bwipeout`)
+
+--- Delete a buffer:
+--- - either the current buffer if `buf` is not provided
+--- - or the buffer `buf` if it is a number
+--- - or every buffer for which `buf` returns true if it is a function
+---@param opts? number|snacks.bufdelete.Opts
+function M.delete(opts)
+  opts = opts or {}
+  opts = type(opts) == "number" and { buf = opts } or opts
+  opts = type(opts) == "function" and { filter = opts } or opts
+  ---@cast opts snacks.bufdelete.Opts
+
+  if type(opts.filter) == "function" then
+    for _, b in ipairs(vim.tbl_filter(opts.filter, vim.api.nvim_list_bufs())) do
+      if vim.bo[b].buflisted then
+        M.delete(vim.tbl_extend("force", {}, opts, { buf = b, filter = false }))
+      end
+    end
+    return
+  end
+
+  local buf = opts.buf or 0
+  if opts.file then
+    buf = vim.fn.bufnr(opts.file)
+    if buf == -1 then
+      return
+    end
+  end
+  buf = buf == 0 and vim.api.nvim_get_current_buf() or buf
+
+  vim.api.nvim_buf_call(buf, function()
+    if vim.bo.modified and not opts.force then
+      local ok, choice = pcall(
+        vim.fn.confirm,
+        ("Save changes to %q?"):format(vim.fn.bufname()),
+        "&Yes\n&No\n&Cancel"
+      )
+      if not ok or choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
+        return
+      end
+      if choice == 1 then -- Yes
+        vim.cmd.write()
+      end
+    end
+
+    for _, win in ipairs(vim.fn.win_findbuf(buf)) do
+      vim.api.nvim_win_call(win, function()
+        if
+          not vim.api.nvim_win_is_valid(win)
+          or vim.api.nvim_win_get_buf(win) ~= buf
+        then
+          return
+        end
+        -- Try using alternate buffer
+        local alt = vim.fn.bufnr("#")
+        if alt ~= buf and vim.fn.buflisted(alt) == 1 then
+          vim.api.nvim_win_set_buf(win, alt)
+          return
+        end
+
+        -- Try using previous buffer
+        local has_previous = pcall(vim.cmd, "bprevious")
+        if has_previous and buf ~= vim.api.nvim_win_get_buf(win) then
+          return
+        end
+
+        -- Create new listed buffer
+        local new_buf = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(win, new_buf)
+      end)
+    end
+    if vim.api.nvim_buf_is_valid(buf) then
+      pcall(vim.cmd, (opts.wipe and "bwipeout! " or "bdelete! ") .. buf)
+    end
+  end)
+end
+
+--- Delete all buffers
+---@param opts? snacks.bufdelete.Opts
+function M.all(opts)
+  return M.delete(vim.tbl_extend("force", {}, opts or {}, {
+    filter = function()
+      return true
+    end,
+  }))
+end
+
+--- Delete all buffers except the current one
+---@param opts? snacks.bufdelete.Opts
+function M.other(opts)
+  return M.delete(vim.tbl_extend("force", {}, opts or {}, {
+    filter = function(b)
+      return b ~= vim.api.nvim_get_current_buf()
+    end,
+  }))
+end
+
+return M

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -248,7 +248,7 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
         )
       end)
     else
-      if not self.config.future_features.process_events_live then
+      if not self.config.future_features.process_events_live2 then
         -- these events will be processed when yazi exits
         self.events[#self.events + 1] = event
       end
@@ -270,7 +270,7 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
             }))
           end
 
-          if self.config.future_features.process_events_live == true then
+          if self.config.future_features.process_events_live2 == true then
             yazi_event_handling.process_events_emitted_from_yazi(
               { event },
               self.config,
@@ -283,7 +283,7 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
           nvim_event_handling.emit("YaziDDSCustom", event)
         end)
       else
-        if self.config.future_features.process_events_live == true then
+        if self.config.future_features.process_events_live2 == true then
           vim.schedule(function()
             yazi_event_handling.process_events_emitted_from_yazi(
               { event },

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -27,7 +27,7 @@
 ---@field public config_home? string # optional path for nvim yazi to find a custom yazi.toml
 
 ---@class(exact) yazi.OptInFeatures
----@field process_events_live? boolean # By default, this is `true`, which means yazi.nvim processes events before yazi has been closed. If this is `false`, events are processed in a batch when the user closes yazi. If this is `true`, events are processed immediately.
+---@field process_events_live2? boolean # By default, this is `true`, which means yazi.nvim processes events before yazi has been closed. If this is `false`, events are processed in a batch when the user closes yazi. If this is `true`, events are processed immediately.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 
@@ -68,6 +68,7 @@
 
 ---@alias YaziBufdeleteImpl
 ---| "snacks-if-available" # the implementation from https://github.com/folke/snacks.nvim, which maintains the window layout. If not available, falls back to the builtin implementation in `vim.api.nvim_buf_delete()`, which does not maintain the window layout.
+---| "bundled-snacks" # the implementation from snacks.nvim that is bundled with yazi.nvim. This is the same as "snacks-if-available", but does not require snacks.nvim to be installed.
 ---| fun(bufnr: integer) # a custom implementation provided by the user
 
 ---@class (exact) YaziConfigHighlightGroups # Defines the highlight groups that will be used in yazi

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -427,10 +427,12 @@ function M.bufdelete(implementation, bufnr)
     if ok then
       return bufdelete.delete({ buf = bufnr, force = true, wipe = true })
     else
-      vim.api.nvim_buf_call(bufnr, function()
-        vim.api.nvim_buf_delete(bufnr, { force = true })
-      end)
+      bufdelete = require("yazi.integrations.snacks_bufdelete")
+      bufdelete.delete({ buf = bufnr, force = true, wipe = true })
     end
+  elseif implementation == "bundled-snacks" then
+    local bufdelete = require("yazi.integrations.snacks_bufdelete")
+    bufdelete.delete({ buf = bufnr, force = true, wipe = true })
   elseif implementation == "builtin" then
     vim.api.nvim_buf_call(bufnr, function()
       vim.api.nvim_buf_delete(bufnr, { force = true })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,8 +602,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.8.3:
-    resolution: {integrity: sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==}
+  axios@1.10.0:
+    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -896,8 +896,8 @@ packages:
       supports-color:
         optional: true
 
-  decode-named-character-reference@1.1.0:
-    resolution: {integrity: sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==}
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -929,11 +929,11 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  devtools-protocol@0.0.1439962:
-    resolution: {integrity: sha512-jJF48UdryzKiWhJ1bLKr7BFWUQCEIT5uCNbDLqkQJBtkFxYzILJH44WN0PDKMIlGDN7Utb8vyUY85C3w4R/t2g==}
+  devtools-protocol@0.0.1464554:
+    resolution: {integrity: sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==}
 
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
   dree@5.1.5:
@@ -969,8 +969,8 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1008,8 +1008,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
@@ -1199,10 +1199,6 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
-    engines: {node: '>= 6'}
-
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
     engines: {node: '>= 6'}
@@ -1274,8 +1270,8 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@11.0.2:
-    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -1350,10 +1346,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.4:
-    resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
     engines: {node: '>= 4'}
 
   ignore@7.0.5:
@@ -2003,8 +1995,8 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  pump@3.0.2:
-    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -2014,12 +2006,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@24.9.0:
-    resolution: {integrity: sha512-HFdCeH/wx6QPz8EncafbCqJBqaCG1ENW75xg3cLFMRUoqZDgByT6HSueiumetT2uClZxwqj0qS4qMVZwLHRHHw==}
+  puppeteer-core@24.11.1:
+    resolution: {integrity: sha512-I0Gv3jWBRY9E3NTBElp7br7Gaid5RbFTxCRRMHym1kCf0ompO0Pel4REGsGDwMWkg3uwFzIH7t7qXs3T4DKRWA==}
     engines: {node: '>=18'}
 
-  puppeteer@24.9.0:
-    resolution: {integrity: sha512-L0pOtALIx8rgDt24Y+COm8X52v78gNtBOW6EmUcEPci0TYD72SAuaXKqasRIx4JXxmg2Tkw5ySKcpPOwN8xXnQ==}
+  puppeteer@24.11.1:
+    resolution: {integrity: sha512-QbccB/LgxX4tSZRzr9KQ1Jajdvu3n35Dlf/Otjz0QfR+6mDoZdMWLcWF94uQoC3OJerCyYm5hlU2Ru4nBoId2A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2124,8 +2116,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -2173,8 +2166,8 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.4:
-    resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
+  socks@2.8.5:
+    resolution: {integrity: sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-object-keys@1.1.3:
@@ -2212,8 +2205,8 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
-  streamx@2.22.0:
-    resolution: {integrity: sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==}
+  streamx@2.22.1:
+    resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2258,8 +2251,8 @@ packages:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tar-fs@3.0.9:
-    resolution: {integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==}
+  tar-fs@3.0.10:
+    resolution: {integrity: sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -2474,8 +2467,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2742,7 +2735,7 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.7.2
-      tar-fs: 3.0.9
+      tar-fs: 3.0.10
       yargs: 17.7.2
     transitivePeerDependencies:
       - bare-buffer
@@ -2926,15 +2919,15 @@ snapshots:
   '@umbrelladocs/linkspector@0.4.5(typescript@5.8.3)':
     dependencies:
       commander: 14.0.0
-      dotenv: 16.5.0
+      dotenv: 16.6.1
       github-slugger: 2.0.0
-      glob: 11.0.2
-      ignore: 7.0.4
+      glob: 11.0.3
+      ignore: 7.0.5
       joi: 17.13.3
       js-yaml: 4.1.0
       kleur: 4.1.5
       ora: 8.2.0
-      puppeteer: 24.9.0(typescript@5.8.3)
+      puppeteer: 24.11.1(typescript@5.8.3)
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       unified: 11.0.5
@@ -3025,10 +3018,10 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.8.3:
+  axios@1.10.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.2
+      form-data: 4.0.3
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -3059,7 +3052,7 @@ snapshots:
 
   bare-stream@2.6.5(bare-events@2.5.4):
     dependencies:
-      streamx: 2.22.0
+      streamx: 2.22.1
     optionalDependencies:
       bare-events: 2.5.4
     optional: true
@@ -3145,9 +3138,9 @@ snapshots:
 
   check-more-types@2.24.0: {}
 
-  chromium-bidi@5.1.0(devtools-protocol@0.0.1439962):
+  chromium-bidi@5.1.0(devtools-protocol@0.0.1464554):
     dependencies:
-      devtools-protocol: 0.0.1439962
+      devtools-protocol: 0.0.1464554
       mitt: 3.0.1
       zod: 3.25.67
 
@@ -3235,7 +3228,7 @@ snapshots:
       chalk: 4.1.2
       lodash: 4.17.21
       rxjs: 7.8.2
-      shell-quote: 1.8.1
+      shell-quote: 1.8.3
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -3341,7 +3334,7 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  decode-named-character-reference@1.1.0:
+  decode-named-character-reference@1.2.0:
     dependencies:
       character-entities: 2.0.2
 
@@ -3367,9 +3360,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  devtools-protocol@0.0.1439962: {}
+  devtools-protocol@0.0.1464554: {}
 
-  dotenv@16.5.0: {}
+  dotenv@16.6.1: {}
 
   dree@5.1.5:
     dependencies:
@@ -3401,7 +3394,7 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  end-of-stream@1.4.4:
+  end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
@@ -3461,7 +3454,7 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.5
       '@esbuild/win32-x64': 0.25.5
 
-  escalade@3.1.2: {}
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -3696,13 +3689,6 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  form-data@4.0.2:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-
   form-data@4.0.3:
     dependencies:
       asynckit: 0.4.0
@@ -3751,7 +3737,7 @@ snapshots:
 
   get-stream@5.2.0:
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.3
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -3785,7 +3771,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@11.0.2:
+  glob@11.0.3:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
@@ -3869,8 +3855,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.4: {}
 
   ignore@7.0.5: {}
 
@@ -4128,7 +4112,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      decode-named-character-reference: 1.1.0
+      decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
       micromark: 4.0.2
@@ -4231,7 +4215,7 @@ snapshots:
 
   micromark-core-commonmark@2.0.3:
     dependencies:
-      decode-named-character-reference: 1.1.0
+      decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-factory-destination: 2.0.1
       micromark-factory-label: 2.0.1
@@ -4384,7 +4368,7 @@ snapshots:
 
   micromark-util-decode-string@2.0.1:
     dependencies:
-      decode-named-character-reference: 1.1.0
+      decode-named-character-reference: 1.2.0
       micromark-util-character: 2.1.1
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-symbol: 2.0.1
@@ -4422,7 +4406,7 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.1(supports-color@8.1.1)
-      decode-named-character-reference: 1.1.0
+      decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-factory-space: 2.0.1
@@ -4590,7 +4574,7 @@ snapshots:
       '@types/unist': 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
-      decode-named-character-reference: 1.1.0
+      decode-named-character-reference: 1.2.0
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
@@ -4673,36 +4657,36 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  pump@3.0.2:
+  pump@3.0.3:
     dependencies:
-      end-of-stream: 1.4.4
+      end-of-stream: 1.4.5
       once: 1.4.0
 
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
-  puppeteer-core@24.9.0:
+  puppeteer-core@24.11.1:
     dependencies:
       '@puppeteer/browsers': 2.10.5
-      chromium-bidi: 5.1.0(devtools-protocol@0.0.1439962)
+      chromium-bidi: 5.1.0(devtools-protocol@0.0.1464554)
       debug: 4.4.1(supports-color@8.1.1)
-      devtools-protocol: 0.0.1439962
+      devtools-protocol: 0.0.1464554
       typed-query-selector: 2.12.0
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  puppeteer@24.9.0(typescript@5.8.3):
+  puppeteer@24.11.1(typescript@5.8.3):
     dependencies:
       '@puppeteer/browsers': 2.10.5
-      chromium-bidi: 5.1.0(devtools-protocol@0.0.1439962)
+      chromium-bidi: 5.1.0(devtools-protocol@0.0.1464554)
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      devtools-protocol: 0.0.1439962
-      puppeteer-core: 24.9.0
+      devtools-protocol: 0.0.1464554
+      puppeteer-core: 24.11.1
       typed-query-selector: 2.12.0
     transitivePeerDependencies:
       - bare-buffer
@@ -4841,7 +4825,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.1: {}
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -4899,11 +4883,11 @@ snapshots:
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.1(supports-color@8.1.1)
-      socks: 2.8.4
+      socks: 2.8.5
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.4:
+  socks@2.8.5:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
@@ -4945,7 +4929,7 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  streamx@2.22.0:
+  streamx@2.22.1:
     dependencies:
       fast-fifo: 1.3.2
       text-decoder: 1.2.3
@@ -4998,9 +4982,9 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.7
 
-  tar-fs@3.0.9:
+  tar-fs@3.0.10:
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.3
       tar-stream: 3.1.7
     optionalDependencies:
       bare-fs: 4.1.5
@@ -5012,7 +4996,7 @@ snapshots:
     dependencies:
       b4a: 1.6.7
       fast-fifo: 1.3.2
-      streamx: 2.22.0
+      streamx: 2.22.1
 
   text-decoder@1.2.3:
     dependencies:
@@ -5173,7 +5157,7 @@ snapshots:
 
   wait-on@8.0.3:
     dependencies:
-      axios: 1.8.3
+      axios: 1.10.0
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
@@ -5241,7 +5225,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.2: {}
+  ws@8.18.3: {}
 
   y18n@5.0.8: {}
 
@@ -5250,7 +5234,7 @@ snapshots:
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/spec/yazi/trash_spec.lua
+++ b/spec/yazi/trash_spec.lua
@@ -3,7 +3,7 @@ local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 local reset = require("spec.yazi.helpers.reset")
 local stub = require("luassert.stub")
 local buffers = require("spec.yazi.helpers.buffers")
-local snacks_bufdelete = require("snacks.bufdelete")
+local snacks_bufdelete = require("yazi.integrations.snacks_bufdelete")
 
 describe("process_trash_event", function()
   local snapshot


### PR DESCRIPTION
**Issue:**

For a long time, snacks.nvim had been a dependency of yazi.nvim. Originally I had big plans for using it extensively, but they have not materialized (yet).

Snacks is still a dependency by default, although only a very small part of it is used: the `snacks.bufdelete` module, which is used to delete buffers while preserving the window layout.

Previously, `future_features.process_events_live` has been set to `true` by default, but because the built-in way of closing buffers was found to disturb the window layout, it was recommended to use `snacks.bufdelete` instead.

**Solution:**

Bundle a copy of `snacks.bufdelete` in yazi.nvim, so that snacks.nvim is not required anymore.

Turn this on by default, but allow users to disable it by setting `config.integrations.bufdelete_implementation = "builtin"` and `config.future_features.process_events_live2 = false`. If this happens to you, please open an issue, as this will be the default in the future.