### PR TITLE
docs: remove missing `future_features.new_shell_escaping` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,12 +387,6 @@ return {
       -- use a file to store the last directory that yazi was in before it was
       -- closed. Defaults to `true`.
       use_cwd_file = true,
-
-      -- use a new shell escaping implementation that is more robust and works
-      -- on more platforms. Defaults to `true`. If set to `false`, the old
-      -- shell escaping implementation will be used, which is less robust and
-      -- may not work on all platforms.
-      new_shell_escaping = true,
     },
   },
 }


### PR DESCRIPTION
# docs: remove missing `future_features.new_shell_escaping` option

This option was removed in https://github.com/mikavilpas/yazi.nvim/commit/4f4dd4bc6437818cf3be5f2d7122fa98298d0021 but the documentation was not updated.

---

# Pull request stack

- 👉🏻 **[#1891](https://github.com/mikavilpas/yazi.nvim/pull/1891)** | docs: remove missing `future_features.new_shell_escaping` option 👈🏻