### PR TITLE
ci: commitlint only checkouts one PR's commits

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,7 +12,19 @@ jobs:
     runs-on: ubuntu-24.04
     name: commitlint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Compute fetch depth
+        id: depth
+        shell: bash
+        env:
+          # `+ 1` to include the PR base commit so commitlint can determine the range
+          COMMITS: ${{ github.event.pull_request.commits }}
+        run: |
+          echo "Linting $COMMITS commits"
+          echo "value=$((COMMITS + 1))" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ steps.depth.outputs.value }}
+
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1


### PR DESCRIPTION
# ci: commitlint only checkouts one PR's commits

It used to check out all commits, I suspect it's slower than it could be.

---

# Pull request stack

- 👉🏻 **[#1847](https://github.com/mikavilpas/yazi.nvim/pull/1847)** | ci: commitlint only checkouts one PR's commits 👈🏻