### PR TITLE
ci: bump selene version from 0.26.1 to 0.29.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
             --display-style=quiet ./lua/ ./spec/
             ./integration-tests/test-environment/config-modifications
           # selene version
-          version: 0.26.1
+          version: 0.29.0
 
   markdownlint:
     name: markdownlint


### PR DESCRIPTION
https://github.com/Kampfkarren/selene/releases