### PR TITLE
test: work around fzf-lua inserting "i" unexpectedly on startup

### DIFF
--- a/integration-tests/cypress/e2e/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/integrations.cy.ts
@@ -165,6 +165,8 @@ describe("fzf-lua integration (grep)", () => {
       // wait for fzf-lua to be visible
       cy.contains("to Fuzzy Search")
 
+      // HACK for some reason, an extra "i" gets typed in my testing environment. Remove it.
+      cy.typeIntoTerminal("{backspace}")
       cy.typeIntoTerminal("this")
 
       // results should be visible
@@ -213,6 +215,9 @@ describe("fzf-lua integration (grep)", () => {
 
       // search for some file content. This should match
       // ../../../test-environment/routes/posts.$postId/adjacent-file.txt
+      //
+      // HACK for some reason, an extra "i" gets typed in my testing environment. Remove it.
+      cy.typeIntoTerminal("{backspace}")
       cy.typeIntoTerminal("this", { delay: 30 })
 
       // some results should be visible


### PR DESCRIPTION
If someone else encounters this, we should figure out the root cause and fix it properly.