### PR TITLE
ci: assert exact neovim nightly version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,12 @@ jobs:
             # instead of the Neovim the action just installed.
             if [ "${{ matrix.neovim.name }}" = "nightly" ]; then
               echo "${{ steps.neovim-nightly.outputs.prefix }}/bin" >> "$GITHUB_PATH"
+              SHORT="$(printf '%s' "$NEOVIM_COMMIT" | cut -c1-7)"
+              nvim --version
+              nvim --version | grep --quiet "$short" || {
+                echo "Extracted Neovim does not report the expected commit $NEOVIM_COMMIT (looked for $short)"
+                exit 1
+              }
             fi
             # copied from mise.toml
             luarocks init --no-gitignore


### PR DESCRIPTION
# ci: assert exact neovim nightly version

**Issue:**

The build for neovim nightly is difficult to ensure to be using the correct nvim nightly version.

**Solution:**

Add a tripwire to the nightly build to check that the extracted neovim nightly version is the same as the pinned version.

This will make it obvious if some future change makes them to drift - the intention should be preserved this way.

---

# Pull request stack

- 👉🏻 **[#1972](https://github.com/mikavilpas/yazi.nvim/pull/1972)** | ci: assert exact neovim nightly version 👈🏻