### PR TITLE
test: use internal way of polling for yazi to be ready

### DIFF
--- a/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
+++ b/integration-tests/cypress/e2e/cd-to-buffer-with-ya-emit.cy.ts
@@ -1,5 +1,5 @@
 import { isHoveredInNeovim, isNotHoveredInNeovim } from "./utils/hover-utils"
-import { assertYaziIsReady, yaziNormalModeText } from "./utils/yazi-utils"
+import { assertYaziIsReady } from "./utils/yazi-utils"
 
 // NOTE: cypress doesn't support the tab key, but control+i seems to work fine
 // https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
@@ -43,7 +43,6 @@ describe("revealing another open split (buffer) in yazi", () => {
       // start yazi and wait for it to be visible
       cy.typeIntoTerminal("{upArrow}")
       assertYaziIsReady(nvim)
-      cy.contains(yaziNormalModeText)
 
       // Switch to the other buffers' directories in yazi. This should make
       // yazi send a hover event for the new, highlighted file.
@@ -96,7 +95,6 @@ describe("revealing another open split (buffer) in yazi", () => {
       // start yazi
       cy.typeIntoTerminal("{upArrow}")
       assertYaziIsReady(nvim)
-      cy.contains(yaziNormalModeText)
 
       cy.typeIntoTerminal("{control+i}")
 

--- a/integration-tests/cypress/e2e/lsp.cy.ts
+++ b/integration-tests/cypress/e2e/lsp.cy.ts
@@ -1,8 +1,8 @@
 import assert from "assert"
 import {
+  assertYaziIsReady,
   isDirectorySelectedInYazi,
   isFileSelectedInYazi,
-  yaziNormalModeText,
 } from "./utils/yazi-utils"
 
 describe("rename events with LSP support", () => {
@@ -11,7 +11,10 @@ describe("rename events with LSP support", () => {
     // can use the LSP server to rename the file and all its references in the
     // project.
     cy.visit("/")
-    cy.startNeovim({ filename: "lua-project/config.lua" }).then((nvim) => {
+    cy.startNeovim({
+      filename: "lua-project/config.lua",
+      startupScriptModifications: ["add_yazi_context_assertions.lua"],
+    }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- the default configuration`)
 
@@ -30,9 +33,7 @@ describe("rename events with LSP support", () => {
       })
 
       cy.typeIntoTerminal("{upArrow}")
-
-      // wait for yazi to open and display the footer
-      cy.contains(yaziNormalModeText)
+      assertYaziIsReady(nvim)
 
       isFileSelectedInYazi("config.lua")
       cy.typeIntoTerminal("r")
@@ -58,7 +59,10 @@ describe("rename events with LSP support", () => {
     // is renamed in yazi, yazi.nvim should notify the LSP server to rename the
     // file and update all its references in the project.
     cy.visit("/")
-    cy.startNeovim({ filename: "lua-project/init.lua" }).then((nvim) => {
+    cy.startNeovim({
+      filename: "lua-project/init.lua",
+      startupScriptModifications: ["add_yazi_context_assertions.lua"],
+    }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- 609a3a37-42da-494d-908e-749d3aedca58`)
 
@@ -80,9 +84,7 @@ describe("rename events with LSP support", () => {
       cy.contains(`local utils = require("utils.utils")`)
 
       cy.typeIntoTerminal("{upArrow}")
-
-      // wait for yazi to open and display the footer
-      cy.contains(yaziNormalModeText)
+      assertYaziIsReady(nvim)
 
       cy.typeIntoTerminal("gg")
       // the directory contents should be visible. This is how we know the
@@ -92,7 +94,6 @@ describe("rename events with LSP support", () => {
       cy.contains("Rename:")
       cy.typeIntoTerminal("2{enter}")
       cy.typeIntoTerminal("q")
-      cy.contains(yaziNormalModeText).should("not.exist")
 
       // The LSP server asks for confirmation. Other LSPs don't seem to do
       // this, but it works...
@@ -112,7 +113,10 @@ describe("move events with LSP support", () => {
     // This is like renaming, but moving the file. The result is the same, but
     // yazi sends a different event (move vs rename) for it.
     cy.visit("/")
-    cy.startNeovim({ filename: "lua-project/config.lua" }).then((nvim) => {
+    cy.startNeovim({
+      filename: "lua-project/config.lua",
+      startupScriptModifications: ["add_yazi_context_assertions.lua"],
+    }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- the default configuration`)
 
@@ -137,7 +141,7 @@ describe("move events with LSP support", () => {
       cy.typeIntoTerminal("{upArrow}")
 
       // wait for yazi to open and display the footer
-      cy.contains(yaziNormalModeText)
+      assertYaziIsReady(nvim)
 
       isFileSelectedInYazi("config.lua")
       // start the move command

--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -9,7 +9,6 @@ import {
   assertYaziIsReady,
   isFileNotSelectedInYazi,
   isFileSelectedInYazi,
-  yaziNormalModeText,
 } from "./utils/yazi-utils"
 
 describe("opening files", () => {
@@ -271,6 +270,7 @@ describe("opening files", () => {
       filename: "file2.txt",
       startupScriptModifications: [
         "modify_yazi_config_and_open_multiple_files.lua",
+        "add_yazi_context_assertions.lua",
       ],
     }).then((nvim) => {
       cy.contains("Hello")
@@ -290,7 +290,7 @@ describe("opening files", () => {
       // open yazi. It should open two tabs, one for each file in the quickfix
       // list
       cy.typeIntoTerminal("{upArrow}")
-      cy.contains(yaziNormalModeText)
+      assertYaziIsReady(nvim)
 
       isFileSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
       isFileNotSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)

--- a/integration-tests/cypress/e2e/toggling.cy.ts
+++ b/integration-tests/cypress/e2e/toggling.cy.ts
@@ -1,6 +1,6 @@
 import { flavors } from "@catppuccin/palette"
 import { hoverFileAndVerifyItsHovered, rgbify } from "./utils/hover-utils"
-import { assertYaziIsReady, yaziNormalModeText } from "./utils/yazi-utils"
+import { assertYaziIsReady } from "./utils/yazi-utils"
 
 describe("toggling yazi to pseudo-continue the previous session", () => {
   beforeEach(() => {
@@ -80,9 +80,8 @@ describe("toggling yazi to pseudo-continue the previous session", () => {
       hoverFileAndVerifyItsHovered(nvim, "dir with spaces")
 
       // close yazi
-      cy.contains(yaziNormalModeText)
+      assertYaziIsReady(nvim)
       cy.typeIntoTerminal("q")
-      cy.contains(yaziNormalModeText).should("not.exist")
 
       // toggle yazi again. It should hover the same directory.
       cy.typeIntoTerminal("{control+upArrow}")

--- a/integration-tests/cypress/e2e/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/utils/yazi-utils.ts
@@ -5,8 +5,6 @@ import type { NeovimContext } from "cypress/support/tui-sandbox"
 
 const darkTheme = flavors.macchiato.colors
 
-export const yaziNormalModeText = "NOR"
-
 export function isFileSelectedInYazi(text: string): void {
   cy.contains(text).should(
     "have.css",


### PR DESCRIPTION
**Issue:**

Previously, the tests were waiting for a specific text in yazi's footer to be visible to determine if yazi was ready. The terminal can sometimes shift out of view in CI, so this is not a reliable way.

**Solution:**

Use the internal way of polling for yazi to be ready (`assertYaziIsReady`), which was added some time ago but is not used in all of the tests yet.