### PR TITLE
feat: support installing plugins from deeply nested subdirectories

### DIFF
--- a/documentation/plugin-management.md
+++ b/documentation/plugin-management.md
@@ -145,6 +145,17 @@ return {
     build = function(plugin)
       require("yazi.plugin").build_plugin(plugin, { sub_dir = "git.yazi" })
       require("yazi.plugin").build_plugin(plugin, { sub_dir = "vcs-files.yazi" })
+
+      -- example: installing from a deeply nested subdirectory
+      require("yazi.plugin").build_plugin({
+        dir = plugin_monorepo_dir,
+        name = "yazi-plugins",
+      }, {
+        yazi_dir = yazi_dir,
+        sub_dir = vim.fs.joinpath("deeply", "nested", "plugin.yazi"),
+        -- install as ~/.config/yazi/plugins/plugin.yazi
+        name = "plugin.yazi",
+      })
     end,
   },
   {

--- a/lua/yazi/plugin.lua
+++ b/lua/yazi/plugin.lua
@@ -32,7 +32,7 @@ local M = {}
 --- For more information, see the yazi.nvim documentation.
 ---
 ---@param plugin YaziLazyNvimSpec
----@param options? { yazi_dir: string, sub_dir?: string }
+---@param options? { yazi_dir: string, sub_dir?: string, name?: string }
 function M.build_plugin(plugin, options)
   local yazi_dir = options and options.yazi_dir
     or vim.fn.expand("~/.config/yazi")
@@ -48,7 +48,9 @@ function M.build_plugin(plugin, options)
       name = plugin.name,
       dir = vim.fs.joinpath(plugin.dir, options.sub_dir),
     }
-    to = vim.fs.normalize(vim.fs.joinpath(yazi_plugins_dir, options.sub_dir))
+    to = vim.fs.normalize(
+      vim.fs.joinpath(yazi_plugins_dir, options.name or options.sub_dir)
+    )
   end
 
   return M.symlink(plugin, to)
@@ -75,7 +77,7 @@ end
 --- ```
 ---
 ---@param flavor YaziLazyNvimSpec
----@param options? { yazi_dir: string, sub_dir?: string }
+---@param options? { yazi_dir: string, sub_dir?: string, name?: string }
 function M.build_flavor(flavor, options)
   local yazi_dir = options and options.yazi_dir
     or vim.fn.expand("~/.config/yazi")
@@ -91,7 +93,9 @@ function M.build_flavor(flavor, options)
       name = flavor.name,
       dir = vim.fs.joinpath(flavor.dir, options.sub_dir),
     }
-    to = vim.fs.normalize(vim.fs.joinpath(yazi_flavors_dir, options.sub_dir))
+    to = vim.fs.normalize(
+      vim.fs.joinpath(yazi_flavors_dir, options.name or options.sub_dir)
+    )
   end
 
   return M.symlink(flavor, to)

--- a/spec/yazi/plugin_spec.lua
+++ b/spec/yazi/plugin_spec.lua
@@ -104,6 +104,41 @@ describe("installing a plugin", function()
 
       assert.are.same(plugin_dir, symlink)
     end)
+
+    it(
+      "can install a plugin from a monorepo subdirectory that's deeply nested",
+      function()
+        local plugin_monorepo_dir = vim.fs.joinpath(base_dir, "yazi-plugins")
+        local plugin_dir = vim.fs.joinpath(
+          plugin_monorepo_dir,
+          "deeply",
+          "nested",
+          "easyjump.yazi"
+        )
+        local yazi_dir = vim.fs.joinpath(base_dir, "fake-yazi-dir")
+
+        vim.fn.mkdir(plugin_monorepo_dir)
+        vim.fn.mkdir(plugin_dir, "p")
+        vim.fn.mkdir(yazi_dir)
+        vim.fn.mkdir(vim.fs.joinpath(yazi_dir, "plugins"))
+
+        plugin.build_plugin({
+          dir = plugin_monorepo_dir,
+          name = "yazi-plugins",
+        }, {
+          yazi_dir = yazi_dir,
+          sub_dir = vim.fs.joinpath("deeply", "nested", "easyjump.yazi"),
+          name = "easyjump.yazi",
+        })
+
+        -- verify that the plugin was symlinked
+        local symlink = vim.uv.fs_readlink(
+          vim.fs.joinpath(yazi_dir, "plugins", "easyjump.yazi")
+        )
+
+        assert.are.same(plugin_dir, symlink)
+      end
+    )
   end)
 
   describe("installing a flavor", function()
@@ -147,6 +182,41 @@ describe("installing a plugin", function()
 
       assert.are.same(flavor_dir, symlink)
     end)
+
+    it(
+      "can install a flavor from a monorepo subdirectory that's deeply nested",
+      function()
+        local flavor_monorepo_dir = vim.fs.joinpath(base_dir, "yazi-flavors")
+        local flavor_dir = vim.fs.joinpath(
+          flavor_monorepo_dir,
+          "deeply",
+          "nested",
+          "flavor123.yazi"
+        )
+        local yazi_dir = vim.fs.joinpath(base_dir, "fake-yazi-dir")
+
+        vim.fn.mkdir(flavor_monorepo_dir)
+        vim.fn.mkdir(flavor_dir, "p")
+        vim.fn.mkdir(yazi_dir)
+        vim.fn.mkdir(vim.fs.joinpath(yazi_dir, "flavors"))
+
+        plugin.build_flavor({
+          dir = flavor_monorepo_dir,
+          name = "yazi-flavors",
+        }, {
+          yazi_dir = yazi_dir,
+          sub_dir = vim.fs.joinpath("deeply", "nested", "flavor123.yazi"),
+          name = "flavor123.yazi",
+        })
+
+        -- verify that the flavor was symlinked
+        local symlink = vim.uv.fs_readlink(
+          vim.fs.joinpath(yazi_dir, "flavors", "flavor123.yazi")
+        )
+
+        assert.are.same(flavor_dir, symlink)
+      end
+    )
   end)
 
   describe("symlink", function()


### PR DESCRIPTION
**Issue:**

Using the built-in lazy.nvim-based plugin management system, it's only possible to install plugins from a subdirectory of the plugin's root directory. This works fine for e.g. https://github.com/yazi-rs/plugins/ which provides all the plugins as exactly one level deep from the repo root.

However, some plugins may be located in a deeply nested subdirectory such as `deeply/nested/plugin.yazi`, and the current implementation puts them in `~/.config/yazi/plugins/deeply/nested/plugin.yazi` which does not work with yazi.

Docs for this feature:

- https://github.com/mikavilpas/yazi.nvim/blob/main/documentation/plugin-management.md

**Solution:**

Allow passing in a `name` option to the `build_plugin` and `build_flavor` functions, which will be used as the name of the symlinked plugin or flavor. This puts the plugin in `~/.config/yazi/plugins/plugin.yazi` instead of
`~/.config/yazi/plugins/deeply/nested/plugin.yazi`.

This can be helpful in the future, in case we bundle plugins that enhance the yazi.nvim <-> yazi integration.