### PR TITLE
feat: custom copy_relative_path_to_selected_files implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,12 @@ return {
       -- `grealpath` on OSX, (GNU) `realpath` otherwise
       resolve_relative_path_application = "",
 
+      -- the way to resolve relative paths. The default_implementation can be
+      -- customized with a function. See
+      -- documentation/copy-relative-path-to-files.md for more information.
+      resolve_relative_path_implementation = function(args, get_relative_path)
+      end,
+
       -- how to delete (close) a buffer. Defaults to a bundled version of
       -- `snacks.bufdelete`, copied from https://github.com/folke/snacks.nvim,
       -- which maintains the window layout. See the `types.lua` file for more

--- a/documentation/copy-relative-path-to-files.md
+++ b/documentation/copy-relative-path-to-files.md
@@ -6,6 +6,46 @@ When yazi is open, you can copy the relative path from the current file to other
 files or directories. By default it's mapped to `<c-y>` and requires GNU
 `realpath` or `grealpath` on OSX.
 
+## Customizing the path resolution
+
+> Use case: I want to always resolve the path from Neovim's current working
+> directory
+
+You can customize the path resolution in your configuration:
+
+```lua
+-- Example: when using the `copy_relative_path_to_selected_files` key (default
+-- <c-y>) in yazi, change the way the relative path is resolved.
+require("yazi").setup({
+  integrations = {
+    resolve_relative_path_implementation = function(args, get_relative_path)
+      -- By default, the path is resolved from the file/dir yazi was focused on
+      -- when it was opened. Here, we change it to resolve the path from
+      -- Neovim's current working directory (cwd) to the target_file.
+      local cwd = vim.fn.getcwd()
+      local path = get_relative_path({
+        selected_file = args.selected_file,
+        source_dir = cwd,
+      })
+      return path
+    end,
+  },
+})
+```
+
+This allows for a couple of interesting things:
+
+- fallback to the default implementation
+- reuse the default implementation but change the source directory (e.g. to
+  Neovim's current working directory)
+- use a custom implementation, get creative! Some ideas just for fun:
+  - Maybe it could convert the link to a GitHub url
+  - If the current Neovim file is a markdown file, it could convert the link to
+    a relative markdown link
+
+This configuration is tested as part of the end-to-end test suite
+[in this file](../integration-tests/test-environment/config-modifications/yazi_config/resolve_relative_files_from_cwd.lua).
+
 ## Usage with snacks.nvim
 
 If you use

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -159,6 +159,10 @@ export const MyTestDirectorySchema = z.object({
               name: z.literal("open_multiple_files.lua"),
               type: z.literal("file"),
             }),
+            "resolve_relative_files_from_cwd.lua": z.object({
+              name: z.literal("resolve_relative_files_from_cwd.lua"),
+              type: z.literal("file"),
+            }),
             "set_help_key.lua": z.object({
               name: z.literal("set_help_key.lua"),
               type: z.literal("file"),
@@ -340,6 +344,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/yazi_config/log_yazi_closed_successfully.lua",
   "config-modifications/yazi_config/make_yazi_fullscreen.lua",
   "config-modifications/yazi_config/open_multiple_files.lua",
+  "config-modifications/yazi_config/resolve_relative_files_from_cwd.lua",
   "config-modifications/yazi_config/set_help_key.lua",
   "config-modifications/yazi_config/use_fzf_lua.lua",
   "config-modifications/yazi_config/use_snacks_picker.lua",

--- a/integration-tests/test-environment/config-modifications/yazi_config/resolve_relative_files_from_cwd.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/resolve_relative_files_from_cwd.lua
@@ -1,0 +1,20 @@
+-- NOTE this file is part of public documentation, remember to keep all changes
+-- in sync
+
+-- Example: when using the `copy_relative_path_to_selected_files` key (default
+-- <c-y>) in yazi, change the way the relative path is resolved.
+require("yazi").setup({
+  integrations = {
+    resolve_relative_path_implementation = function(args, get_relative_path)
+      -- By default, the path is resolved from the file/dir yazi was focused on
+      -- when it was opened. Here, we change it to resolve the path from
+      -- Neovim's current working directory (cwd) to the target_file.
+      local cwd = vim.fn.getcwd()
+      local path = get_relative_path({
+        selected_file = args.selected_file,
+        source_dir = cwd,
+      })
+      return path
+    end,
+  },
+})

--- a/lua/yazi/integrations/get_relative_path.lua
+++ b/lua/yazi/integrations/get_relative_path.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+---@param config YaziConfig
+---@param relative_path_arguments YaziGetRelativePathImplementationArguments
+function M.get_relative_path(config, relative_path_arguments)
+  ---@param arguments YaziGetRelativePathImplementationArguments
+  local default_get_relative_path = function(arguments)
+    return require("yazi.utils").relative_path(
+      config.integrations.resolve_relative_path_application,
+      arguments
+    )
+  end
+
+  ---@type string | nil
+  local relative_path
+
+  if config.integrations.resolve_relative_path_implementation ~= nil then
+    relative_path = config.integrations.resolve_relative_path_implementation(
+      relative_path_arguments,
+      default_get_relative_path
+    )
+  else
+    relative_path = default_get_relative_path(relative_path_arguments)
+  end
+
+  assert(
+    relative_path ~= nil,
+    "Could not resolve relative path for "
+      .. vim.inspect(relative_path_arguments)
+  )
+  return relative_path
+end
+
+return M

--- a/lua/yazi/integrations/snacks_relative_path.lua
+++ b/lua/yazi/integrations/snacks_relative_path.lua
@@ -43,8 +43,10 @@ function M.setup_copy_relative_path_picker_action_once()
       local full_path = vim.fs.joinpath(cwd, assert(selected_file.file))
       local relative_path = require("yazi.utils").relative_path(
         config.integrations.resolve_relative_path_application,
-        current_file_dir,
-        full_path
+        {
+          source_dir = current_file_dir,
+          selected_file = full_path,
+        }
       )
       table.insert(relative_paths, relative_path)
     end

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -65,10 +65,15 @@
 ---@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil # called to start a replacement operation on some directory; by default uses grug-far.nvim
 ---@field public replace_in_selected_files? fun(selected_files?: Path[]): nil # called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim
 ---@field public resolve_relative_path_application? string # the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS
+---@field public resolve_relative_path_implementation? fun(args: YaziGetRelativePathImplementationArguments, default_implementation: fun(args: YaziGetRelativePathImplementationArguments): string): string # the way to resolve relative paths. The default_implementation can be customized with a function. See ../../documentation/copy-relative-path-to-files.md for more information.
 ---@field public bufdelete_implementation? YaziBufdeleteImpl # how to delete (close) a buffer. Defaults to `snacks.bufdelete` from https://github.com/folke/snacks.nvim, which maintains the window layout.
 ---@field public picker_add_copy_relative_path_action? "snacks.picker" # add an action to a file picker to copy the relative path to the selected file(s). The implementation is the same as for the `copy_relative_path_to_selected_files` yazi.nvim keymap. Currently only snacks.nvim is supported. Documentation can be found in the keybindings section of the readme. The default is `nil`, which means no action is added.
 ---@field public pick_window_implementation? "snacks.picker" # the implementation to use for picking a window. The default is `snacks.picker`, which uses the snacks.nvim picker's "pick_win" action.
 ---@field public escape_path_implementation? fun(path: string): string # a function that will be used to escape paths before passing them to external commands. Defaults to `vim.fn.shellescape`. Depending on your OS + shell + neovim settings, you might need to customize this for yazi.nvim to work correctly with paths that contain special characters. Defaults to `vim.fn.shellescape`, which is usually sufficient for most users.
+
+---@class YaziGetRelativePathImplementationArguments
+---@field source_dir string the starting path, where the relative path is calculated from
+---@field selected_file string the target path which was selected in yazi; where the relative path is calculated to
 
 ---@alias YaziBufdeleteImpl
 ---| "snacks-if-available" # the implementation from https://github.com/folke/snacks.nvim, which maintains the window layout. If not available, falls back to the builtin implementation in `vim.api.nvim_buf_delete()`, which does not maintain the window layout.

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -4,10 +4,9 @@ local plenary_path = require("plenary.path")
 local M = {}
 
 ---@param realpath_application string
----@param current_file_dir string
----@param selected_file string
+---@param args YaziGetRelativePathImplementationArguments
 ---@return string
-function M.relative_path(realpath_application, current_file_dir, selected_file)
+function M.relative_path(realpath_application, args)
   local command = realpath_application
   assert(
     command ~= nil,
@@ -27,7 +26,7 @@ function M.relative_path(realpath_application, current_file_dir, selected_file)
   assert(command ~= nil, "realpath command must be set")
 
   ---@type Path
-  local start_path = plenary_path:new(current_file_dir)
+  local start_path = plenary_path:new(args.source_dir)
   local start_directory = nil
   if start_path:is_dir() then
     start_directory = start_path
@@ -39,7 +38,7 @@ function M.relative_path(realpath_application, current_file_dir, selected_file)
     command,
     "--relative-to",
     start_directory.filename,
-    selected_file,
+    args.selected_file,
   })
   local result = job:wait(1000)
 


### PR DESCRIPTION
It's now possible to customize how
`copy_relative_path_to_selected_files` (default `<c-y>`) works with the `integrations.resolve_relative_path_implementation` option.

The function has the following signature:

```lua
---@field public resolve_relative_path_implementation? fun(args: YaziGetRelativePathImplementationArguments, default_implementation: fun(args: YaziGetRelativePathImplementationArguments): string): string
```

See the documentation in [`documentation/copy-relative-path-to-files.md`](https://github.com/mikavilpas/yazi.nvim/blob/main/documentation/copy-relative-path-to-files.md) for more information and examples.

Closes https://github.com/mikavilpas/yazi.nvim/issues/1116