### PR TITLE
test: don't install a duplicate yq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          ubi --project mikefarah/yq
-
           VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 


### PR DESCRIPTION
# test: don't install a duplicate yq

It's already installed in the runner image, see https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

---

# Pull request stack

- 👉🏻 **[#1817](https://github.com/mikavilpas/yazi.nvim/pull/1817)** | test: don't install a duplicate yq 👈🏻