### PR TITLE
chore(mise): add rumdl to dependencies for markdown linting

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ lua = "5.1"
 # ripgrep is a dependency of telescope and fzf-lua
 "github:BurntSushi/ripgrep" = { version = "15.1.0", exe = "rg" }
 "github:JohnnyMorganz/stylua" = "2.4.1"
+"github:rvben/rumdl" = "0.1.82"
 actionlint = "1.7.12"
 
 [tasks]


### PR DESCRIPTION
# chore(mise): add rumdl to dependencies for markdown linting

It's used in ci but missing locally.

---

# Pull request stack

- 👉🏻 **[#1802](https://github.com/mikavilpas/yazi.nvim/pull/1802)** | chore(mise): add rumdl to dependencies for markdown linting 👈🏻