### PR TITLE
ci: bump yazi version commit from 2025-07-20 to 2025-07-31

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
           crate: yazi-fm
           git: https://github.com/sxyazi/yazi
           commit:
-            # https://github.com/sxyazi/yazi/commit/74bd98031e04 (2025-07-20)
-            74bd98031e04
+            # https://github.com/sxyazi/yazi/commit/da97e5a8b4580add8f5eb2f97f0fe80886becf06 (2025-07-31)
+            da97e5a8b4580add8f5eb2f97f0fe80886becf06
           # tag: v25.5.31
 
       - name: Compile and install yazi from source
@@ -59,8 +59,8 @@ jobs:
           crate: yazi-cli
           git: https://github.com/sxyazi/yazi
           commit:
-            # https://github.com/sxyazi/yazi/commit/74bd98031e04 (2025-07-20)
-            74bd98031e04
+            # https://github.com/sxyazi/yazi/commit/da97e5a8b4580add8f5eb2f97f0fe80886becf06 (2025-07-31)
+            da97e5a8b4580add8f5eb2f97f0fe80886becf06
           # tag: v25.5.31
 
       - name: Run tests


### PR DESCRIPTION
Link to commit:
https://github.com/sxyazi/yazi/commit/da97e5a8b4580add8f5eb2f97f0fe80886becf06