### PR TITLE
chore: renovate keeps neovim plugins up to date

### DIFF
--- a/integration-tests/test-environment/.config/nvim/lua/plugins.lua
+++ b/integration-tests/test-environment/.config/nvim/lua/plugins.lua
@@ -17,7 +17,13 @@ local plugins = {
     ---@type YaziConfig
     opts = {},
   },
-  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    priority = 1000,
+    -- renovate: datasource=github-releases depName=catppuccin/nvim
+    version = "v1.11.0",
+  },
 }
 
 return plugins

--- a/integration-tests/test-environment/.config/nvim_integrations/init.lua
+++ b/integration-tests/test-environment/.config/nvim_integrations/init.lua
@@ -67,6 +67,8 @@ vim.list_extend(plugins, {
 
   {
     "nvim-telescope/telescope.nvim",
+    -- renovate: datasource=git-refs packageName=nvim-telescope/telescope.nvim
+    commit = "b4da76b",
     lazy = true,
     opts = {
       pickers = {
@@ -76,11 +78,22 @@ vim.list_extend(plugins, {
       },
     },
   },
-  { "ibhagwan/fzf-lua" },
-  { "https://github.com/MagicDuck/grug-far.nvim", opts = {} },
+  {
+    "ibhagwan/fzf-lua",
+    -- renovate: datasource=git-refs depName=ibhagwan/fzf-lua
+    commit = "a8458b7",
+  },
+  {
+    "https://github.com/MagicDuck/grug-far.nvim",
+    -- renovate: datasource=git-refs depName=MagicDuck/grug-far.nvim
+    commit = "3e72397",
+    opts = {},
+  },
 
   {
     "folke/snacks.nvim",
+    -- renovate: datasource=github-releases depName=folke/snacks.nvim
+    version = "v2.28.0",
     priority = 1000,
     lazy = false,
     ---@module "snacks"
@@ -110,6 +123,8 @@ vim.list_extend(plugins, {
   {
     -- https://github.com/mason-org/mason-lspconfig.nvim?tab=readme-ov-file#recommended-setup-for-lazynvim
     "mason-org/mason-lspconfig.nvim",
+    -- renovate: datasource=github-releases depName=mason-org/mason-lspconfig.nvim
+    version = "v2.1.0",
     opts = {},
     config = function()
       ---@diagnostic disable-next-line: missing-fields
@@ -133,11 +148,20 @@ vim.list_extend(plugins, {
       vim.lsp.enable("emmylua_ls")
     end,
     dependencies = {
-      { "mason-org/mason.nvim", opts = {} },
-      "neovim/nvim-lspconfig",
+      {
+        "https://github.com/mason-org/mason.nvim",
+        opts = {},
+        -- renovate: datasource=github-releases depName=mason-org/mason.nvim
+        version = "v2.1.0",
+      },
+      {
+        "neovim/nvim-lspconfig",
+        -- renovate: datasource=github-releases depName=neovim/nvim-lspconfig
+        version = "v2.5.0",
+      },
     },
   },
-})
+} --[[@as LazySpec[][]])
 
 require("lazy").setup({ spec = plugins })
 

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,14 @@
       "customType": "regex",
       "datasourceTemplate": "git-refs",
       "currentValueTemplate": "main",
-      "managerFilePatterns": [".github/workflows/test.yml"],
+      "managerFilePatterns": [
+        ".github/workflows/test.yml",
+        "integration-tests/test-environment/.config/nvim/init.lua",
+        "integration-tests/test-environment/.config/nvim_integrations/init.lua"
+      ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=git-refs\\s+packageName=(?<packageName>\\S+)\\s*[\\r\\n]+[^:]+:\\s*(?<currentDigest>\\S+)"
+        "#\\s*renovate:\\s*datasource=git-refs\\s+packageName=(?<packageName>\\S+)\\s*[\\r\\n]+[^:]+:\\s*(?<currentDigest>\\S+)",
+        "-- renovate: datasource=git-refs packageName=(?<packageName>[^\\s]+).*?commit = \"?(?<currentValue>[^\",]+)\"?"
       ]
     },
     {
@@ -40,7 +45,7 @@
         "integration-tests/test-environment/.config/nvim_integrations/init.lua"
       ],
       "matchStrings": [
-        "--\\s*renovate:\\s*datasource=github-releases\\s+depName=(?<depName>\\S+)\\s*[\\r\\n]+[^=]+=\\s*\"?(?<currentValue>[^\",]+)\"?"
+        "-- renovate: datasource=github-releases depName=(?<depName>[^\\s]+)[\\s\\S]*?version\\s*=\\s*\"?(?<currentValue>[^\",]+)\"?"
       ]
     }
   ]


### PR DESCRIPTION
Also lock down the plugin versions to specific releases to make the build more reproducible.