### PR TITLE
ci: avoid GITHUB_TOKEN issues with mise lua installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,11 +111,6 @@ jobs:
         with:
           nvim_version: ${{ matrix.neovim_version }}
           luarocks_version: "3.11.1"
-          before: |
-            # copied from .mise.toml
-            luarocks init --no-gitignore
-            luarocks install busted 2.2.0-1
-            luarocks install nlua 0.3.2-1
 
       - name: Verify that dependencies are available
         run: |


### PR DESCRIPTION
**Issue:**

I suspect that mise installing lua is causing issues with the GITHUB_TOKEN rate limits. It may not be using the token correctly, leading to the build getting rate limited.

Example:
https://github.com/mikavilpas/yazi.nvim/actions/runs/19967417993/job/57262837513

**Solution:**

Lua does not have to be installed through mise if we copy the build commands that install lua dependencies and just run them directly in the build. Hopefully this will avoid the issues.