### PR TITLE
test: correctly call `vim.lsp.enable` to enable LSP in tests

### DIFF
--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -114,6 +114,15 @@ local plugins = {
     -- https://github.com/mason-org/mason-lspconfig.nvim?tab=readme-ov-file#recommended-setup-for-lazynvim
     "mason-org/mason-lspconfig.nvim",
     opts = {},
+    config = function()
+      -- make sure mason-lspconfig does not automatically enable any LSP
+      -- servers that might be installed on the system. We want to only use the
+      -- LSP servers that are included in the test setup.
+      require("mason-lspconfig").setup({
+        automatic_enable = false,
+      })
+      vim.lsp.enable("lua_ls")
+    end,
     dependencies = {
       { "mason-org/mason.nvim", opts = {} },
       "neovim/nvim-lspconfig",
@@ -131,5 +140,3 @@ do
     { bg = colors.peach, fg = "#000000" }
   )
 end
-
-vim.lsp.enable("lua-language-server")


### PR DESCRIPTION
**Issue:**

Previously, the `vim.lsp.enable("lua-language-server")` call was made in the test environment's `init.lua` file, but it was using the wrong server name.

The tests still worked because the `mason-lspconfig` plugin was automatically enabling the `lua_ls` as it's installed on my system. However, this is magic behaviour that is hard to maintain and understand.

**Solution:**

Make using the desired LSP server explicit by disabling `automatic_enable` of the LSP server, and then explicitly calling `vim.lsp.enable("lua_ls")`.