### PR TITLE
fix: bulk renames not working on nightly

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -321,7 +321,7 @@ describe("opening files", () => {
 
         // yazi should now have opened an embedded Neovim. The file name should say
         // "bulk" somewhere to indicate this
-        cy.contains(new RegExp("yazi-\\d+/bulk-\\d+"))
+        cy.contains(new RegExp("yazi-\\d+/bulk-.*?\\d+"))
 
         // edit the name of the first file
         cy.typeIntoTerminal("xxx")
@@ -350,7 +350,7 @@ describe("opening files", () => {
 
         // yazi should now have opened an embedded Neovim. The file name should say
         // "bulk" somewhere to indicate this
-        cy.contains(new RegExp("yazi-\\d+/bulk-\\d+"))
+        cy.contains(new RegExp("yazi-\\d+/bulk-.*?\\d+"))
 
         // edit the name of the file
         cy.contains("initial-file.txt")

--- a/lua/yazi/event_handling/nvim_event_handling.lua
+++ b/lua/yazi/event_handling/nvim_event_handling.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@alias YaziNeovimEvent.YaziRenamedOrMovedData {changes: table<string, string>} # a table of old paths to new paths
 
 ---Emit an event when files are renamed or moved.
----@param event YaziRenameEvent | YaziMoveEvent | YaziBulkEvent
+---@param event YaziRenameEvent | YaziMoveEvent | YaziBulkEvent | YaziBulkRenameEvent
 ---@see YaziNeovimEvent.YaziRenamedOrMovedData
 function M.emit_renamed_or_moved_event(event)
   ---@type YaziNeovimEvent.YaziRenamedOrMovedData
@@ -29,7 +29,7 @@ function M.emit_renamed_or_moved_event(event)
     ---@type YaziRenameEvent
     local rename_event = event
     event_data.changes[rename_event.data.from] = rename_event.data.to
-  elseif event.type == "bulk" then
+  elseif event.type == "bulk" or event.type == "bulk-rename" then
     event_data.changes = event.changes
   end
 

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -84,7 +84,7 @@ function M.process_event_emitted_from_yazi(event, config, context)
 
       handle_rename_move_bulk_event(config, item)
     end
-  elseif event.type == "bulk" then
+  elseif event.type == "bulk" or event.type == "bulk-rename" then
     ---@cast event YaziBulkEvent
     for from, to in pairs(event.changes) do
       vim.schedule(function()

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -114,6 +114,7 @@ function YaProcess:start(context)
     "cd",
     "hover",
     "bulk",
+    "bulk-rename",
     -- when ya starts, it will send a "hi" event to all yazis. They respond
     -- with "hey" to acknowledge this. We can use this to detect when ya is
     -- ready, so that integration-tests can safely start.
@@ -261,6 +262,7 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
         event.type == "rename"
         or event.type == "move"
         or event.type == "bulk"
+        or event.type == "bulk-rename"
       then
         vim.schedule(function()
           local success, result = pcall(function()

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -83,7 +83,7 @@
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 ---@field public hovered_buffer_in_same_directory? vim.api.keyset.highlight # the color of a buffer that is in the same directory as the hovered buffer
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent | YaziHeyEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziBulkRenameEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent | YaziHeyEvent
 
 ---@class (exact) YaziPreviousState # describes the previous state of yazi when it was closed; the last known state
 ---@field public last_hovered? string
@@ -131,6 +131,10 @@
 
 ---@class (exact) YaziBulkEvent "Like `rename` and `move` but for bulk renaming"
 ---@field public type "bulk"
+---@field public changes table<string, string> # a table of old paths to new paths
+
+---@class (exact) YaziBulkRenameEvent "Like `rename` and `move` but for bulk renaming". See https://github.com/sxyazi/yazi/pull/3793#discussion_r3221066634 where "bulk" was changed to "bulk-rename"
+---@field public type "bulk-rename"
 ---@field public changes table<string, string> # a table of old paths to new paths
 
 ---@class (exact) YaziNvimCycleBufferEvent # yazi commands yazi.nvim to cycle to the next buffer

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -274,7 +274,7 @@ function M.parse_events(event_lines)
       end
 
       table.insert(events, event)
-    elseif type == "bulk" then
+    elseif type == "bulk" or type == "bulk-rename" then
       -- example of a bulk event:
       -- bulk,0,1720800121065599,{"changes":{"/tmp/test-directory/test":"/tmp/test-directory/test2"}}
       local data = vim.json.decode(table.concat(parts, ",", 4, #parts))

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ lua = "5.1"
 "github:JohnnyMorganz/stylua" = "2.5.2"
 "github:rvben/rumdl" = "0.2.0"
 actionlint = "1.7.12"
+pnpm = "11.2.2"
 
 [tasks]
 test = "luarocks test --local"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "prettier-plugin-packagejson": "3.0.2",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f"
 }

--- a/spec/yazi/read_events_spec.lua
+++ b/spec/yazi/read_events_spec.lua
@@ -81,6 +81,19 @@ describe("parsing yazi event file events", function()
     })
   end)
 
+  it("can parse bulk-rename events", function()
+    local data = {
+      'bulk-rename,0,1720800121065599,{"changes":{"/tmp/test-directory/test":"/tmp/test-directory/test2"}}',
+    }
+
+    local events = utils.parse_events(data)
+
+    assert.are.equal(#events, 1)
+    assert.same(events[1].changes, {
+      ["/tmp/test-directory/test"] = "/tmp/test-directory/test2",
+    })
+  end)
+
   it("can parse delete events", function()
     local data = {
       'delete,1,2,{"urls":["/tmp/test-directory/test_2"]}',


### PR DESCRIPTION
# fix: bulk renames not working on nightly

It looks like in https://github.com/sxyazi/yazi/pull/3793#discussion_r3221066634, the `bulk` event type was changed to `bulk-rename`. The e2e tests against nightly are currently failing because of this.

Adapt to this change to fix them, supporting both `bulk` and `bulk-rename` event types.

# chore(mise): add pnpm, it seems to be missing on my system

Not sure why it's missing, but whatever. Install it with mise until something better comes along.

---

# Pull request stack

- 👉🏻 **[#1879](https://github.com/mikavilpas/yazi.nvim/pull/1879)** | fix: bulk renames not working on nightly 👈🏻