### PR TITLE
test: nvim.yazi can open multiple files in vertical splits

### DIFF
--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -6,6 +6,7 @@ import {
   isFileSelectedInYazi,
 } from "../utils/yazi-utils.ts"
 import {
+  assertKeymapNotOwnedByYaziNvim,
   assertNvimYaziPluginIndicatorIsVisible,
   describeOnNightlyYazi,
 } from "./yazi-plugin-utils.ts"
@@ -28,6 +29,8 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       isFileNotSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
       hoverFileAndVerifyItsHovered(nvim, "file2.txt")
       assertNvimYaziPluginIndicatorIsVisible()
+
+      assertKeymapNotOwnedByYaziNvim(nvim, "<c-v>")
 
       // <c-v> is now owned by yazi (via the nvim.yazi plugin). Pressing it
       // publishes a DDS event that yazi.nvim reacts to by opening the hovered
@@ -62,6 +65,8 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       isFileNotSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
       cy.typeIntoTerminal("j")
       isFileSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+
+      assertKeymapNotOwnedByYaziNvim(nvim, "<c-v>")
 
       // <c-v> is now owned by yazi (via the nvim.yazi plugin). Pressing it
       // publishes a DDS event that yazi.nvim reacts to by opening the hovered

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -3,6 +3,7 @@ import { hoverFileAndVerifyItsHovered } from "../utils/hover-utils.ts"
 import {
   assertYaziIsReady,
   isFileNotSelectedInYazi,
+  isFileSelectedInYazi,
 } from "../utils/yazi-utils.ts"
 import {
   assertNvimYaziPluginIndicatorIsVisible,
@@ -37,6 +38,41 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       cy.contains("-- TERMINAL --").should("not.exist")
 
       // both files must be visible (side by side in splits)
+      cy.contains(nvim.dir.contents["file2.txt"].name)
+      cy.contains(nvim.dir.contents["initial-file.txt"].name)
+    })
+  })
+
+  it("<c-v> can open multiple files in vertical splits", () => {
+    cy.startNeovim({
+      startupScriptModifications: [
+        "add_yazi_context_assertions.lua",
+        "yazi_config/enable_yazi_plugin_keymaps.lua",
+      ],
+    }).then((nvim) => {
+      // this should test that the DDS events include details of multiple
+      // files, not just one
+      cy.contains("If you see this text, Neovim is ready!")
+      cy.typeIntoTerminal("{upArrow}")
+      assertYaziIsReady(nvim)
+      assertNvimYaziPluginIndicatorIsVisible()
+      isFileNotSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
+      hoverFileAndVerifyItsHovered(nvim, "file2.txt")
+      cy.typeIntoTerminal("v")
+      isFileNotSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+      cy.typeIntoTerminal("j")
+      isFileSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+
+      // <c-v> is now owned by yazi (via the nvim.yazi plugin). Pressing it
+      // publishes a DDS event that yazi.nvim reacts to by opening the hovered
+      // file in a vertical split - exactly like the terminal-map version.
+      cy.typeIntoTerminal("{control+v}")
+
+      // yazi should now be closed
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      // both files must be visible (side by side in splits)
+      cy.contains(nvim.dir.contents["file3.txt"].name)
       cy.contains(nvim.dir.contents["file2.txt"].name)
       cy.contains(nvim.dir.contents["initial-file.txt"].name)
     })

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
@@ -1,3 +1,8 @@
+import type { RunLuaCodeOutput } from "@tui-sandbox/library/server"
+import * as z from "zod"
+
+import type { NeovimContext } from "../../support/tui-sandbox.js"
+
 export const describeOnNightlyYazi = (title: string, fn: () => void): void => {
   const runner: (title: string, fn: () => void) => void =
     Cypress.expose("runNvimYaziPluginTests") === true ? describe : describe.skip
@@ -6,3 +11,50 @@ export const describeOnNightlyYazi = (title: string, fn: () => void): void => {
 
 export const assertNvimYaziPluginIndicatorIsVisible =
   (): Cypress.Chainable<undefined> => cy.contains(String.fromCodePoint(0xf36f)) // nf-linux-neovim, ""
+
+/**
+ * Issue: yazi.nvim has both neovim keymaps as well as yazi keymaps (via
+ * nvim.yazi) active. The end-to-end tests cannot tell which one activates
+ * simply pressing the key because both are active for the same key.
+ *
+ * Solution: call this function to assert that the yazi.nvim keymap is not
+ * active for the given key.
+ */
+export function assertKeymapNotOwnedByYaziNvim(
+  nvim: NeovimContext,
+  key: string,
+): Cypress.Chainable<RunLuaCodeOutput> {
+  return nvim
+    .runLuaCode({
+      luaCode: `
+        local key = "${key}"
+        local buf = vim.api.nvim_get_current_buf()
+        local target = vim.api.nvim_replace_termcodes(key, true, true, true)
+        local mapped = false
+        for _, map in ipairs(vim.api.nvim_buf_get_keymap(buf, "t")) do
+          if vim.api.nvim_replace_termcodes(map.lhs, true, true, true) == target then
+            mapped = true
+            break
+          end
+        end
+        return { buftype = vim.bo[buf].buftype, mapped = mapped }
+      `,
+    })
+    .then((result) => {
+      const parsed = z
+        .object({ buftype: z.string(), mapped: z.boolean() })
+        .parse(result.value)
+
+      // sanity check: we must actually be inspecting the yazi terminal buffer,
+      // otherwise "no keymap found" would be meaningless
+      expect(
+        parsed.buftype,
+        "expected to inspect the focused yazi terminal buffer",
+      ).to.eql("terminal")
+
+      expect(
+        parsed.mapped,
+        `yazi.nvim must not own a terminal-mode keymap for "${key}" - the key must be handled by the nvim.yazi plugin instead`,
+      ).to.eql(false)
+    })
+}


### PR DESCRIPTION
# test: plugin keymaps are tested explicitly

# test: nvim.yazi can open multiple files in vertical splits

---

# Pull request stack

- 👉🏻 **[#2015](https://github.com/mikavilpas/yazi.nvim/pull/2015)** | test: nvim.yazi can open multiple files in vertical splits 👈🏻
  - [#2016](https://github.com/mikavilpas/yazi.nvim/pull/2016) | feat(yazi.plugin): implement open_file_in_horizontal_split (<c-x>)