### PR TITLE
ci: add testing for yazi v25.12.29 explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
             method: cargo-install
             # renovate: datasource=git-refs packageName=https://github.com/sxyazi/yazi
             commit: 0000141700d9ed627dfb12f81a05bb78c3ef21fa
+          - name: v25.12.29
+            method: download
+            version: v25.12.29
           - name: stable
             method: download
             # renovate: datasource=github-releases depName=sxyazi/yazi


### PR DESCRIPTION
Renovate currently updates the nightly yazi version as well as the latest stable version automatically whenever new versions are released.

Because yazi `v25.12.29` is so new, support it explicitly for some time. This will have to be added manually, and also removed manually later.