### PR TITLE
Updates for tests etc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,7 @@ jobs:
           cache: "pnpm"
       - run: pnpm install
       - working-directory: integration-tests
+        name: Prepare Neovim for integration tests
         run: |
           # NVIM_APPNAME=nvim is the default, but spelled out here for clarity
           NVIM_APPNAME=nvim pnpm tui neovim prepare

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -379,3 +379,4 @@ export const testDirectoryFiles = z.enum([
   ".",
 ])
 export type MyTestDirectoryFile = z.infer<typeof testDirectoryFiles>
+export type MyNeovimAppName = "nvim" | "nvim_integrations"

--- a/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/prepare.lua
@@ -21,4 +21,4 @@ require("mason-registry").refresh()
 -- it seems to install the package anyway
 -- https://github.com/williamboman/mason.nvim/issues/960#issuecomment-1528081759
 local command = require("mason.api.command")
-command.MasonInstall({ "emmylua_ls" }, { version = "0.12.0" })
+command.MasonInstall({ "emmylua_ls" }, { version = "0.13.0" })

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -17,5 +17,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["./cypress", "./eslint.config.mjs"]
+  "include": ["./cypress", "./eslint.config.mjs", "./tui-sandbox.config.ts"]
 }

--- a/integration-tests/tui-sandbox.config.ts
+++ b/integration-tests/tui-sandbox.config.ts
@@ -1,0 +1,8 @@
+import { createDefaultConfig } from "@tui-sandbox/library/dist/src/server/config.js"
+import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/index.js"
+
+export const config: TestServerConfig = createDefaultConfig(
+  process.cwd(),
+  process.env,
+)
+config.integrations.neovim.NVIM_APPNAMEs = ["nvim", "nvim_integrations"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier-plugin-organize-imports": "4.2.0",
     "prettier-plugin-packagejson": "2.5.19"
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
+  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",


### PR DESCRIPTION
# ci: add readable name for neovim preparation step

# chore(test): bump emmylua_ls from 0.12.0 to 0.13.0

# test: define tui-sandbox NVIM_APPNAMEs in its config

# chore: bump pnpm from 10.15.0 to 10.15.1