### PR TITLE
fix: resolve the last directory using the `--cwd-file` option

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -47,6 +47,7 @@ function M.yazi(config, input_path, args)
   local prev_win = vim.api.nvim_get_current_win()
 
   config.chosen_file_path = config.chosen_file_path or vim.fn.tempname()
+  config.cwd_file_path = config.cwd_file_path or vim.fn.tempname()
 
   local win = require("yazi.window").YaziFloatingWindow.new(config)
   win:open_and_display()

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -14,7 +14,9 @@ function M.default()
   return {
     log_level = vim.log.levels.OFF,
     open_for_directories = false,
-    future_features = {},
+    future_features = {
+      use_cwd_file = true,
+    },
     open_multiple_tabs = false,
     enable_mouse_support = false,
     open_file_function = openers.open_file,

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -84,6 +84,11 @@ function YaProcess:get_yazi_command(paths)
     table.insert(command_words, self.yazi_id)
   end
 
+  if self.config.future_features.use_cwd_file then
+    table.insert(command_words, "--cwd-file")
+    table.insert(command_words, self.config.cwd_file_path)
+  end
+
   command_words = remove_duplicates(command_words)
 
   return table.concat(command_words, " ")

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -64,8 +64,20 @@ function YaziProcess:start(config, paths, callbacks)
       end
 
       local last_directory = nil
-      if self.ya_process.cwd ~= nil then
-        last_directory = plenary_path:new(self.ya_process.cwd) --[[@as Path]]
+      if
+        config.future_features.use_cwd_file == true
+        and utils.file_exists(config.cwd_file_path) == true
+      then
+        last_directory =
+          plenary_path:new(vim.fn.readfile(config.cwd_file_path)[1])
+        require("yazi.log"):debug(
+          string.format("using cwd from cwd_file_path", self.ya_process.cwd)
+        )
+      elseif self.ya_process.cwd ~= nil then
+        last_directory = plenary_path:new(self.ya_process.cwd)
+        require("yazi.log"):debug(
+          string.format("using ya process cwd: %s", self.ya_process.cwd)
+        ) --[[@as Path]]
       end
 
       callbacks.on_exit(

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -7,6 +7,7 @@
 ---@class (exact) YaziConfig
 ---@field public open_for_directories? boolean
 ---@field public chosen_file_path? string "the path to a temporary file that will be created by yazi to store the chosen file path"
+---@field public cwd_file_path? string "the path to a temporary file that will be created by yazi to store the last directory that yazi was in before it was closed"
 ---@field public open_multiple_tabs? boolean "open multiple open files in yazi tabs when opening yazi"
 ---@field public enable_mouse_support? boolean
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
@@ -27,6 +28,7 @@
 ---@field public config_home? string # optional path for nvim yazi to find a custom yazi.toml
 
 ---@class(exact) yazi.OptInFeatures
+---@field public use_cwd_file? boolean # use a file to store the last directory that yazi was in before it was closed. Defaults to `true`.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier-plugin-organize-imports": "4.2.0",
     "prettier-plugin-packagejson": "2.5.19"
   },
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -9,6 +9,7 @@ describe("the get_yazi_command() function", function()
     local config = require("yazi.config").default()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
+    config.cwd_file_path = "/tmp/cwd_file_path"
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -20,7 +21,7 @@ describe("the get_yazi_command() function", function()
     local command = ya:get_yazi_command(paths)
 
     assert.are.same(
-      "yazi 'file1' 'file2' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123",
+      "yazi 'file1' 'file2' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
       command
     )
   end)
@@ -31,6 +32,7 @@ describe("the get_yazi_command() function", function()
       local config = require("yazi.config").default()
       config.open_multiple_tabs = false
       config.chosen_file_path = "/tmp/chosen_file_path"
+      config.cwd_file_path = "/tmp/cwd_file_path"
 
       local ya = ya_process.new(config, yazi_id)
 
@@ -42,7 +44,7 @@ describe("the get_yazi_command() function", function()
       local command = ya:get_yazi_command(paths)
 
       assert.are.same(
-        "yazi 'file1' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123",
+        "yazi 'file1' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
         command
       )
     end
@@ -52,6 +54,7 @@ describe("the get_yazi_command() function", function()
     local config = require("yazi.config").default()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
+    config.cwd_file_path = "/tmp/cwd_file_path"
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -68,7 +71,7 @@ describe("the get_yazi_command() function", function()
     local command = ya:get_yazi_command(paths)
 
     assert.are.same(
-      "yazi 'file1' 'file2' 'file3' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123",
+      "yazi 'file1' 'file2' 'file3' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
       command
     )
   end)


### PR DESCRIPTION
# fix: resolve the last directory using the `--cwd-file` option

I had previously implemented tracking the cwd using ya and listening to
the `cd` and `hover` events. It's more reliable to use `--cwd-file`
since ya seems to have some trouble starting on some systems right now.

`cwd-file` is entioned here:
https://yazi-rs.github.io/docs/configuration/keymap/#mgr.quit

# chore: bump pnpm from 10.13.1 to 10.14.0

