### PR TITLE
fix: add stdin=false to prevent EBADF error on spawn

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -146,6 +146,7 @@ function YaProcess:start(context)
     -- • text: (boolean) Handle stdout and stderr as text.
     -- Replaces `\r\n` with `\n`.
     text = true,
+    stdin = false, -- Prevent EBADF after terminal spawn
     stderr = function(err, data)
       if err then
         Log:debug(string.format("ya stderr error: '%s'", data))


### PR DESCRIPTION
## Summary

When yazi is opened, `jobstart()` with `term=true` creates a terminal which can leave file descriptors in an invalid state. The subsequent `vim.system()` call to spawn the `ya sub` process inherits these invalid descriptors, causing an EBADF error.

**Error message:**
```
Error executing Lua callback: .../vim/_system.lua:256: EBADF: bad file descriptor
stack traceback:
    [C]: in function 'error'
    .../vim/_system.lua:256: in function 'spawn'
    .../vim/_system.lua:362: in function 'system'
    .../yazi.nvim/lua/yazi/process/ya_process.lua:145: in function 'start'
    ...
```

## Fix

Explicitly set `stdin = false` in the `vim.system()` call to prevent stdin inheritance.

## Environment

- Neovim: v0.11.4
- OS: macOS (Darwin 25.2.0)
- Yazi: 25.5.31
- Ya: 25.5.31

## Test plan

- [x] Tested locally - yazi opens without EBADF error
- [x] Module loads correctly in headless mode