### PR TITLE
test: don't wait for keys to be sent to neovim

### DIFF
--- a/integration-tests/cypress/e2e/hover-highlights.cy.ts
+++ b/integration-tests/cypress/e2e/hover-highlights.cy.ts
@@ -104,9 +104,6 @@ describe("highlighting the buffer with 'hover' events", () => {
       // open an adjacent file and wait for it to be displayed
       cy.typeIntoTerminal(
         `:vsplit ${nvim.dir.testEnvironmentPathRelative}/${testFile}{enter}`,
-        {
-          delay: 0,
-        },
       )
 
       const file2Text = "Hello"

--- a/integration-tests/cypress/e2e/opening-directories.cy.ts
+++ b/integration-tests/cypress/e2e/opening-directories.cy.ts
@@ -1,3 +1,5 @@
+import { findFileInYazi } from "./utils/yazi-utils"
+
 describe("opening directories", () => {
   it("can open a directory when starting with `neovim .`", () => {
     cy.visit("/")
@@ -49,9 +51,11 @@ describe("opening directories", () => {
       cy.contains("-- TERMINAL --")
       cy.contains(nvim.dir.contents["file2.txt"].name)
 
-      // select a directory
-      cy.typeIntoTerminal("/routes{enter}")
-      // the contents of the directory should now be visible
+      // select a directory and wait for yazi to have found it
+      findFileInYazi("routes")
+      cy.typeIntoTerminal("{enter}")
+
+      // the contents of the directory should now be visible in yazi
       cy.contains("posts.$postId")
 
       // open the directory

--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -2,6 +2,7 @@ import { flavors } from "@catppuccin/palette"
 import { rgbify, textIsVisibleWithBackgroundColor } from "@tui-sandbox/library"
 import { z } from "zod"
 import type { MyTestDirectoryFile } from "../../MyTestDirectory"
+import { hoverFileAndVerifyItsHovered } from "./utils/hover-utils"
 import {
   assertYaziIsReady,
   isDirectorySelectedInYazi,
@@ -14,7 +15,10 @@ describe("reading events", () => {
 
   it("can read 'cd' events and use telescope in the latest directory", () => {
     cy.startNeovim({
-      startupScriptModifications: ["add_yazi_context_assertions.lua"],
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "add_command_to_reveal_a_file.lua",
+      ],
       NVIM_APPNAME: "nvim_integrations",
     }).then((nvim) => {
       //
@@ -26,8 +30,9 @@ describe("reading events", () => {
 
       // move to the parent directory. This should make yazi send the "cd" event,
       // indicating that the directory was changed
-      cy.contains("subdirectory" satisfies MyTestDirectoryFile)
-      cy.typeIntoTerminal("/subdirectory{enter}")
+      cy.contains("other-subdirectory" satisfies MyTestDirectoryFile)
+      hoverFileAndVerifyItsHovered(nvim, "other-subdirectory")
+      cy.typeIntoTerminal("{enter}")
       cy.typeIntoTerminal("{rightArrow}")
       cy.typeIntoTerminal("{control+s}")
 
@@ -258,7 +263,8 @@ describe("'rename' events", () => {
       // the rename dialog covers the name of the file. we can use this to
       // check that the correct new filename has been entered.
       cy.contains("file3.txt" satisfies MyTestDirectoryFile).should("not.exist")
-      cy.typeIntoTerminal("{backspace}3")
+      cy.typeIntoTerminal("{control+e}{control+u}")
+      cy.typeIntoTerminal("file3.txt" satisfies MyTestDirectoryFile)
       cy.contains("file3.txt" satisfies MyTestDirectoryFile)
       cy.typeIntoTerminal("{enter}")
       // a yazi dialog should pop up

--- a/integration-tests/cypress/e2e/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/utils/yazi-utils.ts
@@ -1,6 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify, textIsVisibleWithBackgroundColor } from "@tui-sandbox/library"
 import type { RunLuaCodeOutput } from "@tui-sandbox/library/server"
+import type { MyTestDirectoryFile } from "../../../MyTestDirectory"
 import type { NeovimContext } from "../../support/tui-sandbox"
 
 const darkTheme = flavors.macchiato.colors
@@ -15,6 +16,21 @@ export function isDirectorySelectedInYazi(text: string): void {
 
 export function isFileNotSelectedInYazi(text: string): void {
   textIsVisibleWithBackgroundColor(text, rgbify(darkTheme.base.rgb))
+}
+
+export function isFileFoundInYazi(filename: MyTestDirectoryFile): void {
+  textIsVisibleWithBackgroundColor(
+    filename,
+    rgbify(flavors.macchiato.colors.yellow.rgb),
+  )
+}
+
+/** find a directory and wait for yazi to have found it, then select it */
+export function findFileInYazi(filename: MyTestDirectoryFile): void {
+  cy.typeIntoTerminal("/")
+  cy.contains("Find next:")
+  cy.typeIntoTerminal(filename)
+  isFileFoundInYazi(filename)
 }
 
 export function assertYaziIsReady(

--- a/integration-tests/cypress/support/e2e.ts
+++ b/integration-tests/cypress/support/e2e.ts
@@ -24,3 +24,7 @@ before(function () {
   // https://gist.github.com/simenbrekken/3d2248f9e50c1143bf9dbe02e67f5399?permalink_comment_id=4615046#gistcomment-4615046
   cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
 })
+
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 0,
+})


### PR DESCRIPTION
# test: don't wait for keys to be sent to neovim

This should be reliable now as of
https://github.com/mikavilpas/tui-sandbox/pull/881

Also make tests less relied on timing by adding explicit waits.