### PR TITLE
fix(config): respect config.highlight_hovered_buffers_in_same_directory

### DIFF
--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -230,7 +230,15 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
       )
       self.hovered_url = event.url
       vim.schedule(function()
-        self.highlighter:highlight_buffers_when_hovered(event.url, self.config)
+        if self.config.highlight_hovered_buffers_in_same_directory then
+          self.highlighter:highlight_buffers_when_hovered(
+            event.url,
+            self.config
+          )
+        else
+          Log:debug("Skipping buffer highlighting (disabled in config)")
+        end
+
         nvim_event_handling.emit("YaziDDSHover", event)
       end)
     elseif event.type == "cd" and event.yazi_id == self.yazi_id then


### PR DESCRIPTION
**Issue:**

The `highlight_hovered_buffers_in_same_directory` config option was not being respected. Buffer highlighting would occur even when set to `false`.

**Solution:**

Added a config check before calling the highlight function in [ya_process.lua](lua/yazi/process/ya_process.lua).

Closes #1542