### PR TITLE
refactor!: custom events need to use kebab-case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - name: nightly
             method: cargo-install
             # renovate: datasource=git-refs packageName=https://github.com/sxyazi/yazi
-            commit: 3c42195bacdd73fc1d8e84cc4190c24016b89bf6
+            commit: 30c02795703ee47eb6b500b464f1d7de8756eb75
           - name: stable
             method: download
             # renovate: datasource=github-releases depName=sxyazi/yazi

--- a/documentation/yazi-keymappings.md
+++ b/documentation/yazi-keymappings.md
@@ -30,7 +30,7 @@ Define the key you want to use in yazi's keymap.toml config:
 # send an event with no data
 [[mgr.prepend_keymap]]
 on = "<C-p>"
-run = """shell 'ya pub-to 0 MyMessageNoData'"""
+run = """shell 'ya pub-to 0 my-message-no-data'"""
 
 # send an event that also has json data.
 # yazi allows using shell variables like $0, see the documentation here
@@ -39,7 +39,7 @@ run = """shell 'ya pub-to 0 MyMessageNoData'"""
 on = "<C-h>"
 run = """shell --
 json=$(printf '{"selected_file": "%s"}' "$0")
-ya pub-to 0 MyChangeWorkingDirectoryCommand --json "$json"
+ya pub-to 0 my-change-working-directory-command --json "$json"
 """
 ```
 
@@ -52,7 +52,7 @@ Add the following code to your configuration:
 ---@module "yazi"
 
 require("yazi").config.forwarded_dds_events =
-  { "MyMessageNoData", "MyChangeWorkingDirectoryCommand" }
+  { "my-message-no-data", "my-change-working-directory-command" }
 
 vim.api.nvim_create_autocmd("User", {
   pattern = "YaziDDSCustom",
@@ -68,7 +68,7 @@ vim.api.nvim_create_autocmd("User", {
       event.data,
     }))
 
-    if event.data.type == "MyChangeWorkingDirectoryCommand" then
+    if event.data.type == "my-change-working-directory-command" then
       local json = vim.json.decode(event.data.raw_data)
       local selected_file = assert(json.selected_file)
 

--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -424,21 +424,21 @@ describe("'rename' events", () => {
         assertYaziIsReady(nvim)
         cy.contains(nvim.dir.contents["file2.txt"].name)
 
-        // publish the custom MyMessageNoData event that we subscribed to in
+        // publish the custom my-message-no-data event that we subscribed to in
         // notify_custom_events.lua
         cy.typeIntoTerminal("{control+p}")
 
-        // also publish MyChangeWorkingDirectoryCommand that contains json data
+        // also publish my-change-working-directory-command that contains json data
         cy.typeIntoTerminal("{control+h}")
 
         cy.typeIntoTerminal("q")
         cy.contains(nvim.dir.contents["file2.txt"].name).should("not.exist")
         nvim.runExCommand({ command: "messages" }).should((result) => {
           expect(result.value).to.match(
-            /Just received a YaziDDSCustom event 'MyMessageNoData'!/,
+            /Just received a YaziDDSCustom event 'my-message-no-data'!/,
           )
           expect(result.value).to.match(
-            /Just received a YaziDDSCustom event 'MyChangeWorkingDirectoryCommand'!/,
+            /Just received a YaziDDSCustom event 'my-change-working-directory-command'!/,
           )
           expect(result.value).to.match(/selected_file/)
         })

--- a/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-keymappings.cy.ts
@@ -13,7 +13,7 @@ describe("revealing another open split (buffer) in yazi", () => {
     cy.visit("/")
   })
 
-  it(`can react to the "NvimCycleBuffer" event`, () => {
+  it(`can react to the "nvim-cycle-buffer" event`, () => {
     // This event signifies yazi.nvim should cycle_open_buffers, which makes
     // yazi focus the next visible neovim split as the current file.
     //
@@ -77,7 +77,7 @@ describe("revealing another open split (buffer) in yazi", () => {
     })
   })
 
-  it(`"NvimCycleBuffer" works for only one split`, () => {
+  it(`"nvim-cycle-buffer" works for only one split`, () => {
     cy.startNeovim({
       filename: "initial-file.txt",
       startupScriptModifications: [

--- a/integration-tests/test-environment/.config/yazi/keymap.toml
+++ b/integration-tests/test-environment/.config/yazi/keymap.toml
@@ -6,7 +6,7 @@
 # send an event with no data
 [[mgr.prepend_keymap]]
 on = "<C-p>"
-run = """shell 'ya pub-to 0 MyMessageNoData'"""
+run = """shell 'ya pub-to 0 my-message-no-data'"""
 
 # NOTE: this is also documented in yazi-keymappings.md as a user facing example
 # send an event that also has json data
@@ -14,7 +14,7 @@ run = """shell 'ya pub-to 0 MyMessageNoData'"""
 on = "<C-h>"
 run = """shell --
 json=$(printf '{"selected_file": "%s"}' "$0")
-ya pub-to 0 MyChangeWorkingDirectoryCommand --json "$json"
+ya pub-to 0 my-change-working-directory-command --json "$json"
 """
 
 [[mgr.prepend_keymap]]
@@ -23,4 +23,4 @@ run = """quit"""
 
 [[mgr.prepend_keymap]]
 on = "I"
-run = """shell "ya pub-to 0 NvimCycleBuffer""""
+run = """shell "ya pub-to 0 nvim-cycle-buffer""""

--- a/integration-tests/test-environment/config-modifications/notify_custom_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_custom_events.lua
@@ -4,8 +4,11 @@ do
   local config = require("yazi").config
   assert(config, "yazi.config is not set")
 
-  table.insert(config.forwarded_dds_events, "MyMessageNoData")
-  table.insert(config.forwarded_dds_events, "MyChangeWorkingDirectoryCommand")
+  table.insert(config.forwarded_dds_events, "my-message-no-data")
+  table.insert(
+    config.forwarded_dds_events,
+    "my-change-working-directory-command"
+  )
 end
 
 -- selene: allow(global_usage)
@@ -27,7 +30,7 @@ vim.api.nvim_create_autocmd("User", {
       event.data,
     }))
 
-    if event.data.type == "MyChangeWorkingDirectoryCommand" then
+    if event.data.type == "my-change-working-directory-command" then
       local json = vim.json.decode(event.data.raw_data)
       local selected_file = assert(json.selected_file)
 

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -84,7 +84,7 @@ function M.default()
     floating_window_scaling_factor = 0.9,
     yazi_floating_window_winblend = 0,
     yazi_floating_window_border = border,
-    forwarded_dds_events = { "NvimCycleBuffer" },
+    forwarded_dds_events = { "nvim-cycle-buffer" },
   }
 end
 

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -214,7 +214,7 @@ function M.parse_events(event_lines)
     local yazi_id = parts[3]
 
     -- selene: allow(if_same_then_else)
-    if type == "NvimCycleBuffer" then
+    if type == "nvim-cycle-buffer" then
       ---@type YaziNvimCycleBufferEvent
       local event = {
         type = "cycle-buffer",
@@ -319,7 +319,7 @@ function M.parse_events(event_lines)
       end
     elseif type == "hey" then
       -- example of a hey event:
-      -- hey,0,69016966727041,{"peers":{"1745849494365272":{"abilities":["hey"]},"69016966727041":{"abilities":["dds-emit","@yank","extract"]},"1745849492676175":{"abilities":["hover","move","hey","bulk","cd","delete","rename","trash","NvimCycleBuffer"]}},"version":"25.4.8 VERGEN_IDEMPOTENT_OUTPUT"}
+      -- hey,0,69016966727041,{"peers":{"1745849494365272":{"abilities":["hey"]},"69016966727041":{"abilities":["dds-emit","@yank","extract"]},"1745849492676175":{"abilities":["hover","move","hey","bulk","cd","delete","rename","trash","nvim-cycle-buffer"]}},"version":"25.4.8 VERGEN_IDEMPOTENT_OUTPUT"}
       ---@type YaziHeyEvent
       local event = {
         yazi_id = yazi_id,
@@ -330,7 +330,7 @@ function M.parse_events(event_lines)
       require("yazi.log"):debug(string.format("Unknown event type: %s", type))
       -- Custom user event.
       -- It could look like this (with optional data at the end)
-      -- MyMessageNoData,0,1731774290298033,
+      -- my-message-no-data,0,1731774290298033,
       local data_string = table.concat(parts, ",", 4, #parts)
 
       ---@type YaziCustomDDSEvent


### PR DESCRIPTION
# refactor!: custom events need to use kebab-case

**Issue:**

The following issue has started happening on nightly Yazi 25.9.15
(30c02795 2025-09-20):

```sh
$ ya pub-to 0 NvimCycleBuffer
Cannot send message: Kind `NvimCycleBuffer` must be in kebab-case
```

This breaks the e2e tests because they are sending custom `ya` events in
PascalCase. Stable yazi is not affected.

**Solution:**

It looks like nobody but myself is using this feature, so make a
breaking change and require switching to use kebab-case.

Users using the `NvimCycleBuffer` event in their yazi `keymap.toml` need
to change their yazi config accordingly:

In `/Users/mikavilpas/dotfiles/.config/yazi/keymap.toml`:

```diff
[[mgr.prepend_keymap]]
on = "<tab>"
-run = """shell "ya pub-to 0 NvimCycleBuffer""""
+run = """shell "ya pub-to 0 nvim-cycle-buffer""""
```

---

chore(deps): update https://github.com/sxyazi/yazi digest to 30c0279

Co-authored-by: renovate[bot]
<29139614+renovate[bot]@users.noreply.github.com>