### PR TITLE
ci: install fd, fzf, and rg with mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,23 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
-      - name: Set up dependencies
-        run: |
-          # ripgrep is a dependency of telescope and fzf-lua
-          #
-          # fd is a dependency of telescope and fzf-lua
-          # https://github.com/sharkdp/fd?tab=readme-ov-file#on-ubuntu
-          # make sure it's available as `fd` - there seems to be some conflict in Ubuntu
-          #
-          # realpath is used to resolve relative paths in yazi.nvim
-          sudo apt-get update
-          sudo apt-get install ripgrep fd-find fzf
-          sudo ln -s $(which fdfind) /usr/local/bin/fd
-
-          fd --version
-          fzf --version
-          rg --version
-          which realpath || { exit 1; }
 
       - name: Compile and install `yazi-fm` from source
         if: matrix.yazi-version.method == 'cargo-install'
@@ -90,6 +73,20 @@ jobs:
       - run: pnpm install
 
       - uses: jdx/mise-action@v3.2.0
+
+      - name: Verify that dependencies are available
+        run: |
+          # ripgrep is a dependency of telescope and fzf-lua
+          #
+          # fd is a dependency of telescope and fzf-lua
+          # https://github.com/sharkdp/fd?tab=readme-ov-file#on-ubuntu
+          # make sure it's available as `fd` - there seems to be some conflict in Ubuntu
+          #
+          # realpath is used to resolve relative paths in yazi.nvim
+          fd --version
+          fzf --version
+          rg --version
+          which realpath || { exit 1; }
 
       - working-directory: integration-tests
         name: Prepare Neovim for integration tests

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,9 @@
+
 [tools]
+# fd is a dependency of telescope and fzf-lua
+fd = "10.3.0"
+fzf = "0.65.2"
 "github:EmmyLuaLs/emmylua-analyzer-rust" = "0.13.0"
 lua = "5.1"
+# ripgrep is a dependency of telescope and fzf-lua
+rg = "14.1.1"


### PR DESCRIPTION
# ci: install fd, fzf, and rg with mise

Like the previous commit, this is done

- for speed
- allow developers to use mise to install dependencies for development
  and tests