### PR TITLE
refactor!: disable custom shell escaping as unneeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,15 +366,6 @@ return {
       -- - nil (default, no action added)
       -- - "snacks.picker" (snacks.nvim)
       picker_add_copy_relative_path_action = nil,
-
-      -- Only used when `future_features.new_shell_escaping` is off. A function
-      -- that will be used to escape paths before passing them to external
-      -- commands. Defaults to `vim.fn.shellescape`. Depending on your OS +
-      -- shell + neovim settings, you might need to customize this for
-      -- yazi.nvim to work correctly with paths that contain special
-      -- characters. Defaults to `vim.fn.shellescape`, which is usually
-      -- sufficient for most users.
-      escape_path_implementation = vim.fn.shellescape,
     },
 
     future_features = {

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -16,7 +16,6 @@ function M.default()
     open_for_directories = false,
     future_features = {
       use_cwd_file = true,
-      new_shell_escaping = true,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,
@@ -49,7 +48,6 @@ function M.default()
       hovered_buffer_in_same_directory = nil,
     },
     integrations = {
-      escape_path_implementation = vim.fn.shellescape,
       grep_in_directory = "telescope",
       grep_in_selected_files = "telescope",
       replace_in_directory = function(directory)

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -67,26 +67,13 @@ end
 ---@param paths Path[]
 function YaProcess:get_yazi_command(paths)
   local command_words = { "yazi" }
-  local new_shell_escaping = self.config.future_features.new_shell_escaping
 
   if self.config.open_multiple_tabs == true then
     for _, path in ipairs(paths) do
-      if new_shell_escaping then
-        table.insert(command_words, path.filename)
-      else
-        local escaped_path =
-          self.config.integrations.escape_path_implementation(path.filename)
-        table.insert(command_words, escaped_path)
-      end
+      table.insert(command_words, path.filename)
     end
   else
-    if new_shell_escaping then
-      table.insert(command_words, paths[1].filename)
-    else
-      local path =
-        self.config.integrations.escape_path_implementation(paths[1].filename)
-      table.insert(command_words, path)
-    end
+    table.insert(command_words, paths[1].filename)
   end
 
   table.insert(command_words, "--chooser-file")
@@ -104,11 +91,7 @@ function YaProcess:get_yazi_command(paths)
 
   command_words = remove_duplicates(command_words)
 
-  if new_shell_escaping then
-    return command_words
-  else
-    return table.concat(command_words, " ")
-  end
+  return command_words
 end
 
 ---@param timeout integer

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -30,7 +30,6 @@
 
 ---@class(exact) yazi.OptInFeatures
 ---@field public use_cwd_file? boolean # use a file to store the last directory that yazi was in before it was closed. Defaults to `true`.
----@field public new_shell_escaping? boolean # use a new shell escaping implementation that is more robust and works on more platforms. Defaults to `true`. If set to `false`, the old shell escaping implementation will be used, which is less robust and may not work on all platforms.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 
@@ -69,7 +68,6 @@
 ---@field public bufdelete_implementation? YaziBufdeleteImpl # how to delete (close) a buffer. Defaults to `snacks.bufdelete` from https://github.com/folke/snacks.nvim, which maintains the window layout.
 ---@field public picker_add_copy_relative_path_action? "snacks.picker" # add an action to a file picker to copy the relative path to the selected file(s). The implementation is the same as for the `copy_relative_path_to_selected_files` yazi.nvim keymap. Currently only snacks.nvim is supported. Documentation can be found in the keybindings section of the readme. The default is `nil`, which means no action is added.
 ---@field public pick_window_implementation? "snacks.picker" # the implementation to use for picking a window. The default is `snacks.picker`, which uses the snacks.nvim picker's "pick_win" action.
----@field public escape_path_implementation? fun(path: string): string # a function that will be used to escape paths before passing them to external commands. Defaults to `vim.fn.shellescape`. Depending on your OS + shell + neovim settings, you might need to customize this for yazi.nvim to work correctly with paths that contain special characters. Defaults to `vim.fn.shellescape`, which is usually sufficient for most users.
 
 ---@class YaziGetRelativePathImplementationArguments
 ---@field source_dir string the starting path, where the relative path is calculated from

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -10,7 +10,6 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
-    config.future_features.new_shell_escaping = false
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -21,10 +20,17 @@ describe("the get_yazi_command() function", function()
 
     local command = ya:get_yazi_command(paths)
 
-    assert.are.same(
-      "yazi 'file1' 'file2' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
-      command
-    )
+    assert.are.same({
+      "yazi",
+      "file1",
+      "file2",
+      "--chooser-file",
+      "/tmp/chosen_file_path",
+      "--client-id",
+      "yazi_id_123",
+      "--cwd-file",
+      "/tmp/cwd_file_path",
+    }, command)
   end)
 
   it(
@@ -34,7 +40,6 @@ describe("the get_yazi_command() function", function()
       config.open_multiple_tabs = false
       config.chosen_file_path = "/tmp/chosen_file_path"
       config.cwd_file_path = "/tmp/cwd_file_path"
-      config.future_features.new_shell_escaping = false
 
       local ya = ya_process.new(config, yazi_id)
 
@@ -45,10 +50,16 @@ describe("the get_yazi_command() function", function()
 
       local command = ya:get_yazi_command(paths)
 
-      assert.are.same(
-        "yazi 'file1' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
-        command
-      )
+      assert.are.same({
+        "yazi",
+        "file1",
+        "--chooser-file",
+        "/tmp/chosen_file_path",
+        "--client-id",
+        "yazi_id_123",
+        "--cwd-file",
+        "/tmp/cwd_file_path",
+      }, command)
     end
   )
 
@@ -57,7 +68,6 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
-    config.future_features.new_shell_escaping = false
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -73,10 +83,18 @@ describe("the get_yazi_command() function", function()
 
     local command = ya:get_yazi_command(paths)
 
-    assert.are.same(
-      "yazi 'file1' 'file2' 'file3' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
-      command
-    )
+    assert.are.same({
+      "yazi",
+      "file1",
+      "file2",
+      "file3",
+      "--chooser-file",
+      "/tmp/chosen_file_path",
+      "--client-id",
+      "yazi_id_123",
+      "--cwd-file",
+      "/tmp/cwd_file_path",
+    }, command)
   end)
 
   it("returns a table if new_shell_escaping is used", function()
@@ -87,7 +105,6 @@ describe("the get_yazi_command() function", function()
     config.open_multiple_tabs = true
     config.chosen_file_path = "/tmp/chosen_file_path"
     config.cwd_file_path = "/tmp/cwd_file_path"
-    assert(config.future_features.new_shell_escaping)
 
     local ya = ya_process.new(config, yazi_id)
 
@@ -100,46 +117,6 @@ describe("the get_yazi_command() function", function()
       "yazi file1 --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
       table.concat(command, " ")
     )
-  end)
-
-  describe("escape_path_implementation", function()
-    it("can handle paths with spaces", function()
-      local config = require("yazi.config").default()
-      config.chosen_file_path = "/tmp/chosen_file_path"
-      config.cwd_file_path = "/tmp/cwd_file_path"
-      config.future_features.new_shell_escaping = false
-
-      local ya = ya_process.new(config, yazi_id)
-
-      local command = ya:get_yazi_command({ { filename = "file 1" } })
-
-      assert.are.same(
-        "yazi 'file 1' --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
-        command
-      )
-    end)
-
-    it("allows customizing the way shellescape is done", function()
-      local config = require("yazi.config").default()
-      config.chosen_file_path = "/tmp/chosen_file_path"
-      config.cwd_file_path = "/tmp/cwd_file_path"
-      config.future_features.new_shell_escaping = false
-
-      config.integrations.escape_path_implementation = function(path)
-        -- replace / with \
-        local result = path:gsub("/", "\\")
-        return result
-      end
-
-      local ya = ya_process.new(config, yazi_id)
-
-      local command = ya:get_yazi_command({ { filename = "file/1" } })
-
-      assert.are.same(
-        "yazi file\\1 --chooser-file /tmp/chosen_file_path --client-id yazi_id_123 --cwd-file /tmp/cwd_file_path",
-        command
-      )
-    end)
   end)
 end)
 


### PR DESCRIPTION
BREAKING CHANGE: removed `integrations.escape_path_implementation` (function) and `future_features.new_shell_escaping` (boolean).

The custom shell escaping implementation is no longer needed, as we found a better way to handle starting yazi in
https://github.com/mikavilpas/yazi.nvim/issues/1101 that should avoid all kinds of shell related issues on all platforms.

It has been automatically enabled by default for almost two months without any issues.

Nobody seems to be using this feature, and we haven't had any bug reports about it since it was merged in
https://github.com/mikavilpas/yazi.nvim/pull/1102

I left the old implementation in as a precaution for users to optionally toggle it back on, but I think it's safe to remove it completely.