### PR TITLE
test: centralize starting nvim with the nvim.yazi plugin enabled

### DIFF
--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -1,4 +1,8 @@
 import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
+import type {
+  MyStartNeovimServerArguments,
+  NeovimContext,
+} from "../../support/tui-sandbox.ts"
 import { hoverFileAndVerifyItsHovered } from "../utils/hover-utils.ts"
 import {
   assertYaziIsReady,
@@ -11,18 +15,25 @@ import {
   describeOnNightlyYazi,
 } from "./yazi-plugin-utils.ts"
 
+const openNeovimWithNvimYaziPlugin = (
+  args?: MyStartNeovimServerArguments,
+): Cypress.Chainable<NeovimContext> =>
+  cy.startNeovim({
+    ...args,
+    startupScriptModifications: [
+      "add_yazi_context_assertions.lua",
+      "yazi_config/enable_yazi_plugin_keymaps.lua",
+      ...(args?.startupScriptModifications ?? []),
+    ],
+  })
+
 describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
   beforeEach(() => {
     cy.visit("/")
   })
 
   it("<c-v> can open a file in a vertical split", () => {
-    cy.startNeovim({
-      startupScriptModifications: [
-        "add_yazi_context_assertions.lua",
-        "yazi_config/enable_yazi_plugin_keymaps.lua",
-      ],
-    }).then((nvim) => {
+    openNeovimWithNvimYaziPlugin().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")
       cy.typeIntoTerminal("{upArrow}")
       assertYaziIsReady(nvim)
@@ -47,12 +58,7 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
   })
 
   it("<c-v> can open multiple files in vertical splits", () => {
-    cy.startNeovim({
-      startupScriptModifications: [
-        "add_yazi_context_assertions.lua",
-        "yazi_config/enable_yazi_plugin_keymaps.lua",
-      ],
-    }).then((nvim) => {
+    openNeovimWithNvimYaziPlugin().then((nvim) => {
       // this should test that the DDS events include details of multiple
       // files, not just one
       cy.contains("If you see this text, Neovim is ready!")
@@ -84,12 +90,7 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
   })
 
   it("<c-x> can open a file in a horizontal split", () => {
-    cy.startNeovim({
-      startupScriptModifications: [
-        "add_yazi_context_assertions.lua",
-        "yazi_config/enable_yazi_plugin_keymaps.lua",
-      ],
-    }).then((nvim) => {
+    openNeovimWithNvimYaziPlugin().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")
       cy.typeIntoTerminal("{upArrow}")
       assertYaziIsReady(nvim)
@@ -111,12 +112,7 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
   })
 
   it("keymaps are documented in yazi's help view", () => {
-    cy.startNeovim({
-      startupScriptModifications: [
-        "add_yazi_context_assertions.lua",
-        "yazi_config/enable_yazi_plugin_keymaps.lua",
-      ],
-    }).then((nvim) => {
+    openNeovimWithNvimYaziPlugin().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")
       cy.typeIntoTerminal("{upArrow}")
       assertYaziIsReady(nvim)


### PR DESCRIPTION
# test: centralize starting nvim with the nvim.yazi plugin enabled

**Issue:**

Each test in the yazi-plugin-keymaps test file needs to load neovim roughly the same way, with the nvim.yazi plugin enabled.

It's tricky to ensure the tests opt into this intricate setup correctly.

**Solution:**

Make each test call a helper function that centralizes this logic into a single place. As long as the tests look the same, they should work correctly, making it a bit easier to maintain the tests in the future.

---

# Pull request stack

- 👉🏻 **[#2019](https://github.com/mikavilpas/yazi.nvim/pull/2019)** | test: centralize starting nvim with the nvim.yazi plugin enabled 👈🏻
  - [#2020](https://github.com/mikavilpas/yazi.nvim/pull/2020) | feat(nvim.yazi): implement opening a file in a new tab