### PR TITLE
fix: avoid using shell escaping for passing paths to yazi

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -67,17 +67,26 @@ end
 ---@param paths Path[]
 function YaProcess:get_yazi_command(paths)
   local command_words = { "yazi" }
+  local new_shell_escaping = self.config.future_features.new_shell_escaping
 
   if self.config.open_multiple_tabs == true then
-    for _, p in ipairs(paths) do
-      local path =
-        self.config.integrations.escape_path_implementation(p.filename)
-      table.insert(command_words, path)
+    for _, path in ipairs(paths) do
+      if new_shell_escaping then
+        table.insert(command_words, path.filename)
+      else
+        local escaped_path =
+          self.config.integrations.escape_path_implementation(path.filename)
+        table.insert(command_words, escaped_path)
+      end
     end
   else
-    local path =
-      self.config.integrations.escape_path_implementation(paths[1].filename)
-    table.insert(command_words, path)
+    if new_shell_escaping then
+      table.insert(command_words, paths[1].filename)
+    else
+      local path =
+        self.config.integrations.escape_path_implementation(paths[1].filename)
+      table.insert(command_words, path)
+    end
   end
 
   table.insert(command_words, "--chooser-file")
@@ -95,7 +104,11 @@ function YaProcess:get_yazi_command(paths)
 
   command_words = remove_duplicates(command_words)
 
-  return table.concat(command_words, " ")
+  if new_shell_escaping then
+    return command_words
+  else
+    return table.concat(command_words, " ")
+  end
 end
 
 ---@param timeout integer

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -30,6 +30,7 @@
 
 ---@class(exact) yazi.OptInFeatures
 ---@field public use_cwd_file? boolean # use a file to store the last directory that yazi was in before it was closed. Defaults to `true`.
+---@field public new_shell_escaping? boolean # use a new shell escaping implementation that is more robust and works on more platforms. Defaults to `true`. If set to `false`, the old shell escaping implementation will be used, which is less robust and may not work on all platforms.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -76,6 +76,29 @@ describe("the get_yazi_command() function", function()
     )
   end)
 
+  it("returns a table if new_shell_escaping is used", function()
+    -- Doing this lets vim.fn.jobstart() handle the escaping for shell
+    -- arguments, which might work more reliably across different systems.
+    -- https://github.com/mikavilpas/yazi.nvim/issues/1101
+    local config = require("yazi.config").default()
+    config.open_multiple_tabs = true
+    config.chosen_file_path = "/tmp/chosen_file_path"
+    config.cwd_file_path = "/tmp/cwd_file_path"
+    config.future_features.new_shell_escaping = true
+
+    local ya = ya_process.new(config, yazi_id)
+
+    local paths = { { filename = "file1" } }
+    local command = ya:get_yazi_command(paths)
+
+    assert(type(command) == "table")
+
+    assert.are_equal(
+      "yazi file1 --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
+      table.concat(command, " ")
+    )
+  end)
+
   describe("escape_path_implementation", function()
     it("can handle paths with spaces", function()
       local config = require("yazi.config").default()


### PR DESCRIPTION
This tries to avoid issues related to different shell escaping implementations on different platforms. It might be possible to avoid using shell escaping altogether by passing the paths as a table to `vim.fn.jobstart()`, which handles the escaping internally.

This is now on by default, but can be disabled by setting `future_features.new_shell_escaping = false` in the configuration. Please open an issue if you encounter any problems with this.

Related issue: https://github.com/mikavilpas/yazi.nvim/issues/1101