### PR TITLE
ci: use the development version of EmmyLua in CI too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           ubi --project jdx/mise
 
           VERSION=$(yq '.tools."ubi:EmmyLuaLs/emmylua-analyzer-rust".version' .mise.toml)
-          ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "0.14.0" --exe emmylua_ls --matching-regex "^emmylua_ls"
+          ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 
           VERSION=$(yq '.tools."ubi:BurntSushi/ripgrep".version' .mise.toml)
           ubi --project BurntSushi/ripgrep --tag "$VERSION" --exe rg


### PR DESCRIPTION
# ci: use the development version of EmmyLua in CI too

Looks like I had left this locked on to version 0.14.0 when developing
the ci workflows.

Always use the version specified in mise.toml instead to ensure the
development environment is tested in ci.