### PR TITLE
test: rescue clogged up test pipeline 🙏🏻

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,16 +55,16 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
+          VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust"' mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 
-          VERSION=$(yq '.tools."github:BurntSushi/ripgrep".version' mise.toml)
+          VERSION=$(yq '.tools.ripgrep.version' mise.toml)
           ubi --project BurntSushi/ripgrep --tag "$VERSION" --exe rg
 
-          VERSION=$(yq '.tools."github:junegunn/fzf"' mise.toml)
+          VERSION=$(yq '.tools.fzf' mise.toml)
           ubi --project junegunn/fzf --tag "v$VERSION"
 
-          VERSION=$(yq '.tools."github:sharkdp/fd"' mise.toml)
+          VERSION=$(yq '.tools.fd' mise.toml)
           ubi --project sharkdp/fd --tag "v$VERSION"
           ls -alR bin
         env:

--- a/integration-tests/cypress/e2e/healthcheck.cy.ts
+++ b/integration-tests/cypress/e2e/healthcheck.cy.ts
@@ -3,11 +3,7 @@ import * as assert from "assert"
 describe("the healthcheck", () => {
   it("can run the :healthcheck for yazi.nvim", () => {
     cy.visit("/")
-    cy.startNeovim({
-      additionalEnvironmentVariables: {
-        MISE_NO_CONFIG: "1",
-      },
-    }).then((nvim) => {
+    cy.startNeovim().then((nvim) => {
       // wait until text on the start screen is visible
       cy.contains("If you see this text, Neovim is ready!")
 

--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -51,6 +51,9 @@ describe("opening files", () => {
       // normally, when yazi is started, a message is shown at the bottom
       cy.typeIntoTerminal("{upArrow}")
       cy.contains("-- TERMINAL --")
+      cy.contains(
+        nvim.dir.contents["config-modifications"].name.replace("/", ""),
+      )
       cy.typeIntoTerminal("q")
       cy.contains("-- TERMINAL --").should("not.exist")
 
@@ -810,9 +813,9 @@ describe("changing the cwd on close (change_neovim_cwd_on_close)", () => {
       // verify the pwd does not change without enabling the setting
       assertNeovimCwd(nvim, startPath)
       cy.typeIntoTerminal("{upArrow}")
-      cy.contains("-- TERMINAL --")
+      cy.contains("NOR")
       cy.typeIntoTerminal("q")
-      cy.contains("-- TERMINAL --").should("not.exist")
+      cy.contains("NOR").should("not.exist")
       assertNeovimCwd(nvim, startPath)
 
       // allow change_neovim_cwd_on_close, which makes the pwd change
@@ -823,9 +826,9 @@ describe("changing the cwd on close (change_neovim_cwd_on_close)", () => {
 
       // verify the pwd changes
       cy.typeIntoTerminal("{upArrow}")
-      cy.contains("-- TERMINAL --")
+      cy.contains("NOR")
       cy.typeIntoTerminal("q")
-      cy.contains("-- TERMINAL --").should("not.exist")
+      cy.contains("NOR").should("not.exist")
       nvim.runExCommand({ command: "pwd" }).then((result) => {
         const pwd = z.string().parse(result.value)
         expect(pwd).to.eql(

--- a/integration-tests/cypress/e2e/utils/hover-utils.ts
+++ b/integration-tests/cypress/e2e/utils/hover-utils.ts
@@ -56,34 +56,28 @@ export function assertYaziIsHovering(
   })
 }
 
-/** HACK in CI, there can be timing issues where the first hover event is
- * lost. Right now we work around this by selecting another file first, then
- * hovering the desired file.
+/** Reveal a file in yazi and wait until our yazi confirms it is hovering it.
  *
- * Requires the {add_command_to_reveal_a_file.lua} script to be loaded from
- * config-modifications.
+ * In CI the `hover` DDS event yazi emits in response to a `reveal` can be lost,
  */
 export function hoverFileAndVerifyItsHovered(
   nvim: NeovimContext,
   file: MyTestDirectoryFile,
 ): Cypress.Chainable<RunLuaCodeOutput> {
   assertYaziIsReady(nvim)
+  const modulePath = `${nvim.dir.rootPathAbsolute}/config-modifications/add_command_to_reveal_a_file.lua`
+
   {
     // select another file (hacky) and wait for it to be hovered
     const dir = "config-modifications" satisfies MyTestDirectoryFile
     const path = nvim.dir.rootPathAbsolute + "/" + dir
-    nvim
-      .runLuaCode({
-        luaCode: `return Yazi_reveal_path("${path}")`,
-      })
-      .then(() => assertYaziIsHovering(nvim, dir))
+    nvim.runLuaCode({
+      luaCode: `return dofile("${modulePath}").reveal_path_and_wait_for_hover("${path}")`,
+    })
   }
 
-  // now select the desired file
   const path = nvim.dir.rootPathAbsolute + "/" + file
-  return nvim
-    .runLuaCode({
-      luaCode: `return Yazi_reveal_path("${path}")`,
-    })
-    .then(() => assertYaziIsHovering(nvim, file))
+  return nvim.runLuaCode({
+    luaCode: `return dofile("${modulePath}").reveal_path_and_wait_for_hover("${path}")`,
+  })
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@catppuccin/palette": "1.8.0",
     "@eslint/js": "10.0.1",
-    "@tui-sandbox/library": "12.5.4",
+    "@tui-sandbox/library": "12.6.0",
     "@types/node": "24.13.1",
     "@types/tinycolor2": "1.4.6",
     "assert": "2.1.0",

--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -1,29 +1,40 @@
--- selene: allow(unused_variable)
-function Yazi_reveal_path(path)
+local M = {}
+
+--- Reveal (hover) `path` in our yazi instance and block until our yazi confirms
+--- it is hovering that path.
+---
+--- @param path string
+function M.reveal_path_and_wait_for_hover(path)
   local yazi = require("yazi")
+  local Log = require("yazi.log")
 
   ---@type YaziActiveContext | nil
   local context = yazi.active_contexts:peek()
-
-  local Log = require("yazi.log")
-  if context then
-    Log:debug("Revealing path in yazi context: " .. vim.inspect(path))
-
-    require("yazi.process.retry").retry({
-      description = "Revealing path in yazi context",
-      delay = 50,
-      retries = 10,
-      action = function()
-        local job = context.api:reveal(path)
-        local completed = job:wait(1000)
-
-        assert(completed.code == 0)
-        return nil
-      end,
-    })
-  else
-    Log:debug("No active yazi context found")
+  if not context then
+    error("No active yazi context found. Is yazi running?")
   end
+
+  Log:debug("Revealing path in yazi context: " .. vim.inspect(path))
+
+  local attempts = 20
+  local interval_ms = 100
+  for _ = 1, attempts do
+    context.api:reveal(path)
+    local hovered = vim.wait(interval_ms, function()
+      return context.ya_process.hovered_url == path
+    end, 20)
+    if hovered then
+      return
+    end
+  end
+
+  error(
+    string.format(
+      "Timed out waiting for yazi to hover '%s'. Last hovered url: '%s'",
+      path,
+      tostring(context.ya_process.hovered_url)
+    )
+  )
 end
 
-print("Yazi: Loaded custom command to reveal a file")
+return M

--- a/integration-tests/tui-sandbox.config.ts
+++ b/integration-tests/tui-sandbox.config.ts
@@ -1,6 +1,8 @@
 import { createDefaultConfig } from "@tui-sandbox/library/dist/src/server/config.js"
 import type { TestServerConfig } from "@tui-sandbox/library/dist/src/server/index.js"
 
+process.env.MISE_YES = "1"
+
 export const config: TestServerConfig = createDefaultConfig(
   process.cwd(),
   process.env,

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -211,8 +211,15 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
 
   for _, event in ipairs(events) do
     if self.ready ~= true and event.type == "hey" then
-      ---@cast event YaziHeyEvent
-      if event.yazi_id == self.yazi_id then
+      ---@cast event YaziRawHeyEvent
+      -- The `hey` handshake is sent by whichever instance acts as the DDS
+      -- server, so `event.yazi_id` (the sender) is not necessarily our yazi.
+      -- Instead, detect the readiness of our yazi by looking for its client-id
+      -- in the peer list. This is robust even when other yazi instances are
+      -- running on the system. The peers are parsed lazily here as we only
+      -- need to do this once.
+      local peers = utils.parse_hey_peers(event.raw_data)
+      if peers[self.yazi_id] == true then
         Log:debug(
           string.format("ya process is ready, yazi_id: %s", self.yazi_id)
         )

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -227,7 +227,13 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
         self.on_first_output()
         self.on_first_output = nil
       end
-    elseif event.type == "hover" then
+    elseif event.type == "hover" and event.yazi_id == self.yazi_id then
+      -- Only track hovers from our own yazi. The DDS bus is shared across all
+      -- yazi instances on the system, so other instances (e.g. another yazi
+      -- the user has open, or a not-yet-exited one from a previous test) also
+      -- broadcast `hover` events. Honoring them would corrupt our
+      -- `hovered_url`. The `cd` handler below filters by `yazi_id` for the
+      -- same reason.
       ---@cast event YaziHoverEvent
       Log:debug(
         string.format(

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -83,7 +83,7 @@
 ---@field public hovered_buffer? vim.api.keyset.highlight # the color of a buffer that is hovered over in yazi
 ---@field public hovered_buffer_in_same_directory? vim.api.keyset.highlight # the color of a buffer that is in the same directory as the hovered buffer
 
----@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziBulkRenameEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent | YaziHeyEvent
+---@alias YaziEvent YaziRenameEvent | YaziMoveEvent | YaziDeleteEvent | YaziTrashEvent | YaziChangeDirectoryEvent | YaziHoverEvent | YaziBulkEvent | YaziBulkRenameEvent | YaziCustomDDSEvent | YaziNvimCycleBufferEvent | YaziRawHeyEvent
 
 ---@class (exact) YaziPreviousState # describes the previous state of yazi when it was closed; the last known state
 ---@field public last_hovered? string
@@ -125,9 +125,10 @@
 ---@field public type "hover"
 ---@field public url string
 
----@class (exact) YaziHeyEvent
----@field public yazi_id string
+---@class (exact) YaziRawHeyEvent
+---@field public yazi_id string # the client-id of the *sender* of the handshake (the DDS server), not necessarily our yazi
 ---@field public type "hey"
+---@field public raw_data string # the raw JSON payload. This is parsed lazily when needed.
 
 ---@class (exact) YaziBulkEvent "Like `rename` and `move` but for bulk renaming"
 ---@field public type "bulk"

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -371,10 +371,19 @@ function M.parse_events(event_lines)
     elseif type == "hey" then
       -- example of a hey event:
       -- hey,0,69016966727041,{"peers":{"1745849494365272":{"abilities":["hey"]},"69016966727041":{"abilities":["dds-emit","@yank","extract"]},"1745849492676175":{"abilities":["hover","move","hey","bulk","cd","delete","rename","trash","nvim-cycle-buffer"]}},"version":"25.4.8 VERGEN_IDEMPOTENT_OUTPUT"}
-      ---@type YaziHeyEvent
+      --
+      -- NOTE: the third field (`yazi_id`) is the *sender* of the handshake,
+      -- which is the DDS server and not necessarily our yazi. The `peers` map
+      -- is keyed by client-id and lists every connected client, including our
+      -- yazi (started with `--client-id <yazi_id>`). To detect our yazi
+      -- reliably we look it up in `peers`, not in the sender field.
+      --
+      ---@type YaziRawHeyEvent
       local event = {
         yazi_id = yazi_id,
         type = type,
+        -- parsed only when needed
+        raw_data = table.concat(parts, ",", 4, #parts),
       }
       table.insert(events, event)
     else
@@ -414,6 +423,23 @@ function M.safe_parse_events(event_lines)
   end
 
   return events
+end
+
+---Parse the set of connected client-ids ("peers") from the raw JSON payload of
+---a `hey` handshake event.
+---@param raw_data string # the JSON payload of a `hey` event
+---@return table<string, boolean>
+function M.parse_hey_peers(raw_data)
+  ---@type table<string, boolean>
+  local peers = {}
+  local ok, json = pcall(vim.json.decode, raw_data)
+  if ok and json ~= nil and json.peers ~= nil then
+    for peer_id, _ in pairs(json.peers) do
+      peers[peer_id] = true
+    end
+  end
+
+  return peers
 end
 
 ---@return RenameableBuffer[]

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 [tools]
+"github:EmmyLuaLs/emmylua-analyzer-rust" = "0.23.1"
+fzf = "0.73.1"
 # fd is a dependency of telescope and fzf-lua
-"github:EmmyLuaLs/emmylua-analyzer-rust" = { version = "0.23.2", asset_pattern = "emmylua_ls-*" }
-"github:junegunn/fzf" = "0.73.1"
-"github:sharkdp/fd" = "10.4.2"
+fd = "10.4.2"
 lua = "5.1"
 # ripgrep is a dependency of telescope and fzf-lua
-"github:BurntSushi/ripgrep" = { version = "15.1.0", exe = "rg" }
+ripgrep = { version = "15.1.0", exe = "rg" }
 "github:JohnnyMorganz/stylua" = "2.5.2"
 "github:rvben/rumdl" = "0.2.14"
 actionlint = "1.7.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
       '@tui-sandbox/library':
-        specifier: 12.5.4
-        version: 12.5.4(cypress@15.16.0)(prettier@3.8.3)(type-fest@5.7.0)(typescript@6.0.3)(wait-on@9.0.10)(zod@4.4.3)
+        specifier: 12.6.0
+        version: 12.6.0(cypress@15.16.0)(prettier@3.8.3)(type-fest@5.7.0)(typescript@6.0.3)(wait-on@9.0.10)(zod@4.4.3)
       '@types/node':
         specifier: 24.13.1
         version: 24.13.1
@@ -91,7 +91,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 8.61.0
-        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       wait-on:
         specifier: 9.0.10
         version: 9.0.10
@@ -216,158 +216,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -872,8 +872,8 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@12.5.4':
-    resolution: {integrity: sha512-PLcO90yxt+Di71otrVa/kT/336e2n3hGC1XIfGRbqyArUP8aOH0Ymun/dqk/29sDIOnD+tLtDBQ5BlM7/0RATg==}
+  '@tui-sandbox/library@12.6.0':
+    resolution: {integrity: sha512-DdubiBRTlstyhB8/cUgyGN7DGXroNb9p5bD3Xslu5POXk4z35KeAsFG4cq+onemmLLt5uoaMMLLiL6bZas7CKg==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
@@ -1194,11 +1194,6 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   conventional-changelog-angular@8.3.0:
     resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
     engines: {node: '>=18'}
@@ -1349,8 +1344,8 @@ packages:
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2091,10 +2086,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
-
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
@@ -2263,8 +2254,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2408,8 +2399,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zigpty@0.1.6:
-    resolution: {integrity: sha512-0B+6Xa4mKgyTNMq87HoGEUb30jQ08DZLEshSlgXPvUv+GB3E0zuTM+IUuYqe0CiaZyaZvCyx9snvGqxIKhl0sA==}
+  zigpty@0.2.0:
+    resolution: {integrity: sha512-rEn53TjljnMVzuCi5Rx9/Do0iZkq6y+71BMOX7tBVD2DSfOyCEKobNRXHWBUkC38g3nLjSaPU2bB/hLALY7HYg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2593,82 +2584,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.2':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.2':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.2':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.2':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.2':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.2':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.2':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.2':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.2':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.2':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.2':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.2':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.2':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.2':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.2':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.2':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.2':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.2':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.2':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.2':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.2':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.2':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.2':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.2':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.2':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))':
@@ -2967,7 +2958,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@tui-sandbox/library@12.5.4(cypress@15.16.0)(prettier@3.8.3)(type-fest@5.7.0)(typescript@6.0.3)(wait-on@9.0.10)(zod@4.4.3)':
+  '@tui-sandbox/library@12.6.0(cypress@15.16.0)(prettier@3.8.3)(type-fest@5.7.0)(typescript@6.0.3)(wait-on@9.0.10)(zod@4.4.3)':
     dependencies:
       '@catppuccin/palette': 1.8.0
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
@@ -2976,7 +2967,7 @@ snapshots:
       '@xterm/addon-fit': 0.11.0
       '@xterm/addon-unicode11': 0.9.0
       '@xterm/xterm': 6.0.0
-      concurrently: 9.2.1
+      concurrently: 10.0.3
       cors: 2.8.6
       cypress: 15.16.0
       dree: 5.1.5
@@ -2984,12 +2975,12 @@ snapshots:
       prettier: 3.8.3
       sirv: 3.0.2
       string-width: 8.2.1
-      tsx: 4.21.0
+      tsx: 4.22.4
       type-fest: 5.7.0
       typescript: 6.0.3
       wait-on: 9.0.10
       winston: 3.19.0
-      zigpty: 0.1.6
+      zigpty: 0.2.0
       zod: 4.4.3
 
   '@tybys/wasm-util@0.10.2':
@@ -3017,12 +3008,12 @@ snapshots:
 
   '@types/triple-beam@1.3.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.0
       eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
@@ -3033,7 +3024,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
@@ -3063,7 +3054,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
@@ -3324,15 +3315,6 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 18.0.0
 
-  concurrently@9.2.1:
-    dependencies:
-      chalk: 4.1.2
-      rxjs: 7.8.2
-      shell-quote: 1.8.3
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
-
   conventional-changelog-angular@8.3.0:
     dependencies:
       compare-func: 2.0.0
@@ -3510,34 +3492,34 @@ snapshots:
 
   es-toolkit@1.46.1: {}
 
-  esbuild@0.27.2:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -4296,8 +4278,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
-
   shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
@@ -4462,10 +4442,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.21.0:
+  tsx@4.22.4:
     dependencies:
-      esbuild: 0.27.2
-      get-tsconfig: 4.14.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -4485,10 +4464,10 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript-eslint@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3):
+  typescript-eslint@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
@@ -4638,6 +4617,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zigpty@0.1.6: {}
+  zigpty@0.2.0: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
 allowBuilds:
   cypress: true
   esbuild: true
+minimumReleaseAgeExclude:
+  - "@tui-sandbox/library@12.6.0"
 saveExact: true
 
 # https://pnpm.io/pnpm-workspace_yaml

--- a/spec/yazi/read_events_spec.lua
+++ b/spec/yazi/read_events_spec.lua
@@ -175,4 +175,36 @@ describe("parsing yazi event file events", function()
       },
     } --[[@as YaziHoverEvent[] ]])
   end)
+
+  it("can parse hey events, keeping the raw payload", function()
+    local payload =
+      '{"peers":{"1781852712628265":{"abilities":["bulk","move","hey","cd","hover"]},"263042799271791":{"abilities":["dds-exec","dds-emit","extract"]},"1781852081177795":{"abilities":["hey","hi"]}},"version":"26.5.6 ab8d634f"}'
+    local data = { "hey,0,263042799271791," .. payload }
+
+    local events = utils.parse_events(data)
+
+    assert.are.same({
+      {
+        type = "hey",
+        yazi_id = "263042799271791",
+        raw_data = payload,
+      },
+    } --[[@as YaziRawHeyEvent[] ]], events)
+  end)
+
+  it("can parse the connected peers from a hey event payload", function()
+    local payload =
+      '{"peers":{"1781852712628265":{"abilities":["bulk","move","hey","cd","hover"]},"263042799271791":{"abilities":["dds-exec","dds-emit","extract"]},"1781852081177795":{"abilities":["hey","hi"]}},"version":"26.5.6 ab8d634f"}'
+
+    assert.are.same({
+      ["1781852712628265"] = true,
+      ["263042799271791"] = true,
+      ["1781852081177795"] = true,
+    }, utils.parse_hey_peers(payload))
+  end)
+
+  it("returns no peers when a hey payload is malformed", function()
+    assert.are.same({}, utils.parse_hey_peers("not json"))
+    assert.are.same({}, utils.parse_hey_peers('{"version":"26.5.6"}'))
+  end)
 end)


### PR DESCRIPTION
# test: make hovering files more robust

Poll the entire operation instead of just the result.

Instead of:

1. telling yazi to hover a file
2. polling for it to have reported hovering it

Do:

1. tell yazi to hover another file, poll until it reports hovering it
2. tell yazi to hover the desired file, poll until it reports hovering it

# fix: only track hover events from our own yazi instance

Something has changed in the e2e test environment - maybe neovim/yazi being closed (killed) leaves some yazi/ya/nvim related processes or state running in the background.

- we seem to be getting leftover `hover` events from a previous test run there https://github.com/mikavilpas/yazi.nvim/actions/runs/27813700469/job/82309668617?pr=1943
- these overwrite the `hovered_url` state in the current test run, causing the test to fail when it tries to assert on the hovered URL

# test: allow detecting yazi readiness even if multiple yazis run

**Issue:**

Currently in the tests, when yazi and ya are started, we need to wait for yazi to become ready before we can proceed with the test. This is done by waiting for a `hey` event from the yazi, which is the response of the DDS handshake protocol.

However, if multiple yazi instances are running on the system, the sender of the `hey` event is not necessarily our yazi. In this case, the test keeps waiting until it fails.

**Solution:**

Detect the readiness of our yazi by looking for its client-id in the peer list of the `hey` event instead. This is more robust as the peer list includes every connected yazi.

# test: add waiting time to reduce flakiness

# test: prevent mise from activating and disturbing the tests

# test: fix emmylua_ls installation being invalid

It looked like the tool was installed but for the wrong platform. It seems to work without the previous magic now, so let's try that.

---

# Pull request stack

- 👉🏻 **[#1943](https://github.com/mikavilpas/yazi.nvim/pull/1943)** | test: rescue clogged up test pipeline 🙏🏻 👈🏻