### PR TITLE
test: fix not clearing the log after each test

### DIFF
--- a/integration-tests/cypress/support/commands.ts
+++ b/integration-tests/cypress/support/commands.ts
@@ -3,6 +3,6 @@
 afterEach(function () {
   if (this.currentTest?.state === "failed") {
     cy.task("showYaziLog")
-    cy.task("removeYaziLog")
   }
+  cy.task("removeYaziLog")
 })


### PR DESCRIPTION
# test: fix not clearing the log after each test

When a test failed, it would show the log of all previous tests - unreadable.

---

# Pull request stack

- 👉🏻 **[#2027](https://github.com/mikavilpas/yazi.nvim/pull/2027)** | test: fix not clearing the log after each test 👈🏻