### PR TITLE
ci: remove mise warning about idiomatic_version_file_enable_tools

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,4 @@
+settings.idiomatic_version_file_enable_tools = []
 
 [tools]
 # fd is a dependency of telescope and fzf-lua


### PR DESCRIPTION
> mise WARN deprecated [idiomatic_version_file_enable_tools]:
>
> Idiomatic version files like ~/work/yazi.nvim/yazi.nvim/.nvmrc are
> currently enabled by default. However, this will change in mise
> 2025.10.0 to instead default to disabled.
>
> You can remove this warning by explicitly enabling idiomatic version
> files for node with:
>
>     mise settings add idiomatic_version_file_enable_tools node
>
> You can disable idiomatic version files with:
>
>     mise settings add idiomatic_version_file_enable_tools "[]"
>
> See https://github.com/jdx/mise/discussions/4345 for more information.