### PR TITLE
test: adapt to :messages staying open on nightly neovim

### DIFF
--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -445,15 +445,6 @@ describe("'rename' events", () => {
 
         cy.typeIntoTerminal("q")
         cy.contains(nvim.dir.contents["file2.txt"].name).should("not.exist")
-        nvim.runExCommand({ command: "messages" }).should((result) => {
-          expect(result.value).to.match(
-            /Just received a YaziDDSCustom event 'my-message-no-data'!/,
-          )
-          expect(result.value).to.match(
-            /Just received a YaziDDSCustom event 'my-change-working-directory-command'!/,
-          )
-          expect(result.value).to.match(/selected_file/)
-        })
 
         nvim
           .runLuaCode({ luaCode: `return _G.YaziTestDDSCustomEvents` })

--- a/integration-tests/test-environment/config-modifications/notify_custom_events.lua
+++ b/integration-tests/test-environment/config-modifications/notify_custom_events.lua
@@ -21,14 +21,6 @@ vim.api.nvim_create_autocmd("User", {
   callback = function(event)
     -- selene: allow(global_usage)
     table.insert(_G.YaziTestDDSCustomEvents, event)
-    -- printing the messages will allow seeing them with `:messages` in tests
-    print(vim.inspect({
-      string.format(
-        "Just received a YaziDDSCustom event '%s'!",
-        event.data.type
-      ),
-      event.data,
-    }))
 
     if event.data.type == "my-change-working-directory-command" then
       local json = vim.json.decode(event.data.raw_data)


### PR DESCRIPTION
**Issue:**

Neovim nightly blocks when `print()` messages are visible for some reason. This makes a test fail, blocking updates and continuous test runs that make sure the plugin always works with the latest versions of everything.

**Solution:**

Printing the messages can be avoided as it's not checked in the test. We already have a global variable that stores the events, so we can just read that instead, avoiding the issue.