### PR TITLE
test: fix linting issue in opening-files.cy.ts

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -1,7 +1,7 @@
 import { flavors } from "@catppuccin/palette"
 import { rgbify, textIsVisibleWithBackgroundColor } from "@tui-sandbox/library"
 import assert from "assert"
-import path, { join } from "path"
+import path from "path"
 import { z } from "zod"
 import type { MyTestDirectoryFile } from "../../MyTestDirectory.js"
 import {
@@ -461,7 +461,7 @@ describe("opening files", () => {
       }).then((nvim) => {
         cy.contains("Hello from file_1.txt")
         nvim.runExCommand({
-          command: `cd ${join(nvim.dir.testEnvironmentPathRelative, nvim.dir.contents.highlights.name)}`,
+          command: `cd ${path.join(nvim.dir.testEnvironmentPathRelative, nvim.dir.contents.highlights.name)}`,
         })
 
         cy.typeIntoTerminal("{upArrow}")


### PR DESCRIPTION
# test: fix linting issue in opening-files.cy.ts

```sh
[Running: pnpm lint]
$ pnpm --filter ./integration-tests/ lint
$ pnpx oxlint --type-aware --deny-warnings --report-unused-disable-directives && eslint --max-warnings=0 .
Packages: +2
++
Progress: resolved 20, reused 0, downloaded 2, added 2, done

  ⚠ unicorn(import-style): Use default import for module `path`.
   ╭─[cypress/e2e/opening-files.cy.ts:4:1]
 3 │ import assert from "assert"
 4 │ import path, { join } from "path"
   · ─────────────────────────────────
 5 │ import { z } from "zod"
   ╰────

Found 1 warning and 0 errors.
Finished in 1.4s on 18 files with 233 rules using 10 threads.
/Users/mikavilpas/git/yazi.nvim/integration-tests:
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @yazi.nvim/integration-tests@0.0.0 lint: `pnpx oxlint --type-aware --deny-warnings --report-unused-disable-directives && eslint --max-warnings=0 .`
Exit status 1
[ELIFECYCLE] Command failed with exit code 1.
[Command exited with 1, lasted 4s]
```

---

# Pull request stack

- 👉🏻 **[#1895](https://github.com/mikavilpas/yazi.nvim/pull/1895)** | test: fix linting issue in opening-files.cy.ts 👈🏻