### PR TITLE
refactor: fix oxlint warning

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -15,6 +15,18 @@ import {
   isFileSelectedInYazi,
 } from "./utils/yazi-utils.js"
 
+function getSelectedFilePath(): Cypress.Chainable<string> {
+  const filenameSchema = z.object({ filename: z.string() })
+  return cy
+    .nvim_runLuaCode({
+      luaCode: `return require("yazi.utils").selected_file_path()`,
+    })
+    .then((result) => {
+      const value = filenameSchema.parse(result.value)
+      return value.filename satisfies string
+    })
+}
+
 describe("opening files", () => {
   beforeEach(() => {
     cy.visit("/")
@@ -77,18 +89,6 @@ describe("opening files", () => {
   it("can open yazi and hover a filename selected in visual mode", () => {
     cy.startNeovim().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")
-
-      function getSelectedFilePath(): Cypress.Chainable<string> {
-        const filenameSchema = z.object({ filename: z.string() })
-        return cy
-          .nvim_runLuaCode({
-            luaCode: `return require("yazi.utils").selected_file_path()`,
-          })
-          .then((result) => {
-            const value = filenameSchema.parse(result.value)
-            return value.filename satisfies string
-          })
-      }
 
       // add text that contains a filename in the middle to test that limiting
       // the recognition of the filename works


### PR DESCRIPTION
```sh
[Running: pnpm lint]
$ pnpm --filter ./integration-tests/ lint
$ pnpx oxlint --type-aware --deny-warnings --report-unused-disable-directives && eslint --max-warnings=0 .

  ⚠ unicorn(consistent-function-scoping): Function `getSelectedFilePath` does not capture any variables from its parent scope
    ╭─[cypress/e2e/opening-files.cy.ts:77:12]
 76 │
 77 │   function getSelectedFilePath(): Cypress.Chainable<string> {
    ·            ───────────────────
 78 │     const filenameSchema = z.object({ filename: z.string() })
    ╰────
  help: Move `getSelectedFilePath` to the outer scope to avoid recreating it on every call.
```