### PR TITLE
Mini perf improvement for `Yazi toggle`, log fixes and test maintenance

### DIFF
--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -8,7 +8,19 @@ function Yazi_reveal_path(path)
   local Log = require("yazi.log")
   if context then
     Log:debug("Revealing path in yazi context: " .. vim.inspect(path))
-    context.api:reveal(path)
+
+    require("yazi.process.retry").retry({
+      description = "Revealing path in yazi context",
+      delay = 50,
+      retries = 10,
+      action = function()
+        local job = context.api:reveal(path)
+        local completed = job:wait(1000)
+
+        assert(completed.code == 0)
+        return nil
+      end,
+    })
   else
     Log:debug("No active yazi context found")
   end

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -66,12 +66,12 @@ function M.yazi(config, input_path, args)
           description = string.format("reveal path '%s'", args.reveal_path),
           delay = 50,
           retries = retries,
-          action = function()
+          action = vim.schedule_wrap(function()
             local reveal_job = api:reveal(args.reveal_path)
             local completed = reveal_job:wait(500)
             assert(completed.code == 0)
             return nil
-          end,
+          end),
         })
       end
     end,

--- a/lua/yazi/process/retry.lua
+++ b/lua/yazi/process/retry.lua
@@ -38,10 +38,11 @@ function retry.retry(params)
       else
         require("yazi.log"):debug(
           string.format(
-            "yazi.retry: failed with '%s', retrying after %sms. retries_remaining: %s",
+            "yazi.retry: failed with '%s', retrying after %sms. retries_remaining: %s, result: %s",
             params.description,
             params.delay,
-            retries_remaining
+            retries_remaining,
+            vim.inspect(result)
           )
         )
       end


### PR DESCRIPTION
# test: add retry logic to `Yazi_reveal_path()` for flaky tests

This is an internal function that some tests use to reveal a file in
yazi.

Some tests sometimes try to reveal a path even though yazi is not ready
yet. It could be fixed by making each test wait for yazi to be ready,
but it's perhaps easier to add the retry logic to `Yazi_reveal_path()`.

# perf: fix `Yazi toggle` always failing the first try

**Issue:**

When using `Yazi toggle` to open yazi and focus (reveal) the previously
hovered path, the first attempt to reveal the path often fails. This is
because the `reveal` action is executed in a `vim.in_fast_event()`.

The action is retried many times, and typically the next attempt
succeeds. However, it's slower than it could be.

**Solution:**

Use `vim.schedule_wrap` to ensure the action is executed in the main
thread, allowing it to run immediately without being delayed by
retrying.

# fix: internal retry logic didn't log results on failure

This does not affect users in any way. It's only visible when debugging.

