### PR TITLE
chore: remove pnpm from mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,6 @@ lua = "5.1"
 "github:JohnnyMorganz/stylua" = "2.5.2"
 "github:rvben/rumdl" = "0.2.0"
 actionlint = "1.7.12"
-pnpm = "11.2.2"
 zizmor = "1.25.2"
 
 [tasks]


### PR DESCRIPTION
# chore: remove pnpm from mise.toml

I added it to quickly get rid of an error https://github.com/mikavilpas/yazi.nvim/commit/0f8744abf39c24a780f3a0b3ce0590145b31b60a

I remembered the correct way to install it is `corepack enable pnpm`. This is also documented in `documentation/for-developers/developing.md`

---

# Pull request stack

- 👉🏻 **[#1882](https://github.com/mikavilpas/yazi.nvim/pull/1882)** | chore: remove pnpm from mise.toml 👈🏻