### PR TITLE
fix: remove snaks dependency from yazi.nvim rockspec

### DIFF
--- a/yazi.nvim-scm-1.rockspec
+++ b/yazi.nvim-scm-1.rockspec
@@ -9,7 +9,6 @@ dependencies = {
   -- Add runtime dependencies here
   -- e.g. "plenary.nvim",
   "plenary.nvim",
-  "snacks.nvim",
 }
 test_dependencies = {
   "nlua",


### PR DESCRIPTION
Snacks was made optional in this commit, but it was not removed from the rockspec:

https://github.com/mikavilpas/yazi.nvim/commit/24eb264e93eae2a2898f27e8f7ddae2ffadb09ef