### PR TITLE
ci: automerge dependabot updates when tests pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,3 +101,21 @@ jobs:
           name: cypress-screenshots
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+
+  automerge:
+    needs: build
+    name: Automerge Dependabot PRs
+    runs-on: ubuntu-latest
+    permissions:
+      # NOTE: no special token needs to be generated if these permissions are
+      # used. However, "Workflow permissions > Allow GitHub Actions to create
+      # and approve pull requests" needs to be enabled under
+      # github.com/user/repo/settings/actions
+      # https://github.com/fastify/github-action-merge-dependabot/issues/359
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3.11.1
+        with:
+          # https://github.com/fastify/github-action-merge-dependabot?tab=readme-ov-file
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ you need to install the dependencies yourself. Also see the discussion in
 ---@type LazySpec
 {
   "mikavilpas/yazi.nvim",
+  version = "*", -- use the latest stable version
   event = "VeryLazy",
   dependencies = {
     { "nvim-lua/plenary.nvim", lazy = true },


### PR DESCRIPTION
Dependabot is used to automatically create pull requests for testing related dependencies. These do not affect the neovim functionality of this plugin in any way, and users should not be concerned about these updates.

This is an internal change done to reduce the maintenance burden of this repository.

It will create more frequent commits to the repository, so users are recommended to set the version manager to only update to the newest releases, and not to the latest commit. I added an example of this to the readme file.

- https://lazy.folke.io/spec/versioning
- https://github.com/echasnovski/mini.deps