### PR TITLE
fix: opening yazi in a fugitive buffer falls back to cwd

### DIFF
--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -130,6 +130,16 @@ function M.selected_file_path(path)
     path = vim.fn.expand("%:p")
   end
 
+  -- if the path uses a non-file URI scheme (e.g. fugitive://, oil://), fall
+  -- back to the current working directory. Yazi only understands file paths.
+  if
+    path
+    and string.find(path, "://")
+    and not string.find(path, "^file://")
+  then
+    path = vim.fn.getcwd()
+  end
+
   -- if the path is still empty (no file loaded / invalid buffer), try to get
   -- the directory of the current file.
   if path == "" or path == nil then

--- a/spec/yazi/selected_files_spec.lua
+++ b/spec/yazi/selected_files_spec.lua
@@ -21,6 +21,34 @@ describe("choosing the correct files when starting yazi", function()
 
       assert.equal(result.filename, vim.fn.getcwd())
     end)
+
+    it(
+      "when the buffer has a non-file URI scheme (e.g. fugitive://), falls back to cwd",
+      function()
+        -- simulate opening a vim-fugitive buffer
+        local bufnr = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_buf_set_name(
+          bufnr,
+          "fugitive:///Users/test/repo/.git//HEAD"
+        )
+        vim.api.nvim_set_current_buf(bufnr)
+
+        local result = utils.selected_file_path()
+
+        assert.equal(vim.fn.getcwd(), result.filename)
+      end
+    )
+
+    it("when the buffer has an oil:// URI scheme, falls back to cwd", function()
+      -- simulate opening an oil.nvim buffer
+      local bufnr = vim.api.nvim_create_buf(true, false)
+      vim.api.nvim_buf_set_name(bufnr, "oil:///Users/test/somedir/")
+      vim.api.nvim_set_current_buf(bufnr)
+
+      local result = utils.selected_file_path()
+
+      assert.equal(vim.fn.getcwd(), result.filename)
+    end)
   end)
 
   describe("selected_files", function()


### PR DESCRIPTION
**Issue:**

When https://github.com/tpope/vim-fugitive is used and yazi is opened in its buffer, an error occurs because yazi cannot handle the `fugitive://` URI scheme.

```vim
error: invalid value 'fugitive:///Users/foo/gitrep/lib/lexical/.git//' for '[ENTRIES]...': invalid scheme kind: fugitive
```

**Solution:**

Fall back to using equivalent behavior as with `:Yazi cwd` in this case to avoid the error.

Closes https://github.com/mikavilpas/yazi.nvim/issues/1538