### PR TITLE
fix: suppress handled swapfile attention errors

### DIFF
--- a/lua/yazi/openers.lua
+++ b/lua/yazi/openers.lua
@@ -1,15 +1,32 @@
 local M = {}
 
+---@param command string
+---@param chosen_file string
+local function edit_file(command, chosen_file)
+  local ok, err = pcall(function()
+    vim.cmd(string.format("%s %s", command, vim.fn.fnameescape(chosen_file)))
+  end)
+  if ok then
+    return
+  end
+
+  if tostring(err):find("E325:", 1, true) then
+    return
+  end
+
+  error(err, 0)
+end
+
 ---@param chosen_file string
 function M.open_file(chosen_file)
-  vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
+  edit_file("edit", chosen_file)
 end
 
 ---@param chosen_file string
 function M.open_file_in_vertical_split(chosen_file)
   local is_directory = vim.fn.isdirectory(chosen_file) == 1
   if not is_directory then
-    vim.cmd(string.format("vsplit %s", vim.fn.fnameescape(chosen_file)))
+    edit_file("vsplit", chosen_file)
   end
 end
 
@@ -17,7 +34,7 @@ end
 function M.open_file_in_horizontal_split(chosen_file)
   local is_directory = vim.fn.isdirectory(chosen_file) == 1
   if not is_directory then
-    vim.cmd(string.format("split %s", vim.fn.fnameescape(chosen_file)))
+    edit_file("split", chosen_file)
   end
 end
 
@@ -25,7 +42,7 @@ end
 function M.open_file_in_tab(chosen_file)
   local is_directory = vim.fn.isdirectory(chosen_file) == 1
   if not is_directory then
-    vim.cmd(string.format("tabedit %s", vim.fn.fnameescape(chosen_file)))
+    edit_file("tabedit", chosen_file)
   end
 end
 

--- a/spec/yazi/file_openers_spec.lua
+++ b/spec/yazi/file_openers_spec.lua
@@ -19,6 +19,28 @@ after_each(function()
   snapshot:revert()
 end)
 
+describe("open_file", function()
+  it("does not raise if neovim reports a swap-file attention", function()
+    vim.cmd.invokes(function()
+      error("nvim_exec2(), line 1: Vim(edit):E325: ATTENTION")
+    end)
+
+    assert.has_no.errors(function()
+      openers.open_file("/tmp/file.txt")
+    end)
+  end)
+
+  it("raises non-swap-file errors", function()
+    vim.cmd.invokes(function()
+      error("Vim(edit):E37: No write since last change")
+    end)
+
+    assert.error_matches(function()
+      openers.open_file("/tmp/file.txt")
+    end, "E37:", 1, true)
+  end)
+end)
+
 describe("open_file_in_vertical_split", function()
   it("does not open if the given path is a directory", function()
     -- a directory cannot be opened in a split - it would show the netrw file


### PR DESCRIPTION
## Summary
- catch Neovim's E325 swap-file attention error in the default yazi.nvim file openers
- keep rethrowing non-swap edit errors
- add opener unit coverage for the handled swap-file path

## Verification
- stylua --check lua/yazi/openers.lua spec/yazi/file_openers_spec.lua
- luac -p lua/yazi/openers.lua spec/yazi/file_openers_spec.lua
- mise exec -- lua_modules/bin/busted spec/yazi/file_openers_spec.lua
- PATH=/private/tmp/yazi-test-bin2:$PATH mise exec -- lua_modules/bin/busted

Note: the full local suite needed a temporary GNU realpath-compatible grealpath wrapper on macOS; without it, the existing relative-path specs fail because this machine does not have GNU coreutils grealpath.