### PR TITLE
feat: start nvim.yazi plugin for yazi-owned keymaps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,10 @@ jobs:
         with:
           install: false
           command: pnpm tui run
+        env:
+          # The tests related to nvim.yazi can only be run in a modern yazi nightly.
+          # Gate on this to avoid failures on older yazis.
+          YAZI_IS_NIGHTLY: ${{ matrix.yazi-version.name == 'nightly' }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # add the line below to store screenshots only on failures

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -81,6 +81,10 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("yazi/"),
           type: z.literal("directory"),
           contents: z.object({
+            "init.lua": z.object({
+              name: z.literal("init.lua"),
+              type: z.literal("file"),
+            }),
             "keymap.toml": z.object({
               name: z.literal("keymap.toml"),
               type: z.literal("file"),
@@ -157,6 +161,10 @@ export const MyTestDirectorySchema = z.object({
             }),
             "enable_change_neovim_cwd_on_close.lua": z.object({
               name: z.literal("enable_change_neovim_cwd_on_close.lua"),
+              type: z.literal("file"),
+            }),
+            "enable_yazi_plugin_keymaps.lua": z.object({
+              name: z.literal("enable_yazi_plugin_keymaps.lua"),
               type: z.literal("file"),
             }),
             "highlight_buffers_in_same_directory.lua": z.object({
@@ -341,6 +349,7 @@ export const testDirectoryFiles = z.enum([
   ".config/nvim_integrations",
   ".config/nvim_no_package_manager/init.lua",
   ".config/nvim_no_package_manager",
+  ".config/yazi/init.lua",
   ".config/yazi/keymap.toml",
   ".config/yazi",
   ".config",
@@ -359,6 +368,7 @@ export const testDirectoryFiles = z.enum([
   "config-modifications/yazi_config/customize_window_properties.lua",
   "config-modifications/yazi_config/disable_a_keybinding.lua",
   "config-modifications/yazi_config/enable_change_neovim_cwd_on_close.lua",
+  "config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua",
   "config-modifications/yazi_config/highlight_buffers_in_same_directory.lua",
   "config-modifications/yazi_config/log_yazi_closed_successfully.lua",
   "config-modifications/yazi_config/make_yazi_fullscreen.lua",

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -10,9 +10,16 @@ const yaziLogFile = path.resolve(__dirname, "test-environment/.repro/yazi.log")
 
 console.log(`yaziLogFile: ${yaziLogFile}`)
 
+const isCI = process.env.CI === "true" || process.env.CI === "1"
+const runNvimYaziPluginTests = !isCI || process.env.YAZI_IS_NIGHTLY === "true"
+
 export default defineConfig({
   e2e: {
     allowCypressEnv: false,
+    expose: {
+      // allow some tests to only run when a nightly yazi is available
+      runNvimYaziPluginTests,
+    },
     baseUrl: "http://localhost:3000",
     video: true,
     setupNodeEvents(on, _config) {

--- a/integration-tests/cypress/e2e/integrations.cy.ts
+++ b/integration-tests/cypress/e2e/integrations.cy.ts
@@ -65,6 +65,7 @@ describe("grug-far integration (search and replace)", () => {
       cy.typeIntoTerminal("vj")
       cy.typeIntoTerminal("{control+g}")
 
+      cy.contains("Grug FAR")
       cy.typeIntoTerminal("ithis")
       cy.typeIntoTerminal("{esc}")
 

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -1,0 +1,61 @@
+import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
+import { hoverFileAndVerifyItsHovered } from "../utils/hover-utils.ts"
+import {
+  assertYaziIsReady,
+  isFileNotSelectedInYazi,
+} from "../utils/yazi-utils.ts"
+import {
+  assertNvimYaziPluginIndicatorIsVisible,
+  describeOnNightlyYazi,
+} from "./yazi-plugin-utils.ts"
+
+describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
+  beforeEach(() => {
+    cy.visit("/")
+  })
+
+  it("<c-v> can open a file in a vertical split", () => {
+    cy.startNeovim({
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "yazi_config/enable_yazi_plugin_keymaps.lua",
+      ],
+    }).then((nvim) => {
+      cy.contains("If you see this text, Neovim is ready!")
+      cy.typeIntoTerminal("{upArrow}")
+      assertYaziIsReady(nvim)
+      isFileNotSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
+      hoverFileAndVerifyItsHovered(nvim, "file2.txt")
+      assertNvimYaziPluginIndicatorIsVisible()
+
+      // <c-v> is now owned by yazi (via the nvim.yazi plugin). Pressing it
+      // publishes a DDS event that yazi.nvim reacts to by opening the hovered
+      // file in a vertical split - exactly like the terminal-map version.
+      cy.typeIntoTerminal("{control+v}")
+
+      // yazi should now be closed
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      // both files must be visible (side by side in splits)
+      cy.contains(nvim.dir.contents["file2.txt"].name)
+      cy.contains(nvim.dir.contents["initial-file.txt"].name)
+    })
+  })
+
+  it("keymaps are documented in yazi's help view", () => {
+    cy.startNeovim({
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "yazi_config/enable_yazi_plugin_keymaps.lua",
+      ],
+    }).then((nvim) => {
+      cy.contains("If you see this text, Neovim is ready!")
+      cy.typeIntoTerminal("{upArrow}")
+      assertYaziIsReady(nvim)
+      assertNvimYaziPluginIndicatorIsVisible()
+
+      cy.typeIntoTerminal("~")
+      cy.contains("yazi.nvim: open file in vertical split")
+    })
+  })
+})

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
@@ -1,0 +1,8 @@
+export const describeOnNightlyYazi = (title: string, fn: () => void): void => {
+  const runner: (title: string, fn: () => void) => void =
+    Cypress.expose("runNvimYaziPluginTests") === true ? describe : describe.skip
+  runner(title, fn)
+}
+
+export const assertNvimYaziPluginIndicatorIsVisible =
+  (): Cypress.Chainable<undefined> => cy.contains(String.fromCodePoint(0xf36f)) // nf-linux-neovim, ""

--- a/integration-tests/test-environment/.config/yazi/init.lua
+++ b/integration-tests/test-environment/.config/yazi/init.lua
@@ -1,0 +1,4 @@
+local ok, nvim_plugin = pcall(require, "nvim")
+if ok then
+  nvim_plugin:setup()
+end

--- a/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
@@ -1,0 +1,31 @@
+---@module "yazi"
+
+require("yazi").setup(
+  ---@type YaziConfig
+  {
+    future_features = {
+      yazi_plugin_keymaps = {
+        open_file_in_vertical_split = "<c-v>",
+      },
+    },
+  }
+)
+
+-- Make the bundled `nvim.yazi` plugin available to yazi by symlinking it into
+-- yazi's plugin directory. An absolute path (derived from the repo root) avoids
+-- the fragile relative symlinks that break when the test directory is
+-- materialized into a temporary location.
+-- selene: allow(global_usage)
+local repo_root = _G.yazi_nvim_repo_root
+  or vim.fn.fnamemodify(vim.uv.os_environ().HOME, ":h:h:h:h")
+
+local plugin_source = vim.fs.joinpath(repo_root, "nvim.yazi")
+local yazi_plugins_dir = vim.fn.expand("~/.config/yazi/plugins")
+vim.fn.mkdir(yazi_plugins_dir, "p")
+
+local link = vim.fs.joinpath(yazi_plugins_dir, "nvim.yazi")
+local existing = vim.uv.fs_lstat(link)
+if existing and existing.type == "link" then
+  vim.uv.fs_unlink(link)
+end
+vim.uv.fs_symlink(plugin_source, link)

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -16,6 +16,7 @@ function M.default()
     open_for_directories = false,
     future_features = {
       use_cwd_file = true,
+      yazi_plugin_keymaps = {},
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,
@@ -98,15 +99,26 @@ function M.set_keymappings(yazi_buffer, config, context)
     return
   end
 
-  if config.keymaps.open_file_in_vertical_split ~= false then
-    vim.keymap.set(
-      { "t" },
-      config.keymaps.open_file_in_vertical_split,
-      function()
-        keybinding_helpers.open_file_in_vertical_split(config, context.api)
-      end,
-      { buffer = yazi_buffer }
-    )
+  do
+    local vertical_split_owned_by_yazi = config.future_features.yazi_plugin_keymaps
+        ~= nil
+      and config.future_features.yazi_plugin_keymaps.open_file_in_vertical_split ~= nil
+      and config.future_features.yazi_plugin_keymaps.open_file_in_vertical_split
+        ~= false
+
+    if
+      config.keymaps.open_file_in_vertical_split ~= false
+      and not vertical_split_owned_by_yazi
+    then
+      vim.keymap.set(
+        { "t" },
+        config.keymaps.open_file_in_vertical_split,
+        function()
+          keybinding_helpers.open_file_in_vertical_split(config, context.api)
+        end,
+        { buffer = yazi_buffer }
+      )
+    end
   end
 
   if config.keymaps.open_file_in_horizontal_split ~= false then

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -102,4 +102,59 @@ function M.process_event_emitted_from_yazi(event, config, context)
   end
 end
 
+--- dispatch a keymap action that was triggered from inside yazi by the
+--- `nvim.yazi` plugin.
+---
+---@class yazi.PluginKeymapPayload
+---@field action string # the keymap action, e.g. "open_file_in_vertical_split"
+---@field yazi_id? string # the id of the yazi instance that sent the event
+---@field hovered? string # the currently hovered path, if any
+---@field selected? string[] # the currently selected paths
+---
+---@param event YaziCustomDDSEvent
+---@param expected_yazi_id string # only handle events from our own yazi instance
+---@param config YaziConfig
+---@param context YaziActiveContext
+function M.process_plugin_keymap_event(event, expected_yazi_id, config, context)
+  local Log = require("yazi.log")
+  local keybinding_helpers = require("yazi.keybinding_helpers")
+
+  local ok, payload = pcall(vim.json.decode, event.raw_data)
+  if not ok or type(payload) ~= "table" then
+    Log:debug(
+      string.format(
+        "Could not decode yazi-nvim event payload: %s",
+        vim.inspect(event.raw_data)
+      )
+    )
+    return
+  end
+  ---@cast payload yazi.PluginKeymapPayload
+
+  -- The DDS bus is shared across all yazi instances on the system. Only react
+  -- to events from our own yazi.
+  if payload.yazi_id ~= nil and payload.yazi_id ~= expected_yazi_id then
+    Log:debug(
+      string.format(
+        "Ignoring yazi-nvim event from a different yazi (%s, ours is %s)",
+        vim.inspect(payload.yazi_id),
+        expected_yazi_id
+      )
+    )
+    return
+  end
+
+  Log:debug(
+    string.format("Handling yazi-nvim plugin keymap event: %s", payload.action)
+  )
+
+  if payload.action == "open_file_in_vertical_split" then
+    keybinding_helpers.open_file_in_vertical_split(config, context.api)
+  else
+    Log:debug(
+      string.format("Unknown yazi-nvim plugin action: %s", payload.action)
+    )
+  end
+end
+
 return M

--- a/lua/yazi/plugin_keymaps.lua
+++ b/lua/yazi/plugin_keymaps.lua
@@ -1,0 +1,28 @@
+local M = {}
+
+-- The environment variable the serialized keymaps are passed through.
+M.env_var = "YAZI_NVIM_PLUGIN_KEYMAPS"
+
+--- Serialize `plugin_keymaps` into a string the `nvim.yazi` yazi plugin can parse.
+---
+--- yazi's plugin Lua sandbox has no JSON available, so a simple line/tab-delimited
+--- format is used: one record per line, fields separated by tabs
+--- (`on\taction\tdesc`). Yazi keys, action ids, and the generated descriptions
+--- never contain tabs or newlines, so the encoding is unambiguous. The records are
+--- sorted so the output is deterministic (nicer for tests and logs).
+---
+--- @param plugin_keymaps YaziPluginKeymaps
+--- @return string
+function M.serialize(plugin_keymaps)
+  local records = {}
+  for action, key in pairs(plugin_keymaps) do
+    if key ~= false and key ~= nil then
+      local desc = "yazi.nvim: " .. (action:gsub("_", " "))
+      records[#records + 1] = table.concat({ key, action, desc }, "\t")
+    end
+  end
+  table.sort(records)
+  return table.concat(records, "\n")
+end
+
+return M

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -121,6 +121,12 @@ function YaProcess:start(context)
     "hey",
   }
 
+  -- subscribe to the events published by the `nvim.yazi` plugin if the user
+  -- has enabled it.
+  if self.config.future_features.yazi_plugin_keymaps ~= nil then
+    event_kinds[#event_kinds + 1] = "yazi-nvim"
+  end
+
   ---@type table<string,boolean>
   local interesting_events = {}
   if self.config.forwarded_dds_events ~= nil then
@@ -266,6 +272,16 @@ function YaProcess:process_events(events, forwarded_event_kinds, context)
         ---@cast event YaziNvimCycleBufferEvent
         yazi_event_handling.process_event_emitted_from_yazi(
           event,
+          self.config,
+          context
+        )
+      end)
+    elseif event.type == "yazi-nvim" then
+      ---@cast event YaziCustomDDSEvent
+      vim.schedule(function()
+        yazi_event_handling.process_plugin_keymap_event(
+          event,
+          self.yazi_id,
           self.config,
           context
         )

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -49,14 +49,25 @@ function YaziProcess:start(config, paths, callbacks)
     input_path = paths[1],
   }
 
+  local env = {
+    -- expose NVIM_CWD so that yazi keybindings can use it to offer basic
+    -- neovim specific functionality
+    NVIM_CWD = vim.uv.cwd(),
+    YAZI_CONFIG_HOME = config.config_home,
+    YAZI_NVIM_ID = yazi_id,
+  }
+
+  -- hand the user-configured `plugin_keymaps` to the `nvim.yazi` plugin, which
+  -- registers them inside yazi at runtime.
+  if config.future_features.yazi_plugin_keymaps ~= nil then
+    local plugin_keymaps = require("yazi.plugin_keymaps")
+    env[plugin_keymaps.env_var] =
+      plugin_keymaps.serialize(config.future_features.yazi_plugin_keymaps)
+  end
+
   self.yazi_job_id = vim.fn.jobstart(yazi_cmd, {
     term = true,
-    env = {
-      -- expose NVIM_CWD so that yazi keybindings can use it to offer basic
-      -- neovim specific functionality
-      NVIM_CWD = vim.uv.cwd(),
-      YAZI_CONFIG_HOME = config.config_home,
-    },
+    env = env,
     on_exit = function(_, code)
       self.ya_process:kill_and_wait(1000)
 

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -30,6 +30,7 @@
 
 ---@class(exact) yazi.OptInFeatures
 ---@field public use_cwd_file? boolean # use a file to store the last directory that yazi was in before it was closed. Defaults to `true`.
+---@field public yazi_plugin_keymaps? YaziPluginKeymaps # keymaps that are registered *inside yazi* by the `nvim.yazi` plugin instead of as Neovim terminal-mode maps. yazi owns these keys, so they are automatically disabled while yazi is in an input mode (bulk rename, filter, find).
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 
@@ -45,6 +46,9 @@
 ---@field send_to_quickfix_list? YaziKeymap # Send the selected files to the quickfix list for later processing
 ---@field change_working_directory? YaziKeymap # Change working directory to the directory opened by yazi
 ---@field open_and_pick_window? YaziKeymap # Pick a window to open the file in
+
+---@class YaziPluginKeymaps
+---@field open_file_in_vertical_split? YaziKeymap # When a file is hovered, open it in a vertical split
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi

--- a/nvim.yazi/keymaps.lua
+++ b/nvim.yazi/keymaps.lua
@@ -1,0 +1,45 @@
+--- @since 25.5.31
+
+-- Keymap registration for nvim.yazi.
+--
+-- yazi.nvim serializes the user's configured `plugin_keymaps` into the
+-- `YAZI_NVIM_PLUGIN_KEYMAPS` environment variable (see
+-- `lua/yazi/plugin_keymaps.lua`). This module parses them and registers each as
+-- a dynamic yazi keymap via `km.mgr.rules`.
+
+local M = {}
+
+-- Read the keymaps yazi.nvim passed via the environment. One record per line,
+-- tab-separated fields `on\taction\tdesc`.
+---@param raw string
+---@return { on: string, action: string, desc?: string }[]
+function M.parse_from_env(raw)
+  if raw == nil or raw == "" then
+    return {}
+  end
+
+  local keymaps = {}
+  for line in raw:gmatch("[^\n]+") do
+    local on, action, desc = line:match("^(.-)\t(.-)\t(.*)$")
+    if on and action then
+      keymaps[#keymaps + 1] = { on = on, action = action, desc = desc }
+    end
+  end
+  return keymaps
+end
+
+-- Register each keymap inside yazi via the dynamic keymap API. Pressing a key
+-- runs `plugin nvim -- <action>`, which invokes this plugin's `entry` and
+-- publishes a DDS event that yazi.nvim reacts to.
+---@param keymaps { on: string, action: string, desc?: string }[]
+function M.register(keymaps)
+  for _, mapping in ipairs(keymaps) do
+    km.mgr.rules:insert(1, {
+      on = mapping.on,
+      run = string.format("plugin nvim -- %s", mapping.action),
+      desc = mapping.desc,
+    })
+  end
+end
+
+return M

--- a/nvim.yazi/main.lua
+++ b/nvim.yazi/main.lua
@@ -1,0 +1,50 @@
+--- @since 25.5.31
+
+--- nvim.yazi is a companion plugin for yazi.nvim that enables neovim related
+--- functionality. This is needed because some features are so complex that neovim
+--- cannot implement them directly (yazi internal state is needed).
+---
+return {
+  setup = function()
+    require(".notify").guard("failed to add status indicator", function()
+      require(".status").setup()
+    end)
+
+    -- The dynamic keymap API was merged in
+    -- https://github.com/sxyazi/yazi/pull/4031 (merged 2026-06). On older yazi
+    -- it's absent; do nothing so yazi.nvim can fall back.
+    if km == nil then
+      -- This can be moved to the @since annotation once yazi is released with
+      -- the dynamic keymap API.
+      ya.dbg("nvim.yazi: `km` API unavailable, not registering keymaps")
+      return
+    end
+
+    require(".notify").guard("failed to register keymaps", function()
+      local keymaps = require(".keymaps")
+      local mappings =
+        keymaps.parse_from_env(os.getenv("YAZI_NVIM_PLUGIN_KEYMAPS") or "")
+      keymaps.register(mappings)
+    end)
+  end,
+
+  ---@param job { args: string[] }
+  entry = function(_, job)
+    if os.getenv("YAZI_NVIM_ID") == nil then
+      require(".notify").error("nvim.yazi can only be used from yazi.nvim")
+      return
+    end
+
+    local action = job.args[1]
+    if not action then
+      return
+    end
+
+    require(".notify").guard(
+      string.format("failed to handle keymap action '%s'", action),
+      function()
+        require(".publish").keymap_event(action)
+      end
+    )
+  end,
+}

--- a/nvim.yazi/notify.lua
+++ b/nvim.yazi/notify.lua
@@ -1,0 +1,40 @@
+--- @since 25.5.31
+
+-- Error reporting for nvim.yazi.
+--
+-- When something in the plugin fails (a bad keymap, a failed DDS publish, a
+-- module that won't load), surface it to the user as a yazi notification
+-- instead of failing silently.
+local M = {}
+
+-- Show an error notification and mirror it to yazi's log.
+---@param message string
+function M.error(message)
+  local text = "nvim.yazi: " .. message
+  ya.err(text)
+  ya.notify({
+    title = "yazi.nvim",
+    content = text,
+    level = "error",
+    timeout = 60,
+  })
+end
+
+-- Run `fn`, reporting any error as a notification rather than letting it surface
+-- as an unhandled yazi plugin failure. `context` describes what was being
+-- attempted and is prefixed to the message. Returns `fn`'s result on success, or
+-- `nil` if it raised.
+---@generic T
+---@param context string
+---@param fn fun(): T
+---@return T?
+function M.guard(context, fn)
+  local ok, result = pcall(fn)
+  if not ok then
+    M.error(string.format("%s: %s", context, tostring(result)))
+    return nil
+  end
+  return result
+end
+
+return M

--- a/nvim.yazi/publish.lua
+++ b/nvim.yazi/publish.lua
@@ -1,0 +1,30 @@
+--- @since 25.5.31
+
+local M = {}
+
+-- Publish the DDS event for a keymap action, so yazi.nvim's `ya sub` receives
+-- it. Then yazi.nvim can react to the action. This kind of design allows yazi
+-- to own the keymaps, so that yazi.nvim doesn't have to guess when it should
+-- intercept them (e.g. when the user is in an input mode like bulk rename,
+-- filter, or find).
+M.keymap_event = ya.sync(function(_, action)
+  local hovered = cx.active.current.hovered
+
+  local selected = {}
+  for _, url in pairs(cx.active.selected) do
+    selected[#selected + 1] = tostring(url)
+  end
+
+  -- Send everything yazi.nvim might need so it can stay stateless (spike
+  -- decision #2). yazi_id lets yazi.nvim ignore events from other yazi
+  -- instances; if the env var is unavailable it stays nil and yazi.nvim simply
+  -- doesn't filter (fine for a single instance).
+  ps.pub_to(0, "yazi-nvim", {
+    action = action,
+    yazi_id = os.getenv("YAZI_NVIM_ID"),
+    hovered = hovered and tostring(hovered.url) or nil,
+    selected = selected,
+  })
+end)
+
+return M

--- a/nvim.yazi/status.lua
+++ b/nvim.yazi/status.lua
@@ -1,0 +1,17 @@
+--- @since 25.5.31
+
+-- Status bar indicator for nvim.yazi.
+-- This is useful for e2e tests since they assert on output on the screen.
+local M = {}
+
+local ICON = "\u{f36f}" -- nf-linux-neovim, ""
+
+function M.setup()
+  Status:children_add(function()
+    return ui.Line({
+      ui.Span(" " .. ICON .. " "):fg("#57a143"):dim(),
+    })
+  end, 500, Status.RIGHT)
+end
+
+return M

--- a/spec/yazi/plugin_keymaps_spec.lua
+++ b/spec/yazi/plugin_keymaps_spec.lua
@@ -1,0 +1,40 @@
+local assert = require("luassert")
+local plugin_keymaps = require("yazi.plugin_keymaps")
+
+describe("plugin_keymaps.serialize", function()
+  it("serializes an action/key pair into a tab-delimited record", function()
+    local result = plugin_keymaps.serialize({
+      open_file_in_vertical_split = "<c-v>",
+    })
+
+    assert.equal(
+      "<c-v>\topen_file_in_vertical_split\tyazi.nvim: open file in vertical split",
+      result
+    )
+  end)
+
+  it("serializes multiple keymaps deterministically (sorted)", function()
+    local result = plugin_keymaps.serialize({
+      open_file_in_vertical_split = "<c-v>",
+      open_file_in_horizontal_split = "<c-x>",
+    })
+
+    assert.equal(
+      "<c-v>\topen_file_in_vertical_split\tyazi.nvim: open file in vertical split\n"
+        .. "<c-x>\topen_file_in_horizontal_split\tyazi.nvim: open file in horizontal split",
+      result
+    )
+  end)
+
+  it("skips keymaps that are disabled (false) or nil", function()
+    local result = plugin_keymaps.serialize({
+      open_file_in_vertical_split = false,
+    })
+
+    assert.equal("", result)
+  end)
+
+  it("returns an empty string for an empty table", function()
+    assert.equal("", plugin_keymaps.serialize({}))
+  end)
+end)


### PR DESCRIPTION
# feat: start nvim.yazi plugin for yazi-owned keymaps

> [!NOTE]
>
> This is still pretty experimental and requires a nightly yazi!

Currently just testing if this works in CI. Better instructions will if this proves a viable approach.

Now `future_features.yazi_plugin_keymaps` can be configured, and the associated `nvim.yazi` plugin installed ().

This enables yazi to own certain keymaps (like `<c-v>` for opening a file in a vertical split) instead of having them registered as Neovim terminal-mode maps.

Related: https://github.com/mikavilpas/yazi.nvim/issues/1999

# test: add waiting to fix test flakiness

---

# Pull request stack

- 👉🏻 **[#2006](https://github.com/mikavilpas/yazi.nvim/pull/2006)** | feat: start nvim.yazi plugin for yazi-owned keymaps 👈🏻