### PR TITLE
docs: add an example of a custom event for changing Neovim's cwd

### DIFF
--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -415,6 +415,11 @@ describe("'rename' events", () => {
         // The user can set a config option to specify custom yazi dds events that
         // they want to subscribe to. These are emitted as YaziDDSCustom events.
         cy.contains("If you see this text, Neovim is ready!")
+        nvim.runExCommand({ command: "pwd" }).then((result) => {
+          const dir = z.string().parse(result.value)
+          expect(dir + "/").to.eql(nvim.dir.testEnvironmentPath)
+        })
+
         cy.typeIntoTerminal("{upArrow}")
         assertYaziIsReady(nvim)
         cy.contains(nvim.dir.contents["file2.txt"].name)
@@ -423,7 +428,7 @@ describe("'rename' events", () => {
         // notify_custom_events.lua
         cy.typeIntoTerminal("{control+p}")
 
-        // also publish MyMessageWithData that contains json data
+        // also publish MyChangeWorkingDirectoryCommand that contains json data
         cy.typeIntoTerminal("{control+h}")
 
         cy.typeIntoTerminal("q")
@@ -433,7 +438,7 @@ describe("'rename' events", () => {
             /Just received a YaziDDSCustom event 'MyMessageNoData'!/,
           )
           expect(result.value).to.match(
-            /Just received a YaziDDSCustom event 'MyMessageWithData'!/,
+            /Just received a YaziDDSCustom event 'MyChangeWorkingDirectoryCommand'!/,
           )
           expect(result.value).to.match(/selected_file/)
         })
@@ -458,6 +463,11 @@ describe("'rename' events", () => {
               new RegExp("initial-file.txt" satisfies MyTestDirectoryFile),
             )
           })
+
+        // should have changed the working directory
+        nvim.runExCommand({ command: "pwd" }).then((result) => {
+          expect(result.value).to.eql(nvim.dir.rootPathAbsolute)
+        })
       })
     })
   })

--- a/integration-tests/test-environment/.config/yazi/keymap.toml
+++ b/integration-tests/test-environment/.config/yazi/keymap.toml
@@ -12,7 +12,10 @@ run = """shell 'ya pub-to 0 MyMessageNoData'"""
 # send an event that also has json data
 [[mgr.prepend_keymap]]
 on = "<C-h>"
-run = """shell "ya pub-to 0 MyMessageWithData --json \\"{\\"selected_file\\": \\"$0\\"}\\"""""
+run = """shell --
+json=$(printf '{"selected_file": "%s"}' "$0")
+ya pub-to 0 MyChangeWorkingDirectoryCommand --json "$json"
+"""
 
 [[mgr.prepend_keymap]]
 on = "i"

--- a/integration-tests/test-environment/config-modifications/notify_custom_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_custom_events.lua
@@ -7,7 +7,7 @@ do
   config.forwarded_dds_events = vim.tbl_extend(
     "force",
     config.forwarded_dds_events or {},
-    { "MyMessageNoData", "MyMessageWithData" }
+    { "MyMessageNoData", "MyChangeWorkingDirectoryCommand" }
   )
 end
 
@@ -29,5 +29,15 @@ vim.api.nvim_create_autocmd("User", {
       ),
       event.data,
     }))
+
+    if event.data.type == "MyChangeWorkingDirectoryCommand" then
+      local json = vim.json.decode(event.data.raw_data)
+      local selected_file = assert(json.selected_file)
+
+      local new_cwd = vim.fn.fnamemodify(selected_file, ":p:h")
+
+      -- change Neovim's current working directory
+      vim.cmd("cd " .. new_cwd)
+    end
   end,
 })


### PR DESCRIPTION
# docs: add an example of a custom event for changing Neovim's cwd

This might help implementing
https://github.com/mikavilpas/yazi.nvim/issues/617

# docs: update yazi-keymappings.md to use mgr instead of manager

`manager` was deprecated in
https://github.com/sxyazi/yazi/releases/tag/v25.5.28

