### PR TITLE
ci: don't use `mise run build` to install Lua dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
               TARGET="$HOME/.local/bin" sh
 
           ubi --project mikefarah/yq
-          ubi --project jdx/mise
 
           VERSION=$(yq '.tools."ubi:EmmyLuaLs/emmylua-analyzer-rust".version' .mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
@@ -103,7 +102,10 @@ jobs:
           nvim_version: ${{ matrix.neovim_version }}
           luarocks_version: "3.11.1"
           before: |
-            mise run build
+            # copied from .mise.toml
+            luarocks init --no-gitignore
+            luarocks install busted 2.2.0-1
+            luarocks install nlua 0.3.2-1
 
       - name: Verify that dependencies are available
         run: |


### PR DESCRIPTION
It seems to fail intermittently
https://github.com/mikavilpas/yazi.nvim/actions/runs/20562324899/job/59054700363?pr=1507#step:12:308