### PR TITLE
ci: split tests into separate jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,43 @@ jobs:
         with:
           commit: ${{ env.YAZI_NIGHTLY_COMMIT }}
 
-  build:
+  busted:
+    name: "Busted (neovim ${{ matrix.neovim.name }})"
+    runs-on: ubuntu-24.04
+    needs:
+      - build-neovim-nightly
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        neovim:
+          - name: nightly
+          - name: stable
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download pinned Neovim nightly
+        if: matrix.neovim.name == 'nightly'
+        uses: mikavilpas/neovim-action/restore-nightly@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+        with:
+          commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
+
+      - name: Install stable Neovim
+        if: matrix.neovim.name == 'stable'
+        uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1.6.1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+
+  e2e:
     name:
-      "Test (neovim ${{ matrix.neovim.name }}, yazi ${{ matrix.yazi-version.name
+      "E2E (neovim ${{ matrix.neovim.name }}, yazi ${{ matrix.yazi-version.name
       }})"
     runs-on: ubuntu-24.04
     needs:
@@ -136,9 +170,6 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
-
-      - name: Run tests
-        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
 
       - name: Verify that dependencies are available
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,3 +209,26 @@ jobs:
           name: cypress-screenshots
           path: integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+
+  ci:
+    name: ci
+    if: ${{ always() }}
+    needs:
+      - build-neovim-nightly
+      - build-yazi-nightly
+      - busted
+      - e2e
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Verify all required jobs succeeded
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: |
+          echo "One or more required jobs did not succeed."
+          exit 1

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -1,6 +1,7 @@
 local assert = require("luassert")
 local ya_process = require("yazi.process.ya_process")
 local spy = require("luassert.spy")
+local stub = require("luassert.stub")
 
 local yazi_id = "yazi_id_123"
 
@@ -346,6 +347,12 @@ describe("opening yazi in a terminal", function()
       end)
       local jobstart_spy = spy.new(function() end)
       vim.fn.jobstart = jobstart_spy
+
+      -- starting the yazi process also spawns the `ya` command line tool via
+      -- `vim.system`. Mock it.
+      stub(vim, "system", function()
+        return {}
+      end)
 
       require("yazi.process.yazi_process"):start(config, { path }, {
         on_exit = function() end,

--- a/spec/yazi/yazi_spec.lua
+++ b/spec/yazi/yazi_spec.lua
@@ -4,6 +4,7 @@ local assert = require("luassert")
 local mock = require("luassert.mock")
 local match = require("luassert.match")
 local spy = require("luassert.spy")
+local stub = require("luassert.stub")
 local test_files = require("spec.yazi.helpers.test_files")
 package.loaded["yazi.process.yazi_process"] =
   require("spec.yazi.helpers.fake_yazi_process")
@@ -12,10 +13,27 @@ local yazi_process = require("yazi.process.yazi_process")
 
 local plugin = require("yazi")
 
+local snapshot
+
 before_each(function()
   local reset = require("spec.yazi.helpers.reset")
   reset.clear_all_buffers()
   reset.close_all_windows()
+
+  snapshot = assert:snapshot()
+
+  -- `require("yazi").yazi()` bails out early unless the `yazi` and `ya`
+  -- executables are found on the PATH.
+  stub(vim.fn, "executable", function(command)
+    if command == "yazi" or command == "ya" then
+      return 1
+    end
+    return 0
+  end)
+end)
+
+after_each(function()
+  snapshot:revert()
 end)
 
 describe("opening a file", function()


### PR DESCRIPTION
# ci: add "ci successful" gate job for easy required job maintenance

# ci: split tests into separate jobs

**Issue:**

Currently the busted tests and the e2e tests are run in the same job. Both of them need to wait for both nightly neovim and nightly yazi to be built, even though the busted tests only need nightly neovim, and the e2e tests need both.

**Solution:**

Split the tests into two separate jobs and require only the necessary dependencies for each job.

# test(busted): don't depend on the `ya` app

---

# Pull request stack

- 👉🏻 **[#1997](https://github.com/mikavilpas/yazi.nvim/pull/1997)** | ci: split tests into separate jobs 👈🏻