### PR TITLE
fix: split commands no longer break while bulk renaming

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -230,7 +230,7 @@ function M.setup(opts)
   end
 
   vim.api.nvim_create_autocmd("VimEnter", {
-    pattern = "/tmp/yazi-*",
+    pattern = "*/yazi-*/bulk-*",
     callback = function()
       if vim.env.NVIM == nil then
         return


### PR DESCRIPTION
This uses RPC to communicate with the parent process and autocommands to set and unset keymaps when the child process is opened and closed.

Fixes #739