### PR TITLE
Revert "ci: bump yazi version for e2e tests from 2025-08-05 to 2025-0…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,17 +41,26 @@ jobs:
             exit 1
           }
 
+      - name: Compile and install `yazi-fm` from source
+        uses: baptiste0928/cargo-install@v3.3.1
+        with:
+          # yazi-fm is the `yazi` executable
+          crate: yazi-fm
+          git: https://github.com/sxyazi/yazi
+          commit:
+            # https://github.com/sxyazi/yazi/commit/d5f225bc4adc22231b6e254431183518747fadb9 (2025-08-05)
+            d5f225bc4adc22231b6e254431183518747fadb9
+          # tag: v25.5.31
+
       - name: Compile and install yazi from source
         uses: baptiste0928/cargo-install@v3.3.1
         with:
-          # Due to Cargo's limitations, the `yazi-fm` and `yazi-cli` crates on
-          # crates.io must be built with `cargo install --force yazi-build`
-          # https://github.com/sxyazi/yazi/blob/2ec3a6c645324295331c0f2ef6d4d946cf11c06b/yazi-fm/build.rs?plain=1#L23-L25
-          crate: yazi-build
+          # yazi-cli is the `ya` command line interface
+          crate: yazi-cli
           git: https://github.com/sxyazi/yazi
           commit:
-            # https://github.com/sxyazi/yazi/commit/2ec3a6c645324295331c0f2ef6d4d946cf11c06b (2025-08-14)
-            2ec3a6c645324295331c0f2ef6d4d946cf11c06b
+            # https://github.com/sxyazi/yazi/commit/d5f225bc4adc22231b6e254431183518747fadb9 (2025-08-05)
+            d5f225bc4adc22231b6e254431183518747fadb9
           # tag: v25.5.31
 
       - name: Make sure yazi and ya are installed


### PR DESCRIPTION
…8-14 (#1137)"

This reverts commit 8c22e5773ff3e96183409b4cabb28be8e21f1bc4.

The build is failing because the new version of yazi needs to be built with a custom build package. The rust caching action does not seem to support this because it expects a one-to-one relationship with the crate being built (yazi-build) and the resulting binary. The build crate produced two binaries (yazi and ya), which breaks this assumption.

While I figure a way around this, I'll try reverting this change to make the build green 🟢 again.