### PR TITLE
refactor(ci): hide neovim nightly build+restore inside the actions

### DIFF
--- a/.github/actions/download-neovim-nightly/action.yml
+++ b/.github/actions/download-neovim-nightly/action.yml
@@ -1,0 +1,59 @@
+---
+name: "Download pinned Neovim nightly"
+description: >-
+  Download and extract the pinned Neovim nightly artifact published by the
+  companion `setup-neovim-nightly` action, exposing its install prefix so jobs
+  can use the pinned build without rebuilding it.
+
+inputs:
+  artifact-name:
+    description: "Name of the workflow artifact to download the build from."
+    required: false
+    default: neovim-nightly
+  commit:
+    description:
+      "The expected https://github.com/neovim/neovim commit. When set, the
+      extracted Neovim is asserted to report this commit, so a mismatched or
+      stale artifact fails loudly instead of being tested silently."
+    required: false
+
+outputs:
+  prefix:
+    description:
+      "Install prefix of the extracted Neovim (binary at <prefix>/bin/nvim)."
+    value: ${{ steps.config.outputs.prefix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve install prefix
+      id: config
+      shell: bash
+      run: echo "prefix=${{ runner.temp }}/neovim-nightly" >> "$GITHUB_OUTPUT"
+
+    - name: Download pinned Neovim nightly
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/neovim-nightly-artifact
+
+    - name: Extract pinned Neovim nightly
+      shell: bash
+      env:
+        NEOVIM_COMMIT: ${{ inputs.commit }}
+        NEOVIM_PREFIX: ${{ steps.config.outputs.prefix }}
+      run: |
+        mkdir -p "$NEOVIM_PREFIX"
+        tar -xzf "${{ runner.temp }}/neovim-nightly-artifact/neovim-nightly.tar.gz" -C "$NEOVIM_PREFIX"
+        "$NEOVIM_PREFIX/bin/nvim" --version
+
+        # When a commit is given, assert the extracted Neovim reports it, so a
+        # mismatched or stale artifact fails loudly instead of being tested
+        # silently.
+        if [ -n "$NEOVIM_COMMIT" ]; then
+          short="$(printf '%s' "$NEOVIM_COMMIT" | cut -c1-7)"
+          "$NEOVIM_PREFIX/bin/nvim" --version | grep --quiet "$short" || {
+            echo "Extracted Neovim does not report the expected commit $NEOVIM_COMMIT (looked for $short)"
+            exit 1
+          }
+        fi

--- a/.github/actions/setup-neovim-nightly/action.yml
+++ b/.github/actions/setup-neovim-nightly/action.yml
@@ -1,5 +1,5 @@
 ---
-name: "Set up pinned Neovim nightly"
+name: "Build pinned Neovim nightly"
 description: >-
   Issue:
 
@@ -13,12 +13,20 @@ description: >-
   bump the nightly commit in a controlled manner, allowing for reproducible
   builds.
 
+  This action builds the pinned nightly once and uploads it as a workflow
+  artifact. Use the companion `download-neovim-nightly` action to download and
+  extract it in jobs that need it, instead of rebuilding it on a cache miss.
+
 inputs:
   commit:
     description:
       "The https://github.com/neovim/neovim commit (on the master branch) to
       build."
     required: true
+  artifact-name:
+    description: "Name of the workflow artifact to publish the build under."
+    required: false
+    default: neovim-nightly
 
 outputs:
   prefix:
@@ -82,3 +90,16 @@ runs:
           echo "Built Neovim does not report the pinned commit $NEOVIM_COMMIT (looked for $short)"
           exit 1
         }
+
+    - name: Package Neovim nightly
+      shell: bash
+      env:
+        NEOVIM_PREFIX: ${{ steps.config.outputs.prefix }}
+      run: tar -czf neovim-nightly.tar.gz -C "$NEOVIM_PREFIX" .
+
+    - name: Upload Neovim nightly artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: neovim-nightly.tar.gz
+        retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Build pinned Neovim nightly
-        id: neovim
         uses: ./.github/actions/setup-neovim-nightly
         with:
           commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
-      - name: Package Neovim nightly
-        env:
-          NEOVIM_PREFIX: ${{ steps.neovim.outputs.prefix }}
-        run: tar -czf neovim-nightly.tar.gz -C "$NEOVIM_PREFIX" .
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: neovim-nightly
-          path: neovim-nightly.tar.gz
-          retention-days: 1
 
   build:
     name:
@@ -135,20 +125,11 @@ jobs:
           ya --version
 
       - name: Download pinned Neovim nightly
-        if: matrix.neovim.name == 'nightly'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: neovim-nightly
-          path: ${{ runner.temp }}/neovim-nightly-artifact
-
-      - name: Extract pinned Neovim nightly
         id: neovim-nightly
         if: matrix.neovim.name == 'nightly'
-        run: |
-          prefix="${{ runner.temp }}/neovim-nightly"
-          mkdir -p "$prefix"
-          tar -xzf "${{ runner.temp }}/neovim-nightly-artifact/neovim-nightly.tar.gz" -C "$prefix"
-          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/download-neovim-nightly
+        with:
+          commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:


### PR DESCRIPTION
# refactor(ci): hide neovim nightly build+restore inside the actions

---

# Pull request stack

- 👉🏻 **[#1950](https://github.com/mikavilpas/yazi.nvim/pull/1950)** | refactor(ci): hide neovim nightly build+restore inside the actions 👈🏻