### PR TITLE
Dev improvements

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -438,7 +438,7 @@ describe("opening files", () => {
       nvim
         .runLuaCode({ luaCode: `return vim.fn.getreg('"')` })
         .then((result) => {
-          expect(result.value).to.contain(
+          expect(result.value).to.eql(
             "routes/posts.$postId/adjacent-file.txt" satisfies MyTestDirectoryFile,
           )
         })

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@catppuccin/palette": "1.7.1",
+    "concurrently": "9.2.0",
     "cypress": "14.5.3",
     "wait-on": "8.0.4",
     "zod": "4.0.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@catppuccin/palette':
         specifier: 1.7.1
         version: 1.7.1
+      concurrently:
+        specifier: 9.2.0
+        version: 9.2.0
       cypress:
         specifier: 14.5.3
         version: 14.5.3


### PR DESCRIPTION
# test: use `to.eql` for exact match in relative_paths test

This makes the test a bit more robust

# chore: fix `pnpm dev` not working due to missing dep

