### PR TITLE
feat: allow customizing the way file paths are escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,14 @@ return {
     highlight_hovered_buffers_in_same_directory = true,
 
     integrations = {
+      -- a function that will be used to escape paths before passing them to
+      -- external commands. Defaults to `vim.fn.shellescape`. Depending on your OS
+      -- + shell + neovim settings, you might need to customize this for
+      -- yazi.nvim to work correctly with paths that contain special characters.
+      -- Defaults to `vim.fn.shellescape`, which is usually sufficient for most
+      -- users.
+      escape_path_implementation = vim.fn.shellescape,
+
       --- What should be done when the user wants to grep in a directory
       grep_in_directory = function(directory)
         -- the default implementation uses telescope if available, otherwise nothing

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -48,6 +48,7 @@ function M.default()
       hovered_buffer_in_same_directory = nil,
     },
     integrations = {
+      escape_path_implementation = vim.fn.shellescape,
       grep_in_directory = "telescope",
       grep_in_selected_files = "telescope",
       replace_in_directory = function(directory)

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -69,11 +69,15 @@ function YaProcess:get_yazi_command(paths)
   local command_words = { "yazi" }
 
   if self.config.open_multiple_tabs == true then
-    for _, path in ipairs(paths) do
-      table.insert(command_words, vim.fn.shellescape(path.filename))
+    for _, p in ipairs(paths) do
+      local path =
+        self.config.integrations.escape_path_implementation(p.filename)
+      table.insert(command_words, path)
     end
   else
-    table.insert(command_words, vim.fn.shellescape(paths[1].filename))
+    local path =
+      self.config.integrations.escape_path_implementation(paths[1].filename)
+    table.insert(command_words, path)
   end
 
   table.insert(command_words, "--chooser-file")

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -67,6 +67,7 @@
 ---@field public bufdelete_implementation? YaziBufdeleteImpl # how to delete (close) a buffer. Defaults to `snacks.bufdelete` from https://github.com/folke/snacks.nvim, which maintains the window layout.
 ---@field public picker_add_copy_relative_path_action? "snacks.picker" # add an action to a file picker to copy the relative path to the selected file(s). The implementation is the same as for the `copy_relative_path_to_selected_files` yazi.nvim keymap. Currently only snacks.nvim is supported. Documentation can be found in the keybindings section of the readme. The default is `nil`, which means no action is added.
 ---@field public pick_window_implementation? "snacks.picker" # the implementation to use for picking a window. The default is `snacks.picker`, which uses the snacks.nvim picker's "pick_win" action.
+---@field public escape_path_implementation? fun(path: string): string # a function that will be used to escape paths before passing them to external commands. Defaults to `vim.fn.shellescape`. Depending on your OS + shell + neovim settings, you might need to customize this for yazi.nvim to work correctly with paths that contain special characters. Defaults to `vim.fn.shellescape`, which is usually sufficient for most users.
 
 ---@alias YaziBufdeleteImpl
 ---| "snacks-if-available" # the implementation from https://github.com/folke/snacks.nvim, which maintains the window layout. If not available, falls back to the builtin implementation in `vim.api.nvim_buf_delete()`, which does not maintain the window layout.

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -75,6 +75,44 @@ describe("the get_yazi_command() function", function()
       command
     )
   end)
+
+  describe("escape_path_implementation", function()
+    it("can handle paths with spaces", function()
+      local config = require("yazi.config").default()
+      config.chosen_file_path = "/tmp/chosen_file_path"
+      config.cwd_file_path = "/tmp/cwd_file_path"
+
+      local ya = ya_process.new(config, yazi_id)
+
+      local command = ya:get_yazi_command({ { filename = "file 1" } })
+
+      assert.are.same(
+        "yazi 'file 1' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
+        command
+      )
+    end)
+
+    it("allows customizing the way shellescape is done", function()
+      local config = require("yazi.config").default()
+      config.chosen_file_path = "/tmp/chosen_file_path"
+      config.cwd_file_path = "/tmp/cwd_file_path"
+
+      config.integrations.escape_path_implementation = function(path)
+        -- replace / with \
+        local result = path:gsub("/", "\\")
+        return result
+      end
+
+      local ya = ya_process.new(config, yazi_id)
+
+      local command = ya:get_yazi_command({ { filename = "file/1" } })
+
+      assert.are.same(
+        "yazi file\\1 --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
+        command
+      )
+    end)
+  end)
 end)
 
 describe("process_events()", function()


### PR DESCRIPTION
feat: allow customizing the way file paths are escaped

**Issue:**

Depending on the user's operating system, shell, and neovim settings,
the way file paths are escaped before being passed to yazi commands may
need to be customized.

**Solution:**

Allow customizing this with
`config.integrations.escape_path_implementation`, which has the type
`escape_path_implementation? fun(path: string): string`.

Examples of possible implementations:

```lua
-- example: replace / with \
config.integrations.escape_path_implementation = function(path)
  -- string.gsub() returns multiple values, so we take the first one to
  -- keep the Lua LSP happy
  local result = path:gsub("/", "\\")
  return result
end
```

The default implementation uses `vim.fn.shellescape` (as it did before
this change), which is usually sufficient for most users, but some users
may need to customize this to handle special characters in file paths
correctly.

Closes https://github.com/mikavilpas/yazi.nvim/issues/1092