### PR TITLE
feat: allow setting more window properties with a hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ return {
 
       -- This function is called when yazi is ready to process events.
       on_yazi_ready = function(buffer, config, process_api) end,
+
+      before_opening_window = function(window_options) end,
     },
 
     -- highlight buffers in the same directory as the hovered buffer

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -155,6 +155,10 @@ export const MyTestDirectorySchema = z.object({
               name: z.literal("add_keybinding_to_start_yazi_and_find.lua"),
               type: z.literal("file"),
             }),
+            "customize_window_properties.lua": z.object({
+              name: z.literal("customize_window_properties.lua"),
+              type: z.literal("file"),
+            }),
             "disable_a_keybinding.lua": z.object({
               name: z.literal("disable_a_keybinding.lua"),
               type: z.literal("file"),
@@ -362,6 +366,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/use_light_neovim_colorscheme.lua",
   "config-modifications/yazi_config/add_hovered_buffer_background.lua",
   "config-modifications/yazi_config/add_keybinding_to_start_yazi_and_find.lua",
+  "config-modifications/yazi_config/customize_window_properties.lua",
   "config-modifications/yazi_config/disable_a_keybinding.lua",
   "config-modifications/yazi_config/enable_change_neovim_cwd_on_close.lua",
   "config-modifications/yazi_config/highlight_buffers_in_same_directory.lua",

--- a/integration-tests/test-environment/config-modifications/yazi_config/customize_window_properties.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/customize_window_properties.lua
@@ -1,0 +1,11 @@
+require("yazi").setup({
+  ---@diagnostic disable-next-line: missing-fields
+  hooks = {
+    before_opening_window = function(options)
+      options.col = vim.o.columns
+      options.row = vim.o.lines
+      options.height = math.floor(vim.o.lines / 2)
+      options.width = math.floor(vim.o.columns * 0.8)
+    end,
+  },
+})

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -57,6 +57,7 @@
 ---@field public on_yazi_ready fun(buffer: integer, config: YaziConfig, process_api: YaziProcessApi):nil
 ---@field public yazi_closed_successfully fun(chosen_file: string | nil, config: YaziConfig, state: YaziClosedState): nil
 ---@field public yazi_opened_multiple_files fun(chosen_files: string[], config: YaziConfig, state: YaziClosedState): nil
+---@field public before_opening_window? fun(window_options: vim.api.keyset.win_config): nil
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
 ---@field public grep_in_directory? "telescope" | "fzf-lua" | "snacks.picker" | fun(directory: string): nil # implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -106,6 +106,10 @@ function YaziFloatingWindow:open_and_display()
     zindex = self.config.yazi_floating_window_zindex,
   }
 
+  if self.config.hooks.before_opening_window ~= nil then
+    self.config.hooks.before_opening_window(opts)
+  end
+
   local yazi_buffer = vim.api.nvim_create_buf(false, true)
   -- create file window, enter the window, and use the options defined in opts
   local win = vim.api.nvim_open_win(yazi_buffer, true, opts)


### PR DESCRIPTION
Thanks to @and-rs for the idea!

This allows setting various options for the floating window, such as the `row` and `col` where the window should be positioned on the screen.

Note that not everything can be set, currently the window still has to be a floating window.

Supersedes https://github.com/mikavilpas/yazi.nvim/pull/1406