### PR TITLE
feat(yazi.plugin): add silent option to symlink function

### DIFF
--- a/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
@@ -16,16 +16,8 @@ require("yazi").setup(
 -- the fragile relative symlinks that break when the test directory is
 -- materialized into a temporary location.
 -- selene: allow(global_usage)
-local repo_root = _G.yazi_nvim_repo_root
-  or vim.fn.fnamemodify(vim.uv.os_environ().HOME, ":h:h:h:h")
-
-local plugin_source = vim.fs.joinpath(repo_root, "nvim.yazi")
-local yazi_plugins_dir = vim.fn.expand("~/.config/yazi/plugins")
-vim.fn.mkdir(yazi_plugins_dir, "p")
-
-local link = vim.fs.joinpath(yazi_plugins_dir, "nvim.yazi")
-local existing = vim.uv.fs_lstat(link)
-if existing and existing.type == "link" then
-  vim.uv.fs_unlink(link)
-end
-vim.uv.fs_symlink(plugin_source, link)
+require("yazi.plugin").build_plugin({
+  name = "nvim.yazi",
+  source = vim.fn.expand("~/.config/yazi/plugins"),
+  dir = vim.fs.joinpath(_G.yazi_nvim_repo_root, "nvim.yazi"),
+}, { silent = true })

--- a/lua/yazi/plugin.lua
+++ b/lua/yazi/plugin.lua
@@ -32,7 +32,7 @@ local M = {}
 --- For more information, see the yazi.nvim documentation.
 ---
 ---@param plugin YaziLazyNvimSpec
----@param options? { yazi_dir: string, sub_dir?: string, name?: string }
+---@param options? { yazi_dir: string, sub_dir?: string, name?: string, silent?: boolean }
 function M.build_plugin(plugin, options)
   local yazi_dir = options and options.yazi_dir
     or vim.fn.expand("~/.config/yazi")
@@ -53,7 +53,7 @@ function M.build_plugin(plugin, options)
     )
   end
 
-  return M.symlink(plugin, to)
+  return M.symlink(plugin, to, { silent = options and options.silent })
 end
 
 --- Helper utility for compatibility with
@@ -105,8 +105,9 @@ end
 --- flavors, prefer using `build_plugin` and `build_flavor` instead.
 ---@param spec YaziLazyNvimSpec
 ---@param to string
+---@param options? { silent?: boolean }
 ---@return YaziSpecInstallationResultSuccess | YaziSpecInstallationResultFailure
-function M.symlink(spec, to)
+function M.symlink(spec, to, options)
   -- Check if the symlink already exists, which will happen on repeated calls
   local existing_stat = vim.uv.fs_lstat(to)
   if existing_stat and existing_stat.type == "link" then
@@ -122,7 +123,9 @@ function M.symlink(spec, to)
       from = spec.dir,
       message = "yazi.nvim: failed to install",
     }
-    vim.notify(vim.inspect(result))
+    if not (options or {}).silent then
+      vim.notify(vim.inspect(result))
+    end
     return result
   end
 
@@ -148,7 +151,9 @@ function M.symlink(spec, to)
     to = to,
   }
 
-  vim.notify(vim.inspect(result))
+  if not (options or {}).silent then
+    vim.notify(vim.inspect(result))
+  end
   return result
 end
 


### PR DESCRIPTION
# test: use yazi.plugin.build_plugin() to prepare nvim.yazi

Small refactoring only. Use the already existing plugin symlinking instead of hand rolling a copy.

# feat(yazi.plugin): add silent option to symlink function

The yazi.plugin feature can now create symlinks without displaying a notification. This enabled using it in the integration tests.

---

# Pull request stack

- 👉🏻 **[#2010](https://github.com/mikavilpas/yazi.nvim/pull/2010)** | feat(yazi.plugin): add silent option to symlink function 👈🏻