### PR TITLE
chore: fix renovate git-refs datasource commit matching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=git-refs\\s+packageName=(?<packageName>\\S+)\\s*[\\r\\n]+[^:]+:\\s*(?<currentDigest>\\S+)",
-        "-- renovate: datasource=git-refs packageName=(?<packageName>[^\\s]+)\\s*?commit = \"?(?<currentValue>[^\",]+)\"?"
+        "-- renovate: datasource=git-refs packageName=(?<packageName>[^\\s]+)\\s*?commit = \"?(?<currentDigest>[^\",]+)\"?"
       ]
     },
     {
@@ -51,7 +51,7 @@
         "integration-tests/test-environment/.config/**/*.lua"
       ],
       "matchStrings": [
-        "-- renovate: datasource=git-refs-master packageName=(?<packageName>[^\\s]+)\\s*?commit = \"(?<currentValue>.+?)\""
+        "-- renovate: datasource=git-refs-master packageName=(?<packageName>[^\\s]+)\\s*?commit = \"(?<currentDigest>.+?)\""
       ]
     },
     {


### PR DESCRIPTION
> To fetch the latest digest of a reference instead of the named
> reference: put the named reference in currentValue and match on the
> currentDigest.
>
> https://docs.renovatebot.com/modules/datasource/git-refs/#:~:text=To%20fetch%20the%20latest%20digest%20of%20a%20reference%20instead%20of%20the%20named%20reference%3A%20put%20the%20named%20reference%20in%20currentValue%20and%20match%20on%20the%20currentDigest.