### PR TITLE
fix: reopen yazi float after terminal resize to clear stale frame

### DIFF
--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -150,12 +150,46 @@ function M.yazi(config, input_path, args)
     require("yazi.config").set_keymappings(yazi_buffer, config, yazi_context)
   end
 
+  local active = true
+  local resize_tick = 0
+  local reopen_tick = 0
+
+  vim.api.nvim_buf_attach(yazi_buffer, false, {
+    on_lines = function()
+      if not active or reopen_tick == resize_tick then
+        return
+      end
+
+      reopen_tick = resize_tick
+      vim.schedule(function()
+        if not active or reopen_tick ~= resize_tick then
+          return
+        end
+
+        if win:reopen_preserving_buffer() == nil then
+          return
+        end
+
+        local ok = pcall(vim.api.nvim__redraw, {
+          win = win.win,
+          valid = false,
+          flush = true,
+          cursor = true,
+        })
+        if not ok then
+          pcall(vim.cmd, "redraw!")
+        end
+      end)
+    end,
+    on_detach = function()
+      active = false
+      return true
+    end,
+  })
+
   win.on_resized = function(event)
-    vim.fn.jobresize(
-      yazi_process.yazi_job_id,
-      event.win_width,
-      event.win_height
-    )
+    resize_tick = resize_tick + 1
+    vim.fn.jobresize(yazi_process.yazi_job_id, event.win_width, event.win_height)
   end
 
   vim.schedule(function()

--- a/lua/yazi/window.lua
+++ b/lua/yazi/window.lua
@@ -91,7 +91,7 @@ local function get_window_dimensions(config)
   }
 end
 
-function YaziFloatingWindow:open_and_display()
+local function open_window(self, yazi_buffer, enter)
   local dimensions = get_window_dimensions(self.config)
 
   ---@type vim.api.keyset.win_config
@@ -110,11 +110,47 @@ function YaziFloatingWindow:open_and_display()
     self.config.hooks.before_opening_window(opts)
   end
 
-  local yazi_buffer = vim.api.nvim_create_buf(false, true)
-  -- create file window, enter the window, and use the options defined in opts
-  local win = vim.api.nvim_open_win(yazi_buffer, true, opts)
+  local win = vim.api.nvim_open_win(yazi_buffer, enter, opts)
   self.win = win
   self.content_buffer = yazi_buffer
+  vim.api.nvim_set_option_value("bufhidden", "hide", { buf = yazi_buffer })
+  vim.api.nvim_set_option_value("cursorcolumn", false, { win = win })
+  vim.api.nvim_set_option_value(
+    "winhl",
+    "NormalFloat:YaziFloat,FloatBorder:YaziFloatBorder",
+    { win = win }
+  )
+  vim.api.nvim_set_option_value(
+    "winblend",
+    self.config.yazi_floating_window_winblend,
+    { win = win }
+  )
+
+  return win
+end
+
+function YaziFloatingWindow:reopen_preserving_buffer()
+  if
+    not self.content_buffer
+    or not vim.api.nvim_buf_is_valid(self.content_buffer)
+    or not vim.api.nvim_buf_is_loaded(self.content_buffer)
+  then
+    return nil
+  end
+
+  local enter = self.win and vim.api.nvim_get_current_win() == self.win
+  local previous_win = self.win
+
+  if previous_win and vim.api.nvim_win_is_valid(previous_win) then
+    vim.api.nvim_win_close(previous_win, true)
+  end
+
+  return open_window(self, self.content_buffer, enter)
+end
+
+function YaziFloatingWindow:open_and_display()
+  local yazi_buffer = vim.api.nvim_create_buf(false, true)
+  open_window(self, yazi_buffer, true)
   Log:debug(
     string.format(
       "YaziFloatingWindow opening (content_buffer: %s, win: %s)",
@@ -125,16 +161,12 @@ function YaziFloatingWindow:open_and_display()
 
   vim.bo[yazi_buffer].filetype = "yazi"
 
-  vim.cmd("setlocal bufhidden=hide")
-  vim.cmd("setlocal nocursorcolumn")
   vim.api.nvim_set_hl(0, "YaziFloat", { link = "Normal", default = true })
   vim.api.nvim_set_hl(
     0,
     "YaziFloatBorder",
     { link = "FloatBorder", default = true }
   )
-  vim.cmd("setlocal winhl=NormalFloat:YaziFloat,FloatBorder:YaziFloatBorder")
-  vim.cmd("set winblend=" .. self.config.yazi_floating_window_winblend)
 
   -- When another floating window (e.g. an LSP confirmation dialog) takes
   -- focus and then closes, re-enter terminal insert mode so that keypresses
@@ -155,9 +187,13 @@ function YaziFloatingWindow:open_and_display()
   vim.api.nvim_create_autocmd({ "VimResized" }, {
     buffer = yazi_buffer,
     callback = function()
+      if not (self.win and vim.api.nvim_win_is_valid(self.win)) then
+        return
+      end
+
       local dims = get_window_dimensions(self.config)
 
-      vim.api.nvim_win_set_config(win, {
+      vim.api.nvim_win_set_config(self.win, {
         width = dims.width,
         height = dims.height,
         row = dims.row,


### PR DESCRIPTION

![iShot_2026-03-13_11 53 16_compressed](https://github.com/user-attachments/assets/c7dd1182-daaa-4089-ba16-396c11a034d2)

After terminal resize, `yazi` can render for the new size while the existing float still shows a stale or clipped visible frame.

This patch waits for the first post-resize terminal buffer update, then reopens the float with the same buffer and forces a redraw.

Verified locally with the WezTerm zoom / unzoom + pane-switch reproduction from #1692.