### PR TITLE
fix: enable new shell escaping feature

### DIFF
--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -16,6 +16,7 @@ function M.default()
     open_for_directories = false,
     future_features = {
       use_cwd_file = true,
+      new_shell_escaping = true,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -10,6 +10,7 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
+    config.future_features.new_shell_escaping = false
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -33,6 +34,7 @@ describe("the get_yazi_command() function", function()
       config.open_multiple_tabs = false
       config.chosen_file_path = "/tmp/chosen_file_path"
       config.cwd_file_path = "/tmp/cwd_file_path"
+      config.future_features.new_shell_escaping = false
 
       local ya = ya_process.new(config, yazi_id)
 
@@ -55,6 +57,7 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
+    config.future_features.new_shell_escaping = false
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -84,7 +87,7 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
-    config.future_features.new_shell_escaping = true
+    assert(config.future_features.new_shell_escaping)
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -104,6 +107,7 @@ describe("the get_yazi_command() function", function()
       local config = require("yazi.config").default()
       config.chosen_file_path = "/tmp/chosen_file_path"
       config.cwd_file_path = "/tmp/cwd_file_path"
+      config.future_features.new_shell_escaping = false
 
       local ya = ya_process.new(config, yazi_id)
 
@@ -119,6 +123,7 @@ describe("the get_yazi_command() function", function()
       local config = require("yazi.config").default()
       config.chosen_file_path = "/tmp/chosen_file_path"
       config.cwd_file_path = "/tmp/cwd_file_path"
+      config.future_features.new_shell_escaping = false
 
       config.integrations.escape_path_implementation = function(path)
         -- replace / with \


### PR DESCRIPTION
It was supposed to be on in the previous commit, but was accidentally left off.