### PR TITLE
ci: install tools with ubi instead of mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,34 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Install tools with UBI
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          # make the tools available for subsequent steps
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
+          curl --silent --location \
+              https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
+              TARGET="$HOME/.local/bin" sh
+
+          ubi --project mikefarah/yq
+          ubi --project jdx/mise
+
+          VERSION=$(yq '.tools."ubi:EmmyLuaLs/emmylua-analyzer-rust".version' .mise.toml)
+          ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "0.14.0" --exe emmylua_ls --matching-regex "^emmylua_ls"
+
+          VERSION=$(yq '.tools."ubi:BurntSushi/ripgrep".version' .mise.toml)
+          ubi --project BurntSushi/ripgrep --tag "$VERSION" --exe rg
+
+          VERSION=$(yq '.tools."ubi:junegunn/fzf"' .mise.toml)
+          ubi --project junegunn/fzf --tag "v$VERSION"
+
+          VERSION=$(yq '.tools."ubi:sharkdp/fd"' .mise.toml)
+          ubi --project sharkdp/fd --tag "v$VERSION"
+          ls -alR bin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compile and install `yazi-fm` from source
         if: matrix.yazi-version.method == 'cargo-install'
         uses: baptiste0928/cargo-install@b687c656bda5733207e629b50a22bf68974a0305 # v3.3.2
@@ -71,8 +99,6 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
-
-      - uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
 
       - name: Run tests
         uses: nvim-neorocks/nvim-busted-action@d30f6d4d794c0e77b6edb530872205f98ae969c4 # v1.1.1

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -1,2 +1,0 @@
-# installing lua seems slow in CI (requires building from source), so disable it 
-settings.disable_tools = ["lua"]


### PR DESCRIPTION
Mise has had some challenges with github rate limits. I contacted github support and they said the builds have been making up to 70k requests per hour.

Try to avoid these issues by using the simpler ubi tool to install the required tools. Mise also uses it internally, so the change should not be that large.