### PR TITLE
fix: only handle `cd` events for the current yazi instance

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -12,7 +12,7 @@
     "@catppuccin/palette": "1.7.1",
     "cypress": "14.5.3",
     "wait-on": "8.0.4",
-    "zod": "4.0.13"
+    "zod": "4.0.14"
   },
   "devDependencies": {
     "@eslint/js": "9.32.0",

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -228,7 +228,7 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
         self.highlighter:highlight_buffers_when_hovered(event.url, self.config)
         nvim_event_handling.emit("YaziDDSHover", event)
       end)
-    elseif event.type == "cd" then
+    elseif event.type == "cd" and event.yazi_id == self.yazi_id then
       ---@cast event YaziHoverEvent
       Log:debug(
         string.format("Changing the cwd from %s to %s", self.cwd, event.url)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,15 +36,15 @@ importers:
         specifier: 8.0.4
         version: 8.0.4
       zod:
-        specifier: 4.0.13
-        version: 4.0.13
+        specifier: 4.0.14
+        version: 4.0.14
     devDependencies:
       '@eslint/js':
         specifier: 9.32.0
         version: 9.32.0
       '@tui-sandbox/library':
         specifier: 11.2.0
-        version: 11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.13)
+        version: 11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.14)
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
@@ -2499,8 +2499,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.13:
-    resolution: {integrity: sha512-jv+zRxuZQxTrFHzxZ46ezL2FtnE+M4HIJHJEwLsZ7UjrXHltdG6HrxvqM0twoVCWxJiYf8WqKjAcjztegpkB+Q==}
+  zod@4.0.14:
+    resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2759,7 +2759,7 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@tui-sandbox/library@11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.13)':
+  '@tui-sandbox/library@11.2.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.8.3)(zod@4.0.14)':
     dependencies:
       '@catppuccin/palette': 1.7.1
       '@trpc/client': 11.4.3(@trpc/server@11.4.3(typescript@5.8.3))(typescript@5.8.3)
@@ -2779,7 +2779,7 @@ snapshots:
       type-fest: 4.41.0
       typescript: 5.8.3
       winston: 3.17.0
-      zod: 4.0.13
+      zod: 4.0.14
     transitivePeerDependencies:
       - supports-color
 
@@ -5247,6 +5247,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.13: {}
+  zod@4.0.14: {}
 
   zwitch@2.0.4: {}

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -87,7 +87,7 @@ describe("process_events()", function()
       ya:process_events({
         {
           type = "cd",
-          yazi_id = "cd_123",
+          yazi_id = yazi_id,
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
       }, {}, {})
@@ -95,17 +95,31 @@ describe("process_events()", function()
       assert.are.same("/tmp", ya.cwd)
     end)
 
+    it("ignores cd events from yazis with a different yazi_id", function()
+      local ya = ya_process.new(config, yazi_id)
+
+      ya:process_events({
+        {
+          type = "cd",
+          yazi_id = "cd_123", -- different yazi_id
+          url = "/tmp",
+        } --[[@as YaziChangeDirectoryEvent]],
+      }, {}, {})
+
+      assert.are.same(nil, ya.cwd)
+    end)
+
     it("overrides the previous cwd when it's changed multiple times", function()
       local ya = ya_process.new(config, yazi_id)
       ya:process_events({
         {
           type = "cd",
-          yazi_id = "cd_123",
+          yazi_id = yazi_id,
           url = "/tmp",
         } --[[@as YaziChangeDirectoryEvent]],
         {
           type = "cd",
-          yazi_id = "cd_123",
+          yazi_id = yazi_id,
           url = "/tmp/directory",
         } --[[@as YaziChangeDirectoryEvent]],
       }, {}, {} --[[@as YaziActiveContext]])


### PR DESCRIPTION
# fix: only handle `cd` events for the current yazi instance

Might help
https://github.com/mikavilpas/yazi.nvim/issues/1049#issuecomment-3137184040

