### PR TITLE
refactor(ci): use mikavilpas/neovim-action/busted action

### DIFF
--- a/.busted
+++ b/.busted
@@ -2,7 +2,7 @@ return {
   _all = {
     coverage = false,
     lpath = "lua/?.lua;lua/?/init.lua",
-    lua = "./lua_modules/bin/nlua",
+    lua = "nlua",
   },
   default = {
     verbose = true,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,11 +125,17 @@ jobs:
           ya --version
 
       - name: Download pinned Neovim nightly
-        id: neovim-nightly
         if: matrix.neovim.name == 'nightly'
         uses: mikavilpas/neovim-action/restore-nightly@673c9715ab356c92820355ad99d7c23ca564da0c # v3.2.0
         with:
           commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
+
+      - name: Install stable Neovim
+        if: matrix.neovim.name == 'stable'
+        uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1.6.1
+        with:
+          neovim: true
+          version: stable
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -142,37 +148,20 @@ jobs:
       - run: pnpm install
 
       - name: Run tests
-        uses: nvim-neorocks/nvim-busted-action@bbcfe82d35b8fb4660ef6ed4124e1fd9cef4688b # v1.2.0
+        # Neovim-agnostic: it tests against whatever `nvim` is already on PATH
+        # (the pinned nightly restored above, or the stable Neovim installed
+        # above), installs busted + nlua, and runs `luarocks test`.
+        uses: mikavilpas/neovim-action/busted@673c9715ab356c92820355ad99d7c23ca564da0c # v3.2.0
         with:
-          # This action MUST install a neovim by design. For nightly neovim we
-          # want to use our own pinned build, so the action only needs to
-          # install a real Neovim for the `stable` case.
-          nvim_version:
-            ${{ matrix.neovim.name == 'nightly' && 'stable' ||
-            matrix.neovim.name }}
-          luarocks_version: "3.11.1"
-          before: |
-            # The pinned action runs `rhysd/action-setup-vim` before this
-            # `before` hook, and the `luarocks test` run after it. Prepending our
-            # pinned nightly to PATH here therefore makes nlua/busted use it
-            # instead of the Neovim the action just installed.
-            if [ "${{ matrix.neovim.name }}" = "nightly" ]; then
-              prefix="${{ steps.neovim-nightly.outputs.prefix }}/bin"
-              # `>> "$GITHUB_PATH"` only affects *subsequent* steps
-              export PATH="$prefix:$PATH"
-              echo "$prefix" >> "$GITHUB_PATH"
-              short="${{ steps.neovim-nightly.outputs.short-commit }}"
-              echo "nvim resolves to: $(command -v nvim)"
-              nvim --version
-              nvim --version | grep --quiet "$short" || {
-                echo "Extracted Neovim does not report the expected commit $NEOVIM_NIGHTLY_COMMIT (looked for $short)"
-                exit 1
-              }
-            fi
-            # copied from mise.toml
-            luarocks init --no-gitignore
-            luarocks install busted 2.2.0-1
-            luarocks install nlua 0.3.2-1
+          # Hosted runners expose ImageVersion, so fail loudly if the cache key
+          # ever degrades.
+          strict: "true"
+          # `luarocks test` installs the test framework (busted/nlua) but NOT
+          # the plugin's runtime dependencies (plenary.nvim, declared in the
+          # rockspec), so install those into the same --local tree first.
+          before:
+            luarocks --lua-version 5.1 make --local --only-deps
+            yazi.nvim-scm-1.rockspec
 
       - name: Verify that dependencies are available
         run: |
@@ -212,4 +201,3 @@ jobs:
           name: cypress-screenshots
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,20 +148,7 @@ jobs:
       - run: pnpm install
 
       - name: Run tests
-        # Neovim-agnostic: it tests against whatever `nvim` is already on PATH
-        # (the pinned nightly restored above, or the stable Neovim installed
-        # above), installs busted + nlua, and runs `luarocks test`.
         uses: mikavilpas/neovim-action/busted@673c9715ab356c92820355ad99d7c23ca564da0c # v3.2.0
-        with:
-          # Hosted runners expose ImageVersion, so fail loudly if the cache key
-          # ever degrades.
-          strict: "true"
-          # `luarocks test` installs the test framework (busted/nlua) but NOT
-          # the plugin's runtime dependencies (plenary.nvim, declared in the
-          # rockspec), so install those into the same --local tree first.
-          before:
-            luarocks --lua-version 5.1 make --local --only-deps
-            yazi.nvim-scm-1.rockspec
 
       - name: Verify that dependencies are available
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,13 @@ ripgrep = { version = "15.1.0", exe = "rg" }
 actionlint = "1.7.12"
 zizmor = "1.26.1"
 
+[env]
+# busted/nlua live in this project's own luarocks tree (`luarocks init` ->
+# ./lua_modules), isolated from other projects on the machine so their rock
+# versions cannot conflict. Put its bin on PATH so `.busted`'s `lua = "nlua"`
+# resolves locally. In CI, mikavilpas/neovim-action/busted provides nlua on
+# PATH instead (an ephemeral runner has no other projects to conflict with).
+_.path = ["lua_modules/bin"]
 [tasks]
 test = "luarocks test --local"
 test-focus = "luarocks test --local -- --filter focus"


### PR DESCRIPTION
# refactor(ci): use mikavilpas/neovim-action/busted action

**Issue:**

The old nvim-neorocks/nvim-busted-action (https://github.com/lumen-oss/nvim-busted-action) has a couple of issues:

- it can only install a neovim version from a tag, or the newest nightly. It does not support a pinned nightly commit, which is what we want to test against. Currently I have partially abandoned its design by using https://github.com/mikavilpas/neovim-action/blob/main/build-nightly/action.yml, but there are PATH fragilities that I need to work around - it does not exactly spark joy
- caching does not seem to work correctly, lots of cache misses
- it is slower than necessary as it compiles both lua (https://github.com/lumen-oss/nvim-busted-action/blob/bbcfe82d35b8fb4660ef6ed4124e1fd9cef4688b/action.yml#L58) and luarocks (https://github.com/lumen-oss/nvim-busted-action/blob/bbcfe82d35b8fb4660ef6ed4124e1fd9cef4688b/action.yml#L63) on every run
- its dependencies are not pinned, and some track outdated versions such as `actions/cache@v3` while the newest is 6 (https://github.com/lumen-oss/nvim-busted-action/blob/bbcfe82d35b8fb4660ef6ed4124e1fd9cef4688b/action.yml#L33)

**Solution:**

Use a new https://github.com/mikavilpas/neovim-action/ which solves there problems.

---

# Pull request stack

- 👉🏻 **[#1982](https://github.com/mikavilpas/yazi.nvim/pull/1982)** | refactor(ci): use mikavilpas/neovim-action/busted action 👈🏻