### PR TITLE
ci: make sure yazi stable installation has access to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
         if: matrix.yazi-version.method == 'download'
         run: |
           ubi --project sxyazi/yazi --tag "${{ matrix.yazi-version.version }}" --extract-all
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make sure yazi and ya are installed
         run: |


### PR DESCRIPTION
This seems to have failed
https://github.com/mikavilpas/yazi.nvim/actions/runs/19988809363/job/57326552534?pr=1440