### PR TITLE
refactor(lint): eslint ignores oxlint rules based on its config

### DIFF
--- a/integration-tests/eslint.config.mjs
+++ b/integration-tests/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslintConfigPrettier from "eslint-config-prettier"
 import noOnlyTests from "eslint-plugin-no-only-tests"
+import oxlint from "eslint-plugin-oxlint"
 
 import eslint from "@eslint/js"
 import tseslint from "typescript-eslint"
@@ -89,6 +90,7 @@ export default tseslint.config(
     },
   },
 
+  ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),
   // should be the last item
   eslintConfigPrettier,
 )


### PR DESCRIPTION
# refactor(lint): eslint ignores oxlint rules based on its config

https://www.npmjs.com/package/eslint-plugin-oxlint#detect-rules-from-oxlintrcjson

> If you are using flat configuration (eslint >= 9.0), you can use the
> following config:
>
> ```ts
> // eslint.config.js
> import oxlint from 'eslint-plugin-oxlint';
> export default [
>   ..., // other plugins
>   ...oxlint.buildFromOxlintConfigFile('./.oxlintrc.json'),
> ];
> ```