### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ These are the default keybindings that are available when yazi is open:
 You can optionally configure yazi.nvim by setting any of the options below.
 
 ```lua
-
 return {
   -- ... other lazy.nvim configuration from above
 
@@ -320,14 +319,6 @@ return {
     highlight_hovered_buffers_in_same_directory = true,
 
     integrations = {
-      -- a function that will be used to escape paths before passing them to
-      -- external commands. Defaults to `vim.fn.shellescape`. Depending on your OS
-      -- + shell + neovim settings, you might need to customize this for
-      -- yazi.nvim to work correctly with paths that contain special characters.
-      -- Defaults to `vim.fn.shellescape`, which is usually sufficient for most
-      -- users.
-      escape_path_implementation = vim.fn.shellescape,
-
       --- What should be done when the user wants to grep in a directory
       grep_in_directory = function(directory)
         -- the default implementation uses telescope if available, otherwise nothing
@@ -365,6 +356,15 @@ return {
       -- - nil (default, no action added)
       -- - "snacks.picker" (snacks.nvim)
       picker_add_copy_relative_path_action = nil,
+
+      -- Only used when `future_features.new_shell_escaping` is off. A function
+      -- that will be used to escape paths before passing them to external
+      -- commands. Defaults to `vim.fn.shellescape`. Depending on your OS +
+      -- shell + neovim settings, you might need to customize this for
+      -- yazi.nvim to work correctly with paths that contain special
+      -- characters. Defaults to `vim.fn.shellescape`, which is usually
+      -- sufficient for most users.
+      escape_path_implementation = vim.fn.shellescape,
     },
 
     future_features = {

--- a/README.md
+++ b/README.md
@@ -368,7 +368,15 @@ return {
     },
 
     future_features = {
-      -- (any unstable features will be added here in the future)
+      -- use a file to store the last directory that yazi was in before it was
+      -- closed. Defaults to `true`.
+      use_cwd_file = true,
+
+      -- use a new shell escaping implementation that is more robust and works
+      -- on more platforms. Defaults to `true`. If set to `false`, the old
+      -- shell escaping implementation will be used, which is less robust and
+      -- may not work on all platforms.
+      new_shell_escaping = true,
     },
   },
 }

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ These are the default keybindings that are available when yazi is open:
   - `<c-y>`: copy the relative path of the selected file(s) to the clipboard.
     Requires GNU `realpath` or `grealpath` on OSX
     - also available for the snacks.nvim picker, see
-      [here](documentation/copy-relative-path-to-files.md) for more information
+      [documentation/copy-relative-path-to-files.md](documentation/copy-relative-path-to-files.md)
+      for more information
   - `<tab>`: make yazi jump to the open buffers in Neovim. See
     [#232](https://github.com/mikavilpas/yazi.nvim/pull/232) for more
     information


### PR DESCRIPTION
# docs: add better link text for `copy-relative-path-to-files.md`

# docs: explain that `escape_path_implementation` is off by default

# docs: document current `future_features` options

