### PR TITLE
refactor(tests): use integration plugins only for a minority of tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,11 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
-      - run: pnpm tui neovim prepare
-        working-directory: integration-tests
+      - working-directory: integration-tests
+        run: |
+          # NVIM_APPNAME=nvim is the default, but spelled out here for clarity
+          NVIM_APPNAME=nvim pnpm tui neovim prepare
+          NVIM_APPNAME=nvim_integrations pnpm tui neovim prepare
 
       # need to work around https://github.com/cypress-io/github-action/issues/1246
       - run: pnpm --filter integration-tests exec cypress install

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -26,6 +26,41 @@ export const MyTestDirectorySchema = z.object({
               name: z.literal("init.lua"),
               type: z.literal("file"),
             }),
+            lua: z.object({
+              name: z.literal("lua/"),
+              type: z.literal("directory"),
+              contents: z.object({
+                "plugins.lua": z.object({
+                  name: z.literal("plugins.lua"),
+                  type: z.literal("file"),
+                }),
+              }),
+            }),
+            "prepare.lua": z.object({
+              name: z.literal("prepare.lua"),
+              type: z.literal("file"),
+            }),
+          }),
+        }),
+        nvim_integrations: z.object({
+          name: z.literal("nvim_integrations/"),
+          type: z.literal("directory"),
+          contents: z.object({
+            "init.lua": z.object({
+              name: z.literal("init.lua"),
+              type: z.literal("file"),
+            }),
+            lua: z.object({
+              name: z.literal("lua/"),
+              type: z.literal("directory"),
+              contents: z.object({
+                "plugins.lua": z.object({
+                  name: z.literal("plugins.lua"),
+                  type: z.literal("file-symlink"),
+                  target: z.literal("../../nvim/lua/plugins.lua"),
+                }),
+              }),
+            }),
             "prepare.lua": z.object({
               name: z.literal("prepare.lua"),
               type: z.literal("file"),
@@ -272,8 +307,15 @@ export type MyTestDirectory = MyTestDirectoryContentsSchemaType["contents"]
 
 export const testDirectoryFiles = z.enum([
   ".config/nvim/init.lua",
+  ".config/nvim/lua/plugins.lua",
+  ".config/nvim/lua",
   ".config/nvim/prepare.lua",
   ".config/nvim",
+  ".config/nvim_integrations/init.lua",
+  ".config/nvim_integrations/lua/plugins.lua",
+  ".config/nvim_integrations/lua",
+  ".config/nvim_integrations/prepare.lua",
+  ".config/nvim_integrations",
   ".config/yazi/keymap.toml",
   ".config/yazi",
   ".config",

--- a/integration-tests/cypress/e2e/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/integrations.cy.ts
@@ -16,6 +16,7 @@ describe("grug-far integration (search and replace)", () => {
   it("can use grug-far.nvim to search and replace in the directory of the hovered file", () => {
     cy.startNeovim({
       filename: "routes/posts.$postId/adjacent-file.txt",
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("this file is adjacent-file.txt")
@@ -47,6 +48,7 @@ describe("grug-far integration (search and replace)", () => {
   it("can search and replace, limited to selected files only", () => {
     cy.startNeovim({
       filename: "routes/posts.$postId/adjacent-file.txt",
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       cy.contains("this file is adjacent-file.txt")
       cy.typeIntoTerminal("{upArrow}")
@@ -90,6 +92,7 @@ describe("telescope integration (search)", () => {
   it("can use telescope.nvim to search in the current directory", () => {
     cy.startNeovim({
       filename: "routes/posts.$postId/adjacent-file.txt",
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       cy.contains("this file is adjacent-file.txt")
       cy.typeIntoTerminal("{upArrow}")
@@ -110,6 +113,7 @@ describe("telescope integration (search)", () => {
   it("can use telescope.nvim to search, limited to the selected files only", () => {
     cy.startNeovim({
       filename: "routes/posts.$postId/adjacent-file.txt",
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       cy.contains("this file is adjacent-file.txt")
       cy.typeIntoTerminal("{upArrow}")
@@ -147,6 +151,7 @@ describe("fzf-lua integration (grep)", () => {
     cy.startNeovim({
       filename: "routes/posts.$postId/adjacent-file.txt",
       startupScriptModifications: ["modify_yazi_config_use_fzf_lua.lua"],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       cy.contains("this file is adjacent-file.txt")
       cy.typeIntoTerminal("{upArrow}")
@@ -185,6 +190,7 @@ describe("fzf-lua integration (grep)", () => {
         "modify_yazi_config_use_fzf_lua.lua",
         "add_yazi_context_assertions.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until the file contents are visible
       cy.contains("02c67730-6b74-4b7c-af61-fe5844fdc3d7")
@@ -237,6 +243,7 @@ describe("snacks.picker integration (grep)", () => {
         "modify_yazi_config_use_snacks_picker.lua",
         "add_yazi_context_assertions.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until the file contents are visible
       cy.contains("02c67730-6b74-4b7c-af61-fe5844fdc3d7")
@@ -271,7 +278,9 @@ describe("snacks.picker integration (grep)", () => {
 
   it("can optionally setup a keybinding to copy the relative paths to files", () => {
     cy.visit("/")
-    cy.startNeovim({}).then((nvim) => {
+    cy.startNeovim({
+      NVIM_APPNAME: "nvim_integrations",
+    }).then((nvim) => {
       // wait until the file contents are visible
       cy.contains("If you see this text, Neovim is ready!")
       cy.typeIntoTerminal("dd")
@@ -318,6 +327,7 @@ describe("snacks open_and_pick_window integration", () => {
         "add_yazi_context_assertions.lua",
         "add_command_to_reveal_a_file.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       nvim.runExCommand({ command: "vsplit" })
       cy.typeIntoTerminal("{upArrow}")

--- a/integration-tests/cypress/e2e/lsp.cy.ts
+++ b/integration-tests/cypress/e2e/lsp.cy.ts
@@ -18,6 +18,7 @@ describe("rename events with LSP support", () => {
         "add_yazi_context_assertions.lua",
         "accept_lsp_rename_confirmations_immediately.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- the default configuration`)
@@ -64,6 +65,7 @@ describe("rename events with LSP support", () => {
         "add_yazi_context_assertions.lua",
         "accept_lsp_rename_confirmations_immediately.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- 609a3a37-42da-494d-908e-749d3aedca58`)
@@ -116,6 +118,7 @@ describe("move events with LSP support", () => {
         "add_yazi_context_assertions.lua",
         "accept_lsp_rename_confirmations_immediately.lua",
       ],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains(`-- the default configuration`)

--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -70,7 +70,7 @@ describe("opening files", () => {
     })
   })
 
-  it("can open a file that was selected in yazi", () => {
+  it("can open yazi and hover a filename selected in visual mode", () => {
     cy.startNeovim().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")
 
@@ -363,9 +363,10 @@ describe("opening files", () => {
 
         // close yazi
         cy.typeIntoTerminal("q")
+        cy.contains("-- TERMINAL --").should("not.exist")
 
         // the file should now be renamed - ask neovim to confirm this
-        nvim.runExCommand({ command: "buffers" }).and((result) => {
+        nvim.runExCommand({ command: "ls" }).and((result) => {
           expect(result.value).to.contain("renamed-file.txt")
         })
       })

--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -12,6 +12,7 @@ describe("reading events", () => {
   it("can read 'cd' events and use telescope in the latest directory", () => {
     cy.startNeovim({
       startupScriptModifications: ["add_yazi_context_assertions.lua"],
+      NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       //
       // wait until text on the start screen is visible

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "@catppuccin/palette": "1.7.1",
-    "cypress": "14.5.1",
+    "cypress": "14.5.2",
     "wait-on": "8.0.3",
     "zod": "4.0.5"
   },
   "devDependencies": {
     "@eslint/js": "9.31.0",
     "@tui-sandbox/library": "11.1.0",
-    "@types/node": "24.0.13",
+    "@types/node": "24.0.14",
     "@types/tinycolor2": "1.4.6",
     "concurrently": "9.2.0",
     "eslint": "9.31.0",
@@ -26,6 +26,6 @@
     "tinycolor2": "1.6.0",
     "type-fest": "4.41.0",
     "typescript": "5.8.3",
-    "typescript-eslint": "8.36.0"
+    "typescript-eslint": "8.37.0"
   }
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "cy:run": "concurrently --success command-cypress --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start'  'wait-on --timeout 60000 http://127.0.0.1:3000 && npx cypress run'",
-    "dev": "pnpm tui neovim prepare && concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start'  'pnpm cypress open --e2e --browser=electron'",
+    "dev": "pnpm tui neovim prepare && NVIM_APPNAME=nvim_integrations tui neovim prepare && concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start'  'pnpm cypress open --e2e --browser=electron'",
     "eslint": "eslint --max-warnings=0 ."
   },
   "dependencies": {

--- a/integration-tests/test-environment/.config/nvim/lua/plugins.lua
+++ b/integration-tests/test-environment/.config/nvim/lua/plugins.lua
@@ -1,0 +1,22 @@
+local repo_root = vim.fn.fnamemodify(vim.uv.os_environ().HOME, ":h:h:h:h")
+
+-- install the following plugins
+---@module "lazy"
+---@type LazySpec
+local plugins = {
+  {
+    "mikavilpas/yazi.nvim",
+    -- for tests, always use the code from this repository
+    dir = repo_root,
+    event = "VeryLazy",
+    keys = {
+      { "<up>", mode = { "n", "v" }, "<cmd>Yazi<cr>" },
+      { "<c-up>", "<cmd>Yazi toggle<cr>" },
+    },
+    ---@type YaziConfig
+    opts = {},
+  },
+  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
+}
+
+return plugins

--- a/integration-tests/test-environment/.config/nvim/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim/prepare.lua
@@ -7,18 +7,3 @@
 
 -- make sure the dependencies defined in ./init.lua are installed
 vim.cmd("Lazy! sync")
-
--- Install an LSP server for use in end-to-end tests. Here, the server will be
--- put under the .repro/ directory, so it only needs to be installed once when
--- the entire test run is being started. The tests can reuse the LSP server
--- without re-downloading it.
---
--- The recommendation is to add a specific version to avoid issues in the
--- future
-require("mason-registry").refresh()
-
--- NOTE: installing mason packages seems to report errors in headless mode, but
--- it seems to install the package anyway
--- https://github.com/williamboman/mason.nvim/issues/960#issuecomment-1528081759
-local command = require("mason.api.command")
-command.MasonInstall({ "emmylua_ls" }, { version = "0.8.2" })

--- a/integration-tests/test-environment/.config/nvim_integrations/init.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/init.lua
@@ -55,6 +55,83 @@ vim.list_extend(plugins, {
       -- allows logging debug data, which can be shown in CI when cypress tests fail
       log_level = vim.log.levels.DEBUG,
       future_features = {},
+      integrations = {
+        grep_in_directory = "telescope",
+        picker_add_copy_relative_path_action = "snacks.picker",
+      },
+    },
+  },
+
+  {
+    "nvim-telescope/telescope.nvim",
+    lazy = true,
+    opts = {
+      pickers = {
+        live_grep = {
+          theme = "dropdown",
+        },
+      },
+    },
+  },
+  { "ibhagwan/fzf-lua" },
+  { "https://github.com/MagicDuck/grug-far.nvim", opts = {} },
+
+  {
+    "folke/snacks.nvim",
+    priority = 1000,
+    lazy = false,
+    ---@module "snacks"
+    ---@type snacks.Config
+    opts = {
+      picker = {
+        win = {
+          input = {
+            keys = {
+              ["<C-y>"] = { "yazi_copy_relative_path", mode = { "n", "i" } },
+            },
+          },
+        },
+      },
+    },
+    keys = {
+      {
+        "<leader><space>",
+        function()
+          Snacks.picker.smart()
+        end,
+        desc = "Smart Find Files",
+      },
+    },
+  },
+
+  {
+    -- https://github.com/mason-org/mason-lspconfig.nvim?tab=readme-ov-file#recommended-setup-for-lazynvim
+    "mason-org/mason-lspconfig.nvim",
+    opts = {},
+    config = function()
+      ---@diagnostic disable-next-line: missing-fields
+      require("mason-lspconfig").setup({
+        -- make sure mason-lspconfig does not automatically enable any LSP
+        -- servers that might be installed on the system. We want to only use the
+        -- LSP servers that are included in the test setup.
+        automatic_enable = false,
+      })
+      vim.lsp.config("emmylua_ls", {
+        root_markers = {
+          -- The default config prefers a `luarc.json` file which is found at
+          -- the root of the yazi.nvim repository. Here we need to find the
+          -- file inside the test environment instead, so that the tests can
+          -- run in isolation.
+          --
+          -- https://github.com/neovim/nvim-lspconfig/blob/master/lsp/emmylua_ls.lua
+          ".emmyrc.json",
+        },
+      })
+      vim.lsp.enable("emmylua_ls")
+    end,
+    dependencies = {
+      { "mason-org/mason.nvim", opts = {} },
+      "neovim/nvim-lspconfig",
     },
   },
 })

--- a/integration-tests/test-environment/.config/nvim_integrations/lua/plugins.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/lua/plugins.lua
@@ -1,0 +1,1 @@
+../../nvim/lua/plugins.lua

--- a/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
@@ -1,0 +1,24 @@
+-- This file defines how to set up Neovim's plugins and external applications
+-- such as LSP servers and formatters.
+--
+-- They can be slow to install, which would make the tests slow (and they might
+-- be flaky because of this). This is why this file can be executed before
+-- starting the test run.
+
+-- make sure the dependencies defined in ./init.lua are installed
+vim.cmd("Lazy! sync")
+
+-- Install an LSP server for use in end-to-end tests. Here, the server will be
+-- put under the .repro/ directory, so it only needs to be installed once when
+-- the entire test run is being started. The tests can reuse the LSP server
+-- without re-downloading it.
+--
+-- The recommendation is to add a specific version to avoid issues in the
+-- future
+require("mason-registry").refresh()
+
+-- NOTE: installing mason packages seems to report errors in headless mode, but
+-- it seems to install the package anyway
+-- https://github.com/williamboman/mason.nvim/issues/960#issuecomment-1528081759
+local command = require("mason.api.command")
+command.MasonInstall({ "emmylua_ls" }, { version = "0.8.2" })

--- a/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
@@ -21,4 +21,4 @@ require("mason-registry").refresh()
 -- it seems to install the package anyway
 -- https://github.com/williamboman/mason.nvim/issues/960#issuecomment-1528081759
 local command = require("mason.api.command")
-command.MasonInstall({ "emmylua_ls" }, { version = "0.8.2" })
+command.MasonInstall({ "emmylua_ls" }, { version = "0.9.0" })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "cy:run": "pnpm --filter ./integration-tests/ cy:run",
     "dev": "pnpm --filter ./integration-tests/ dev",
     "markdownlint": "markdownlint-cli2 README.md",
-    "prettier": "prettier --check ."
+    "prettier": "prettier --check .",
+    "tui": "pnpm --filter ./integration-tests/ exec tui"
   },
   "devDependencies": {
     "@umbrelladocs/linkspector": "0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 1.7.1
         version: 1.7.1
       cypress:
-        specifier: 14.5.1
-        version: 14.5.1
+        specifier: 14.5.2
+        version: 14.5.2
       wait-on:
         specifier: 8.0.3
         version: 8.0.3
@@ -44,10 +44,10 @@ importers:
         version: 9.31.0
       '@tui-sandbox/library':
         specifier: 11.1.0
-        version: 11.1.0(cypress@14.5.1)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.5)
+        version: 11.1.0(cypress@14.5.2)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.5)
       '@types/node':
-        specifier: 24.0.13
-        version: 24.0.13
+        specifier: 24.0.14
+        version: 24.0.14
       '@types/tinycolor2':
         specifier: 1.4.6
         version: 1.4.6
@@ -73,8 +73,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       typescript-eslint:
-        specifier: 8.36.0
-        version: 8.36.0(eslint@9.31.0)(typescript@5.8.3)
+        specifier: 8.37.0
+        version: 8.37.0(eslint@9.31.0)(typescript@5.8.3)
 
 packages:
 
@@ -416,8 +416,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.0.13':
-    resolution: {integrity: sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==}
+  '@types/node@24.0.14':
+    resolution: {integrity: sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -440,63 +440,63 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.36.0':
-    resolution: {integrity: sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==}
+  '@typescript-eslint/eslint-plugin@8.37.0':
+    resolution: {integrity: sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.36.0
+      '@typescript-eslint/parser': ^8.37.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/parser@8.36.0':
-    resolution: {integrity: sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/project-service@8.36.0':
-    resolution: {integrity: sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/scope-manager@8.36.0':
-    resolution: {integrity: sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.36.0':
-    resolution: {integrity: sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.9.0'
-
-  '@typescript-eslint/type-utils@8.36.0':
-    resolution: {integrity: sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==}
+  '@typescript-eslint/parser@8.37.0':
+    resolution: {integrity: sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/types@8.36.0':
-    resolution: {integrity: sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.36.0':
-    resolution: {integrity: sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==}
+  '@typescript-eslint/project-service@8.37.0':
+    resolution: {integrity: sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/utils@8.36.0':
-    resolution: {integrity: sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==}
+  '@typescript-eslint/scope-manager@8.37.0':
+    resolution: {integrity: sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.37.0':
+    resolution: {integrity: sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.37.0':
+    resolution: {integrity: sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/visitor-keys@8.36.0':
-    resolution: {integrity: sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==}
+  '@typescript-eslint/types@8.37.0':
+    resolution: {integrity: sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.37.0':
+    resolution: {integrity: sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.37.0':
+    resolution: {integrity: sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.37.0':
+    resolution: {integrity: sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@umbrelladocs/linkspector@0.4.6':
@@ -732,8 +732,8 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
-  ci-info@4.2.0:
-    resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
+  ci-info@4.3.0:
+    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
 
   clean-stack@2.2.0:
@@ -860,8 +860,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  cypress@14.5.1:
-    resolution: {integrity: sha512-vYBeZKW3UAtxwv5mFuSlOBCYhyO0H86TeDKRJ7TgARyHiREIaiDjeHtqjzrXRFrdz9KnNavqlm+z+hklC7v8XQ==}
+  cypress@14.5.2:
+    resolution: {integrity: sha512-O4E4CEBqDHLDrJD/dfStHPcM+8qFgVVZ89Li7xDU0yL/JxO/V0PEcfF2I8aGa7uA2MGNLkNUAnghPM83UcHOJw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2346,8 +2346,8 @@ packages:
   typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
 
-  typescript-eslint@8.36.0:
-    resolution: {integrity: sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==}
+  typescript-eslint@8.37.0:
+    resolution: {integrity: sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2754,7 +2754,7 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@tui-sandbox/library@11.1.0(cypress@14.5.1)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.5)':
+  '@tui-sandbox/library@11.1.0(cypress@14.5.2)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.5)':
     dependencies:
       '@catppuccin/palette': 1.7.1
       '@trpc/client': 11.4.3(@trpc/server@11.4.3(typescript@5.8.3))(typescript@5.8.3)
@@ -2764,7 +2764,7 @@ snapshots:
       '@xterm/xterm': 5.5.0
       command-exists: 1.2.9
       cors: 2.8.5
-      cypress: 14.5.1
+      cypress: 14.5.2
       dree: 5.1.5
       express: 5.1.0
       neovim: 5.3.0
@@ -2794,7 +2794,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.0.13':
+  '@types/node@24.0.14':
     dependencies:
       undici-types: 7.8.0
 
@@ -2812,17 +2812,17 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.0.13
+      '@types/node': 24.0.14
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.36.0
-      '@typescript-eslint/type-utils': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.36.0
+      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.37.0
+      '@typescript-eslint/type-utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.37.0
       eslint: 9.31.0
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -2832,40 +2832,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.36.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.36.0
-      '@typescript-eslint/types': 8.36.0
-      '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.36.0
+      '@typescript-eslint/scope-manager': 8.37.0
+      '@typescript-eslint/types': 8.37.0
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.37.0
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.31.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.36.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.37.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.36.0
+      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.37.0
       debug: 4.4.1(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.36.0':
+  '@typescript-eslint/scope-manager@8.37.0':
     dependencies:
-      '@typescript-eslint/types': 8.36.0
-      '@typescript-eslint/visitor-keys': 8.36.0
+      '@typescript-eslint/types': 8.37.0
+      '@typescript-eslint/visitor-keys': 8.37.0
 
-  '@typescript-eslint/tsconfig-utils@8.36.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.37.0(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.36.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/types': 8.37.0
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.31.0
       ts-api-utils: 2.1.0(typescript@5.8.3)
@@ -2873,14 +2874,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.36.0': {}
+  '@typescript-eslint/types@8.37.0': {}
 
-  '@typescript-eslint/typescript-estree@8.36.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.37.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.36.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.36.0
-      '@typescript-eslint/visitor-keys': 8.36.0
+      '@typescript-eslint/project-service': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.37.0
+      '@typescript-eslint/visitor-keys': 8.37.0
       debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -2891,20 +2892,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.36.0(eslint@9.31.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.37.0(eslint@9.31.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.31.0)
-      '@typescript-eslint/scope-manager': 8.36.0
-      '@typescript-eslint/types': 8.36.0
-      '@typescript-eslint/typescript-estree': 8.36.0(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.37.0
+      '@typescript-eslint/types': 8.37.0
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
       eslint: 9.31.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.36.0':
+  '@typescript-eslint/visitor-keys@8.37.0':
     dependencies:
-      '@typescript-eslint/types': 8.36.0
+      '@typescript-eslint/types': 8.37.0
       eslint-visitor-keys: 4.2.1
 
   '@umbrelladocs/linkspector@0.4.6(typescript@5.8.3)':
@@ -3132,7 +3133,7 @@ snapshots:
       mitt: 3.0.1
       zod: 3.25.76
 
-  ci-info@4.2.0: {}
+  ci-info@4.3.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -3253,7 +3254,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cypress@14.5.1:
+  cypress@14.5.2:
     dependencies:
       '@cypress/request': 3.0.8
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -3266,7 +3267,7 @@ snapshots:
       cachedir: 2.4.0
       chalk: 4.1.2
       check-more-types: 2.24.0
-      ci-info: 4.2.0
+      ci-info: 4.3.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.1
       commander: 6.2.1
@@ -5061,11 +5062,12 @@ snapshots:
 
   typed-query-selector@2.12.0: {}
 
-  typescript-eslint@8.36.0(eslint@9.31.0)(typescript@5.8.3):
+  typescript-eslint@8.37.0(eslint@9.31.0)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.36.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0)(typescript@5.8.3)
       eslint: 9.31.0
       typescript: 5.8.3
     transitivePeerDependencies:


### PR DESCRIPTION
# test: bump emmylua_ls LSP from 0.8.2 to 0.9.0

# refactor(tests): use integration plugins only for a minority of tests

**Issue:**

Currently in the integration-tests, 7 neovim plugins are installed so
that the integrations with them can be tested. However, most of the
tests do not use these plugins.

I'm worried that the presence of the plugins in the test neovim
directory (`integration-tests/test-environment/.repro/data/nvim`) will
affect the code that is tested at some point. Right now this is not an
issue, but it could be in the future.

**Solution:**

Make the integration-tests use two different neovim directories - one
for a minimal yazi.nvim setup with no integrations, and another one that
has all the integrations and the `emmylua_ls` LSP server installed.

I added this feature to tui-sandbox here
https://github.com/mikavilpas/tui-sandbox/pull/510, and tested it with a
real (small) project here
https://github.com/mikavilpas/tsugit.nvim/pull/249

