### PR TITLE
ci: use rumdl for markdown linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,9 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-24.04
     steps:
-      - uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
+      # https://github.com/rvben/rumdl?tab=readme-ov-file#github-actions
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: rvben/rumdl@f7bf9e39201877cc83cb83160cacaa95829c521d # v0
 
   actionlint:
     runs-on: ubuntu-24.04

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,63 @@
+# rumdl configuration file
+
+# Global configuration options
+[global]
+# List of rules to disable (uncomment and modify as needed)
+disable = ["MD013", "MD028"]
+
+# List of rules to enable exclusively (if provided, only these rules will run)
+# enable = ["MD001", "MD003", "MD004"]
+
+# List of file/directory patterns to include for linting (if provided, only these will be linted)
+# include = [
+#    "docs/*.md",
+#    "src/**/*.md",
+#    "README.md"
+# ]
+
+# List of file/directory patterns to exclude from linting
+exclude = [
+  # Common directories to exclude
+  ".git",
+  ".github",
+  "node_modules",
+  "vendor",
+  "dist",
+  "build",
+
+  # Specific files or patterns
+  "CHANGELOG.md",
+  "LICENSE.md",
+]
+
+# Respect .gitignore files when scanning directories (default: true)
+respect-gitignore = true
+
+# Markdown flavor/dialect (uncomment to enable)
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, quarto
+# flavor = "mkdocs"
+
+[per-file-ignores]
+"README.md" = ["MD033"]
+
+# Rule-specific configurations (uncomment and modify as needed)
+
+
+# [MD003]
+# style = "atx"  # Heading style (atx, atx_closed, setext)
+
+# [MD004]
+# style = "asterisk"  # Unordered list style (asterisk, plus, dash, consistent)
+
+# [MD007]
+# indent = 4  # Unordered list indentation
+
+# [MD013]
+# line-length = 100  # Line length
+# code-blocks = false  # Exclude code blocks from line length check
+# tables = false  # Exclude tables from line length check
+# headings = true  # Include headings in line length check
+
+# [MD044]
+# names = ["rumdl", "Markdown", "GitHub"]  # Proper names that should be capitalized correctly
+# code-blocks = false  # Check code blocks for proper names (default: false, skips code blocks)

--- a/documentation/copy-relative-path-to-files.md
+++ b/documentation/copy-relative-path-to-files.md
@@ -55,7 +55,8 @@ do the following in your config:
 
 - create a snacks.nvim keymap available in the picker, e.g. for `<C-y>` in
   normal and insert mode
-- ```lua
+
+  ```lua
   ---@module "lazy"
   ---@type LazySpec
   return {

--- a/documentation/for-developers/developing.md
+++ b/documentation/for-developers/developing.md
@@ -148,7 +148,7 @@ code:
    version by commenting the `dir` setting from the plugin specification.
 
 An example can be found
-[here](https://github.com/mikavilpas/dotfiles/blob/75e070ce6ac45b7ed8ac4c818f77abadbdd4b152/.config/nvim/lua/plugins/my-file-manager.lua?plain=1#L9).
+[in my config](https://github.com/mikavilpas/dotfiles/blob/75e070ce6ac45b7ed8ac4c818f77abadbdd4b152/.config/nvim/lua/plugins/my-file-manager.lua?plain=1#L9).
 
 ## Resources
 

--- a/documentation/installing-yazi-from-source.md
+++ b/documentation/installing-yazi-from-source.md
@@ -44,12 +44,11 @@ to the project.
    ```
 
 4. In case there are any issues, you can try these steps:
-
-- Check <https://yazi-rs.github.io/docs/installation/> and see if you have
-  followed all steps correctly
-- Yazi has a `yazi --debug` command that can help you debug issues specific to
-  yazi
-- In yazi.nvim, you can run `:checkhealth yazi` to see if everything works
+   - Check <https://yazi-rs.github.io/docs/installation/> and see if you have
+     followed all steps correctly
+   - Yazi has a `yazi --debug` command that can help you debug issues specific
+     to yazi
+   - In yazi.nvim, you can run `:checkhealth yazi` to see if everything works
 
 5. If you still have issues, please open an issue:
    <https://github.com/mikavilpas/yazi.nvim/issues>

--- a/documentation/reproducing-issues.md
+++ b/documentation/reproducing-issues.md
@@ -31,6 +31,7 @@ To enable logging, you can do one of the following:
 
 - set `log_level = vim.log.levels.DEBUG,` in your yazi configuration
 - or, call yazi manually with logging on by running
+
   ```vim
   :lua require('yazi').yazi({log_level = vim.log.levels.DEBUG})
   ```


### PR DESCRIPTION
# ci: use rumdl for markdown linting and fix docs issues

> Markdown Linter and Formatter written in Rust
>
> https://github.com/rvben/rumdl

docs: make markdown links descriptive