### PR TITLE
feat(opt-in): change Neovim's cwd when no files are selected in yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ return {
     -- https://github.com/mikavilpas/yazi.nvim/pull/359
     open_multiple_tabs = false,
 
+    -- when yazi is closed with no file chosen, change the Neovim working
+    -- directory to the directory that yazi was in before it was closed. Defaults
+    -- to being off (`false`)
+    change_neovim_cwd_on_close = false,
+
     highlight_groups = {
       -- See https://github.com/mikavilpas/yazi.nvim/pull/180
       hovered_buffer = nil,

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -139,6 +139,10 @@ export const MyTestDirectorySchema = z.object({
               name: z.literal("disable_a_keybinding.lua"),
               type: z.literal("file"),
             }),
+            "enable_change_neovim_cwd_on_close.lua": z.object({
+              name: z.literal("enable_change_neovim_cwd_on_close.lua"),
+              type: z.literal("file"),
+            }),
             "highlight_buffers_in_same_directory.lua": z.object({
               name: z.literal("highlight_buffers_in_same_directory.lua"),
               type: z.literal("file"),
@@ -331,6 +335,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/yazi_config/add_hovered_buffer_background.lua",
   "config-modifications/yazi_config/add_keybinding_to_start_yazi_and_find.lua",
   "config-modifications/yazi_config/disable_a_keybinding.lua",
+  "config-modifications/yazi_config/enable_change_neovim_cwd_on_close.lua",
   "config-modifications/yazi_config/highlight_buffers_in_same_directory.lua",
   "config-modifications/yazi_config/log_yazi_closed_successfully.lua",
   "config-modifications/yazi_config/make_yazi_fullscreen.lua",

--- a/integration-tests/cypress/e2e/utils/neovim-utils.ts
+++ b/integration-tests/cypress/e2e/utils/neovim-utils.ts
@@ -1,0 +1,15 @@
+import type { RunExCommandOutput } from "@tui-sandbox/library/src/server/types"
+import type { NeovimContext } from "cypress/support/tui-sandbox"
+import type { MyTestDirectoryFile } from "MyTestDirectory"
+import type { LiteralUnion } from "type-fest"
+import * as z from "zod"
+
+export function assertNeovimCwd(
+  nvim: NeovimContext,
+  expectedCwd: LiteralUnion<MyTestDirectoryFile, string>,
+): Cypress.Chainable<RunExCommandOutput> {
+  return nvim.runExCommand({ command: "pwd" }).then((result) => {
+    const pwd = z.string().parse(result.value)
+    expect(pwd).to.eql(expectedCwd)
+  })
+}

--- a/integration-tests/test-environment/config-modifications/yazi_config/enable_change_neovim_cwd_on_close.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/enable_change_neovim_cwd_on_close.lua
@@ -1,0 +1,8 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    change_neovim_cwd_on_close = true,
+  }
+)

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -19,6 +19,7 @@ function M.default()
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,
+    change_neovim_cwd_on_close = false,
     open_file_function = openers.open_file,
     clipboard_register = "*",
     keymaps = {

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -71,12 +71,15 @@ function YaziProcess:start(config, paths, callbacks)
         last_directory =
           plenary_path:new(vim.fn.readfile(config.cwd_file_path)[1])
         require("yazi.log"):debug(
-          string.format("using cwd from cwd_file_path", self.ya_process.cwd)
+          string.format(
+            "using cwd found from the cwd_file_path: '%s'",
+            last_directory
+          )
         )
       elseif self.ya_process.cwd ~= nil then
         last_directory = plenary_path:new(self.ya_process.cwd)
         require("yazi.log"):debug(
-          string.format("using ya process cwd: %s", self.ya_process.cwd)
+          string.format("using ya process cwd: '%s'", self.ya_process.cwd)
         ) --[[@as Path]]
       end
 

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -10,6 +10,7 @@
 ---@field public cwd_file_path? string "the path to a temporary file that will be created by yazi to store the last directory that yazi was in before it was closed"
 ---@field public open_multiple_tabs? boolean "open multiple open files in yazi tabs when opening yazi"
 ---@field public enable_mouse_support? boolean
+---@field public change_neovim_cwd_on_close? boolean "when yazi is closed with no file chosen, change the Neovim working directory to the directory that yazi was in before it was closed. Defaults to being off (`false`)"
 ---@field public open_file_function? fun(chosen_file: string, config: YaziConfig, state: YaziClosedState): nil "a function that will be called when a file is chosen in yazi"
 ---@field public keymaps? YaziKeymaps | false # The keymaps that are available when yazi is open and focused. Set to `false` to disable all default keymaps.
 ---@field public set_keymappings_function? fun(buffer: integer, config: YaziConfig, context: YaziActiveContext): nil # Can be used to create new, custom keybindings. In most cases it's recommended to use `keymaps` to customize the keybindings that come with yazi.nvim

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -494,6 +494,16 @@ function M.on_yazi_exited(prev_win, window, config, selected_files, state)
   vim.api.nvim_set_current_win(prev_win)
   if #selected_files <= 0 then
     config.hooks.yazi_closed_successfully(nil, config, state)
+
+    if config.change_neovim_cwd_on_close then
+      require("yazi.log"):debug(
+        string.format(
+          "No files were selected, so changing Neovim's current working directory to the last yazi directory '%s'.",
+          state.last_directory
+        )
+      )
+      vim.cmd.cd(state.last_directory.filename)
+    end
     return
   end
 


### PR DESCRIPTION
# feat(opt-in): change Neovim's cwd when no files are selected in yazi

When yazi is closed with no files selected, it can now change Neovim's
current working directory to the directory that yazi was in before it
was closed. It's off by default.

To use this, set `change_neovim_cwd_on_close = true` in your yazi.nvim
configuration.

Closes https://github.com/mikavilpas/yazi.nvim/issues/617

# refactor: clearer wording for cwd handling log messages

