### PR TITLE
refactor: use `yazi_id` instead of `id` in Yazi DDS events

### DIFF
--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -84,12 +84,12 @@
 
 ---@class (exact) YaziRenameEvent
 ---@field public type "rename"
----@field public id string
+---@field public yazi_id string
 ---@field public data YaziEventDataRenameOrMove
 
 ---@class (exact) YaziMoveEvent
 ---@field public type "move"
----@field public id string
+---@field public yazi_id string
 ---@field public data {items: YaziEventDataRenameOrMove[]}
 
 ---@class (exact) YaziEventDataRenameOrMove
@@ -98,17 +98,17 @@
 
 ---@class (exact) YaziDeleteEvent
 ---@field public type "delete"
----@field public id string
+---@field public yazi_id string
 ---@field public data {urls: string[]}
 
 ---@class (exact) YaziTrashEvent
 ---@field public type "trash"
----@field public id string
+---@field public yazi_id string
 ---@field public data {urls: string[]}
 
 ---@class (exact) YaziChangeDirectoryEvent
 ---@field public type "cd"
----@field public id string
+---@field public yazi_id string
 ---@field public url string
 
 ---@class (exact) YaziHoverEvent "The event that is emitted when the user hovers over a file in yazi"

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -230,7 +230,7 @@ function M.parse_events(event_lines)
       ---@type YaziRenameEvent
       local event = {
         type = type,
-        id = yazi_id,
+        yazi_id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -242,7 +242,7 @@ function M.parse_events(event_lines)
       ---@type YaziMoveEvent
       local event = {
         type = type,
-        id = yazi_id,
+        yazi_id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -265,7 +265,7 @@ function M.parse_events(event_lines)
       ---@type YaziDeleteEvent
       local event = {
         type = type,
-        id = yazi_id,
+        yazi_id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -278,7 +278,7 @@ function M.parse_events(event_lines)
       ---@type YaziTrashEvent
       local event = {
         type = type,
-        id = yazi_id,
+        yazi_id = yazi_id,
         data = vim.json.decode(data_string),
       }
       table.insert(events, event)
@@ -291,7 +291,7 @@ function M.parse_events(event_lines)
       ---@type YaziChangeDirectoryEvent
       local event = {
         type = type,
-        id = yazi_id,
+        yazi_id = yazi_id,
         url = vim.json.decode(data_string)["url"],
       }
       table.insert(events, event)

--- a/spec/yazi/delete_spec.lua
+++ b/spec/yazi/delete_spec.lua
@@ -16,7 +16,7 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc/def" } },
     }
 
@@ -34,7 +34,7 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc" } },
     }
 
@@ -52,7 +52,7 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local event = {
       type = "delete",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc/ghi" } },
     }
 
@@ -71,14 +71,14 @@ describe("process_delete_event", function()
     ---@type YaziDeleteEvent
     local delete_event = {
       type = "delete",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/def/file" } },
     }
 
     ---@type YaziRenameEvent
     local rename_event = {
       type = "rename",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { from = "/def/other-file", to = "/def/file" },
     }
 

--- a/spec/yazi/read_events_spec.lua
+++ b/spec/yazi/read_events_spec.lua
@@ -12,7 +12,7 @@ describe("parsing yazi event file events", function()
     assert.are.same(events, {
       {
         type = "rename",
-        id = "1712242143209837",
+        yazi_id = "1712242143209837",
         data = {
           tab = 0,
           from = "/Users/mikavilpas/git/yazi/file",
@@ -32,7 +32,7 @@ describe("parsing yazi event file events", function()
     assert.are.same(events, {
       {
         type = "delete",
-        id = "1712766606832135",
+        yazi_id = "1712766606832135",
         data = {
           urls = { "/tmp/test-directory/test_2" },
         },

--- a/spec/yazi/rename_spec.lua
+++ b/spec/yazi/rename_spec.lua
@@ -96,7 +96,7 @@ describe("process_events_emitted_from_yazi", function()
         from = "/my-tmp/file1",
         to = "/my-tmp/file2",
       },
-      id = "123",
+      yazi_id = "123",
     }
 
     yazi_event_handling.process_events_emitted_from_yazi(
@@ -118,7 +118,7 @@ describe("process_events_emitted_from_yazi", function()
     ---@type YaziMoveEvent
     local event = {
       type = "move",
-      id = "123",
+      yazi_id = "123",
       data = {
         items = {
           {

--- a/spec/yazi/trash_spec.lua
+++ b/spec/yazi/trash_spec.lua
@@ -42,7 +42,7 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc/def" } },
     }
 
@@ -61,7 +61,7 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc" } },
     }
 
@@ -80,7 +80,7 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local event = {
       type = "trash",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/abc/ghi" } },
     }
 
@@ -95,14 +95,14 @@ describe("process_trash_event", function()
     ---@type YaziTrashEvent
     local delete_event = {
       type = "trash",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { urls = { "/def/file" } },
     }
 
     ---@type YaziRenameEvent
     local rename_event = {
       type = "rename",
-      id = "1712766606832135",
+      yazi_id = "1712766606832135",
       data = { from = "/def/other-file", to = "/def/file" },
     }
 

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -85,7 +85,7 @@ describe("process_events()", function()
       ya:process_events({
         {
           type = "cd",
-          id = "cd_123",
+          yazi_id = "cd_123",
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
       }, {}, {})
@@ -98,12 +98,12 @@ describe("process_events()", function()
       ya:process_events({
         {
           type = "cd",
-          id = "cd_123",
+          yazi_id = "cd_123",
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
         {
           type = "cd",
-          id = "cd_123",
+          yazi_id = "cd_123",
           url = "/tmp/directory",
         } --[[@as YaziChangeDirectoryEvent]],
       }, {}, {} --[[@as YaziActiveContext]])
@@ -128,7 +128,7 @@ describe("process_events()", function()
         local events = {
           {
             type = "rename",
-            id = "rename_123",
+            yazi_id = "rename_123",
             data = {
               from = "/tmp/old_path",
               to = "/tmp/new_path",
@@ -170,7 +170,7 @@ describe("process_events()", function()
         local events = {
           {
             type = "move",
-            id = "rename_123",
+            yazi_id = "rename_123",
             data = {
               items = {
                 {


### PR DESCRIPTION
Previously, the `id` field was sometimes called `yazi_id` and sometimes just `id`. This just modifies what the field is called, but has no effect on the functionality.