### PR TITLE
refactor: replace plenary.nvim with built-in YaziPath module

### DIFF
--- a/.github/workflows/release-luarocks.yml
+++ b/.github/workflows/release-luarocks.yml
@@ -21,5 +21,4 @@ jobs:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
           # https://github.com/marketplace/actions/luarocks-tag-release#dependencies
-          dependencies: |
-            plenary.nvim
+          dependencies: ""

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,5 +19,4 @@ jobs:
           level: Information
           libraries:
             # space separated
-            https://github.com/nvim-lua/plenary.nvim
             https://github.com/folke/snacks.nvim

--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ return {
   "mikavilpas/yazi.nvim",
   version = "*", -- use the latest stable version
   event = "VeryLazy",
-  dependencies = {
-    { "nvim-lua/plenary.nvim", lazy = true },
-  },
+  dependencies = {},
   keys = {
     -- 👇 in this section, choose your own keymappings!
     {

--- a/integration-tests/test-environment/.config/nvim_no_package_manager/init.lua
+++ b/integration-tests/test-environment/.config/nvim_no_package_manager/init.lua
@@ -4,13 +4,3 @@ do
   assert(vim.uv.fs_stat(repo_root), "repo_root does not exist: " .. repo_root)
   vim.opt.runtimepath:prepend(repo_root)
 end
-
-do
-  -- HACK: use the plenary that's already installed in the main test nvim
-  -- environment. We can change this to use vim.pack.add once that is stable
-  local plenary = assert(vim.env.HOME)
-    .. "/../../.repro/data/nvim/lazy/plenary.nvim"
-  plenary = vim.fn.fnamemodify(plenary, ":p")
-  assert(vim.uv.fs_stat(plenary), "repo_root does not exist: " .. plenary)
-  vim.opt.runtimepath:prepend(plenary)
-end

--- a/integration-tests/test-environment/config-modifications/yazi_config/log_yazi_closed_successfully.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/log_yazi_closed_successfully.lua
@@ -10,7 +10,7 @@ require("yazi").setup(
         _G.yazi_closed_successfully_hook_test_results = {
           chosen_file = chosen_file,
           last_directory = state.last_directory
-            and state.last_directory:normalize(vim.uv.cwd()),
+            and state.last_directory:make_relative(vim.uv.cwd()),
         }
       end,
     },

--- a/lazy.lua
+++ b/lazy.lua
@@ -11,11 +11,6 @@
 
 ---@type LazySpec
 return {
-  -- Needed for file path resolution mainly
-  --
-  -- https://github.com/nvim-lua/plenary.nvim/
-  { "nvim-lua/plenary.nvim", lazy = true },
-
   {
     "mikavilpas/yazi.nvim",
     ---@type YaziConfig | {}

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -1,5 +1,3 @@
----@module "plenary"
-
 local configModule = require("yazi.config")
 
 local M = {}

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local M = {}
 
 function M.default()

--- a/lua/yazi/keybinding_helpers.lua
+++ b/lua/yazi/keybinding_helpers.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local openers = require("yazi.openers")
 local Log = require("yazi.log")
 local utils = require("yazi.utils")
@@ -187,7 +185,6 @@ function YaziOpenerActions.cycle_open_buffers(_config, context)
     )
   )
 
-  -- make sure the type is a string, because plenary thinks it is `string|unknown`
   context.api:reveal(next_buffer.renameable_buffer.path:absolute())
   context.cycled_file = next_buffer.renameable_buffer
 end
@@ -239,12 +236,12 @@ function YaziOpenerActions.grep_in_selected_files(config, chosen_files)
     return
   end
 
-  local plenary_path = require("plenary.path")
+  local YaziPath = require("yazi.path")
 
-  ---@type Path[]
+  ---@type YaziPath[]
   local paths = {}
   for _, path in ipairs(chosen_files) do
-    table.insert(paths, plenary_path:new(path))
+    table.insert(paths, YaziPath:new(path))
   end
 
   -- pickers typically work with file paths relative to the cwd
@@ -308,10 +305,10 @@ function YaziOpenerActions.replace_in_selected_files(config, chosen_files)
   end
 
   -- limit the replace operation to the selected files only
-  local plenary_path = require("plenary.path")
+  local YaziPath = require("yazi.path")
   local paths = {}
   for _, path in ipairs(chosen_files) do
-    table.insert(paths, plenary_path:new(path))
+    table.insert(paths, YaziPath:new(path))
   end
 
   local success, result_or_error =

--- a/lua/yazi/lsp/embedded-lsp-file-operations/lsp-file-operations/log.lua
+++ b/lua/yazi/lsp/embedded-lsp-file-operations/lsp-file-operations/log.lua
@@ -1,5 +1,3 @@
-local log = require("plenary.log")
+local Log = require("yazi.log")
 
-return log.new({
-  plugin = "nvim-yazi.lsp.embedded-lsp-file-operations.lsp-file-operations",
-}, false)
+return Log

--- a/lua/yazi/lsp/embedded-lsp-file-operations/lsp-file-operations/utils.lua
+++ b/lua/yazi/lsp/embedded-lsp-file-operations/lsp-file-operations/utils.lua
@@ -1,4 +1,4 @@
-local Path = require("plenary").path
+local Path = require("yazi.path")
 
 local log =
   require("yazi.lsp.embedded-lsp-file-operations.lsp-file-operations.log")

--- a/lua/yazi/path.lua
+++ b/lua/yazi/path.lua
@@ -1,0 +1,86 @@
+---@class YaziPath
+---@field filename string
+local YaziPath = {}
+YaziPath.__index = YaziPath
+
+--- Create a new path object from a string.
+--- Compatible with plenary.path's Path:new() interface.
+---@param path string
+---@return YaziPath
+function YaziPath:new(path)
+  local instance = setmetatable({}, self)
+  -- normalize: remove trailing slash unless it's the root "/"
+  if #path > 1 and path:sub(-1) == "/" then
+    path = path:sub(1, -2)
+  end
+  instance.filename = path
+  return instance
+end
+
+---@return YaziPath
+function YaziPath:parent()
+  local dir = vim.fs.dirname(self.filename)
+  return YaziPath:new(dir)
+end
+
+--- Return all ancestor directories as a list of strings (not Path objects).
+--- This matches plenary.path's :parents() which returns string[].
+---@return string[]
+function YaziPath:parents()
+  local result = {}
+  local current = self.filename
+  while true do
+    local dir = vim.fs.dirname(current)
+    if dir == current then
+      break
+    end
+    result[#result + 1] = dir
+    current = dir
+  end
+  return result
+end
+
+---@return boolean
+function YaziPath:is_dir()
+  return vim.fn.isdirectory(self.filename) == 1
+end
+
+---@return boolean
+function YaziPath:is_file()
+  local stat = vim.uv.fs_stat(self.filename)
+  return stat ~= nil and stat.type == "file"
+end
+
+---@return boolean
+function YaziPath:exists()
+  return vim.uv.fs_stat(self.filename) ~= nil
+end
+
+---@return string
+function YaziPath:absolute()
+  return vim.fn.fnamemodify(self.filename, ":p"):gsub("/$", "")
+end
+
+--- Make the path relative to the given base directory.
+---@param base string|nil
+---@return string
+function YaziPath:make_relative(base)
+  if not base then
+    return self.filename
+  end
+  -- ensure base ends without slash for consistent prefix removal
+  if base:sub(-1) == "/" then
+    base = base:sub(1, -2)
+  end
+  local prefix = base .. "/"
+  if self.filename:sub(1, #prefix) == prefix then
+    return self.filename:sub(#prefix + 1)
+  end
+  return self.filename
+end
+
+function YaziPath:__tostring()
+  return self.filename
+end
+
+return YaziPath

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local Log = require("yazi.log")
 local utils = require("yazi.utils")
 local YaziSessionHighlighter =
@@ -64,7 +62,7 @@ local function remove_duplicates(items)
   return result
 end
 
----@param paths Path[]
+---@param paths YaziPath[]
 function YaProcess:get_yazi_command(paths)
   local command_words = { "yazi" }
 

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -1,10 +1,8 @@
----@module "plenary.path"
-
 local YaProcess = require("yazi.process.ya_process")
 local Log = require("yazi.log")
 local utils = require("yazi.utils")
 local YaziProcessApi = require("yazi.process.yazi_process_api")
-local plenary_path = require("plenary.path")
+local YaziPath = require("yazi.path")
 
 ---@class YaziProcess
 ---@field public api YaziProcessApi
@@ -16,11 +14,11 @@ local YaziProcess = {}
 YaziProcess.__index = YaziProcess
 
 ---@class yazi.Callbacks
----@field on_exit fun(code: integer, selected_files: string[], hovered_url: string | nil, last_cwd: Path | nil, context: YaziActiveContext)
+---@field on_exit fun(code: integer, selected_files: string[], hovered_url: string | nil, last_cwd: YaziPath | nil, context: YaziActiveContext)
 ---@field on_ya_first_event fun(api: YaziProcessApi)
 
 ---@param config YaziConfig
----@param paths Path[]
+---@param paths YaziPath[]
 ---@param callbacks yazi.Callbacks
 ---@return YaziProcess, YaziActiveContext
 function YaziProcess:start(config, paths, callbacks)
@@ -70,8 +68,7 @@ function YaziProcess:start(config, paths, callbacks)
         config.future_features.use_cwd_file == true
         and utils.file_exists(config.cwd_file_path) == true
       then
-        last_directory =
-          plenary_path:new(vim.fn.readfile(config.cwd_file_path)[1])
+        last_directory = YaziPath:new(vim.fn.readfile(config.cwd_file_path)[1])
         require("yazi.log"):debug(
           string.format(
             "using cwd found from the cwd_file_path: '%s'",
@@ -79,7 +76,7 @@ function YaziProcess:start(config, paths, callbacks)
           )
         )
       elseif self.ya_process.cwd ~= nil then
-        last_directory = plenary_path:new(self.ya_process.cwd)
+        last_directory = YaziPath:new(self.ya_process.cwd)
         require("yazi.log"):debug(
           string.format("using ya process cwd: '%s'", self.ya_process.cwd)
         ) --[[@as Path]]

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 ---@class YaziProcessApi # Provides yazi.nvim -> yazi process interactions. This allows yazi.nvim to tell yazi what to do.
 ---@field private config YaziConfig
 ---@field private yazi_id string

--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -1,4 +1,4 @@
-local plenary_path = require("plenary.path")
+local YaziPath = require("yazi.path")
 
 ---@param path string
 local function remove_trailing_slash(path)
@@ -14,7 +14,7 @@ end
 ---@field __index RenameableBuffer
 ---@field bufnr number
 ---@field original_path string
----@field path Path
+---@field path YaziPath
 local RenameableBuffer = {}
 RenameableBuffer.__index = RenameableBuffer
 
@@ -27,7 +27,7 @@ function RenameableBuffer.new(bufnr, path)
 
   self.bufnr = bufnr
   self.original_path = path
-  self.path = plenary_path:new(path)
+  self.path = YaziPath:new(path)
 
   return self
 end
@@ -71,7 +71,7 @@ end
 ---@return nil
 function RenameableBuffer:rename(path)
   path = remove_trailing_slash(path)
-  self.path = plenary_path:new(path)
+  self.path = YaziPath:new(path)
 end
 
 ---@param parent_from string the parent directory that was renamed
@@ -83,7 +83,7 @@ function RenameableBuffer:rename_parent(parent_from, parent_to)
 
   local new_path = parent_to .. rest
 
-  self.path = plenary_path:new(new_path)
+  self.path = YaziPath:new(new_path)
 end
 
 return RenameableBuffer

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -1,7 +1,5 @@
 -- TODO all config properties are optional when given, but mandatory inside the plugin
 
----@module "plenary.path"
-
 ---@alias YaziFloatingWindowScaling { height: number, width: number }
 
 ---@class (exact) YaziConfig
@@ -49,7 +47,7 @@
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi
 ---@field ya_process YaProcess the ya process that is currently running, listening for events from yazi
----@field input_path Path the path that is first selected by yazi when it's opened
+---@field input_path YaziPath the path that is first selected by yazi when it's opened
 ---@field cycled_file? RenameableBuffer the last file that was cycled to with e.g. the <tab> key
 
 ---@class (exact) YaziConfigHooks
@@ -61,9 +59,9 @@
 
 ---@class (exact) YaziConfigIntegrations # Defines settings for integrations with other plugins and tools
 ---@field public grep_in_directory? "telescope" | "fzf-lua" | "snacks.picker" | fun(directory: string): nil # implementation to be called when the user wants to grep in a directory. Defaults to `"telescope"`
----@field public grep_in_selected_files? "telescope" | "fzf-lua" | "snacks.picker" | fun(selected_files: Path[], relative_paths: string[]): nil # called to grep on files that were selected in yazi. Defaults to `"telescope"`
----@field public replace_in_directory? fun(directory: Path, selected_files?: Path[]): nil # called to start a replacement operation on some directory; by default uses grug-far.nvim
----@field public replace_in_selected_files? fun(selected_files?: Path[]): nil # called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim
+---@field public grep_in_selected_files? "telescope" | "fzf-lua" | "snacks.picker" | fun(selected_files: YaziPath[], relative_paths: string[]): nil # called to grep on files that were selected in yazi. Defaults to `"telescope"`
+---@field public replace_in_directory? fun(directory: YaziPath, selected_files?: YaziPath[]): nil # called to start a replacement operation on some directory; by default uses grug-far.nvim
+---@field public replace_in_selected_files? fun(selected_files?: YaziPath[]): nil # called to start a replacement operation on files that were selected in yazi; by default uses grug-far.nvim
 ---@field public resolve_relative_path_application? string # the application that will be used to resolve relative paths. By default, this is GNU `realpath` on Linux and `grealpath` on macOS
 ---@field public resolve_relative_path_implementation? fun(args: YaziGetRelativePathImplementationArguments, default_implementation: fun(args: YaziGetRelativePathImplementationArguments): string): string # the way to resolve relative paths. The default_implementation can be customized with a function. See ../../documentation/copy-relative-path-to-files.md for more information.
 ---@field public bufdelete_implementation? YaziBufdeleteImpl # how to delete (close) a buffer. Defaults to `snacks.bufdelete` from https://github.com/folke/snacks.nvim, which maintains the window layout.
@@ -89,7 +87,7 @@
 ---@field public last_hovered? string
 
 ---@class (exact) YaziClosedState # describes the state of yazi when it was closed; the last known state
----@field public last_directory Path # the last directory that yazi was in before it was closed
+---@field public last_directory YaziPath # the last directory that yazi was in before it was closed
 
 ---@class (exact) YaziRenameEvent
 ---@field public type "rename"

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -1,5 +1,5 @@
 local RenameableBuffer = require("yazi.renameable_buffer")
-local plenary_path = require("plenary.path")
+local YaziPath = require("yazi.path")
 
 local M = {}
 
@@ -25,8 +25,8 @@ function M.relative_path(realpath_application, args)
 
   assert(command ~= nil, "realpath command must be set")
 
-  ---@type Path
-  local start_path = plenary_path:new(args.source_dir)
+  ---@type YaziPath
+  local start_path = YaziPath:new(args.source_dir)
   local start_directory = nil
   if start_path:is_dir() then
     start_directory = start_path
@@ -151,8 +151,8 @@ function M.selected_file_path(path)
     path = vim.fn.expand("%:p")
   end
 
-  ---@type Path
-  return plenary_path:new(path)
+  ---@type YaziPath
+  return YaziPath:new(path)
 end
 
 ---@param path string?
@@ -167,12 +167,12 @@ function M.selected_file_paths(path)
     -- get the paths of the files in the quickfix window
     local qflist = vim.fn.getqflist()
 
-    ---@type Path[]
+    ---@type YaziPath[]
     local filenames = {}
     for _, entry in ipairs(qflist) do
       if entry.bufnr and entry.bufnr > 0 then
         local filename = vim.api.nvim_buf_get_name(entry.bufnr)
-        local new_path = plenary_path:new(filename)
+        local new_path = YaziPath:new(filename)
         table.insert(filenames, new_path)
       end
     end
@@ -180,7 +180,7 @@ function M.selected_file_paths(path)
     return filenames
   end
 
-  ---@type Path[]
+  ---@type YaziPath[]
   local paths = { selected_file_path }
   for _, buffer in ipairs(M.get_visible_open_buffers()) do
     -- NOTE: yazi can only display up to 9 paths, and it's an error to give any
@@ -199,15 +199,11 @@ function M.selected_file_paths(path)
 end
 
 ---@param file_path string
----@return Path
+---@return YaziPath
 function M.dir_of(file_path)
-  ---@type Path
-  local path = plenary_path:new(file_path)
+  ---@type YaziPath
+  local path = YaziPath:new(file_path)
   local parent = path:parent()
-
-  -- for some reason, plenary is documented as returning table|unknown[]. we
-  -- want the table version only
-  assert(type(parent) == "table", "parent must be a table")
 
   return parent
 end

--- a/spec/yazi/grug_far_spec.lua
+++ b/spec/yazi/grug_far_spec.lua
@@ -1,9 +1,7 @@
----@module "plenary.path"
-
 local assert = require("luassert")
 local mock = require("luassert.mock")
 local config = require("yazi.config")
-local plenary_path = require("plenary.path")
+local YaziPath = require("yazi.path")
 
 describe("the grug-far integration (search and replace)", function()
   local mock_grug_far = { open = function() end }
@@ -19,7 +17,7 @@ describe("the grug-far integration (search and replace)", function()
   end)
 
   it("opens yazi with the current file selected", function()
-    local tmp_path = plenary_path:new("/tmp/folder with spaces/")
+    local tmp_path = YaziPath:new("/tmp/folder with spaces/")
 
     config.default().integrations.replace_in_directory(tmp_path)
 

--- a/spec/yazi/helpers/fake_yazi_process.lua
+++ b/spec/yazi/helpers/fake_yazi_process.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local M = {}
 
 ---@class FakeYaziArguments

--- a/spec/yazi/helpers/test_files.lua
+++ b/spec/yazi/helpers/test_files.lua
@@ -2,16 +2,16 @@ local M = {}
 
 ---@param target_file string
 function M.create_test_file(target_file)
-  local plenary_path = require("plenary.path")
+  local YaziPath = require("yazi.path")
   local file = io.open(target_file, "w") -- Open or create the file in write mode
   assert(file, "Failed to create file " .. target_file)
   if file then
     file:write("")
     file:close()
   end
-  assert(plenary_path:new(target_file):exists())
-  assert(plenary_path:new(target_file):is_file())
-  assert(plenary_path:new(target_file):parent():is_dir())
+  assert(YaziPath:new(target_file):exists())
+  assert(YaziPath:new(target_file):is_file())
+  assert(YaziPath:new(target_file):parent():is_dir())
 end
 
 return M

--- a/spec/yazi/keybinding_helpers_spec.lua
+++ b/spec/yazi/keybinding_helpers_spec.lua
@@ -2,7 +2,7 @@ local assert = require("luassert")
 local config_module = require("yazi.config")
 local keybinding_helpers = require("yazi.keybinding_helpers")
 local match = require("luassert.match")
-local plenary_path = require("plenary.path")
+local YaziPath = require("yazi.path")
 local stub = require("luassert.stub")
 local spy = require("luassert.spy")
 
@@ -164,7 +164,7 @@ describe("keybinding_helpers", function()
     it("uses yazi's input_path if no cwd is available yet", function()
       ---@diagnostic disable-next-line: missing-fields
       keybinding_helpers.change_working_directory({
-        input_path = plenary_path:new("/tmp"),
+        input_path = YaziPath:new("/tmp"),
         ---@diagnostic disable-next-line: missing-fields
         ya_process = {
           cwd = nil,
@@ -181,7 +181,7 @@ describe("keybinding_helpers", function()
         vim_fn_stub.returns("/tmp")
         ---@diagnostic disable-next-line: missing-fields
         keybinding_helpers.change_working_directory({
-          input_path = plenary_path:new("/tmp"),
+          input_path = YaziPath:new("/tmp"),
           ---@diagnostic disable-next-line: missing-fields
           ya_process = {
             cwd = "/tmp",

--- a/spec/yazi/open_multiple_files_spec.lua
+++ b/spec/yazi/open_multiple_files_spec.lua
@@ -6,8 +6,8 @@ describe("the default configuration", function()
     reset.clear_all_buffers()
   end)
 
-  local plenary_path = require("plenary.path")
-  local last_directory = plenary_path:new(vim.fn.getcwd())
+  local YaziPath = require("yazi.path")
+  local last_directory = YaziPath:new(vim.fn.getcwd())
 
   it("opens multiple files in buffers by default", function()
     local config = require("yazi.config").default()

--- a/spec/yazi/relative_path_spec.lua
+++ b/spec/yazi/relative_path_spec.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local assert = require("luassert")
 local utils = require("yazi.utils")
 local yazi = require("yazi")

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -320,7 +320,7 @@ end)
 
 describe("opening yazi in a terminal", function()
   local config = require("yazi.config").default()
-  local path = require("plenary.path"):new()
+  local path = require("yazi.path"):new("")
 
   local snapshot
 

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -1,5 +1,3 @@
----@module "plenary.path"
-
 local assert = require("luassert")
 local mock = require("luassert.mock")
 local match = require("luassert.match")
@@ -109,7 +107,7 @@ describe("opening a file", function()
     it(
       "uses the parent directory of the input_path as the last_directory when no last_directory is available",
       function()
-        local plenary_path = require("plenary.path")
+        local YaziPath = require("yazi.path")
         -- it can happen that we don't know what the last_directory was when
         -- yazi has exited. This currently happens when `ya` is started too
         -- late - yazi has already reported its `cd` event before `ya` starts
@@ -134,10 +132,7 @@ describe("opening a file", function()
           function(chosen_file, _config, state)
             assert.equal(target_file, chosen_file)
             assert.equal("/tmp", state.last_directory.filename)
-            assert.equal(
-              "/tmp",
-              plenary_path:new(target_file):parent().filename
-            )
+            assert.equal("/tmp", YaziPath:new(target_file):parent().filename)
           end
         )
 

--- a/yazi.nvim-scm-1.rockspec
+++ b/yazi.nvim-scm-1.rockspec
@@ -7,8 +7,6 @@ source = {
 }
 dependencies = {
   -- Add runtime dependencies here
-  -- e.g. "plenary.nvim",
-  "plenary.nvim",
 }
 test_dependencies = {
   "nlua",


### PR DESCRIPTION
Claude notes:

Drop the `plenary.nvim` dependency entirely by introducing `lua/yazi/path.lua`, a minimal `YaziPath` class that provides the same interface as `plenary.path` using Neovim built-ins (`vim.fs.dirname`, `vim.fn.isdirectory`, `vim.uv.fs_stat`, `vim.fn.fnamemodify`).

Changes:
- Add `lua/yazi/path.lua` with `YaziPath` class implementing `:new()`, `.filename`, `:parent()`, `:parents()`, `:is_dir()`, `:is_file()`, `:exists()`, `:absolute()`, `:make_relative()`
- Replace `plenary.log` usage in embedded LSP file operations with the project's own `yazi.log` logger
- Update all `require("plenary.path")` → `require("yazi.path")` across core code and tests
- Update `---@type Path` annotations to `---@type YaziPath`
- Remove `---@module "plenary.path"` annotations from all files
- Remove plenary from rockspec dependencies
- Replace `:normalize()` call in integration test helper with `:make_relative()`

All 130 unit tests and all e2e integration tests pass.