### PR TITLE
test: make the hover helper dance with two files to reduce flake

### DIFF
--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -16,9 +16,35 @@ function M.reveal_path_and_wait_for_hover(path)
 
   Log:debug("Revealing path in yazi context: " .. vim.inspect(path))
 
+  -- yazi only emits a `hover` DDS event when the hovered item actually
+  -- *changes*. The `hover` event yazi sends back in response to a `reveal` can
+  -- be lost in CI, which leaves our `hovered_url` stuck on the previous path
+  -- even though yazi's cursor is already on `path`. Re-emitting `reveal path`
+  -- is then a no-op: the cursor is already there, so yazi emits nothing new
+  -- and we would wait forever.
+  --
+  -- To break out of that, each attempt first reveals a *different* decoy path
+  -- to force the cursor away, then reveals `path` again. Approaching `path`
+  -- from elsewhere guarantees yazi emits a fresh `hover` event, so every
+  -- attempt gets an independent chance to be observed instead of hanging on a
+  -- single event that may never arrive. The decoy is the last known
+  -- `hovered_url`: it is a real, existing path, and whenever we still need to
+  -- retry it differs from `path` (otherwise we'd already be done).
   local attempts = 20
-  local interval_ms = 100
+  local interval_ms = 150
   for _ = 1, attempts do
+    if context.ya_process.hovered_url == path then
+      return
+    end
+
+    local decoy = context.ya_process.hovered_url
+    if type(decoy) == "string" and decoy ~= path then
+      -- Wait for the decoy reveal to be delivered before revealing the target,
+      -- so yazi clearly processes them as two distinct moves rather than
+      -- coalescing them into a single no-op cursor update.
+      context.api:reveal(decoy):wait(500)
+    end
+
     context.api:reveal(path)
     local hovered = vim.wait(interval_ms, function()
       return context.ya_process.hovered_url == path


### PR DESCRIPTION
# test: make the hover helper dance with two files to reduce flake

---

# Pull request stack

- 👉🏻 **[#2028](https://github.com/mikavilpas/yazi.nvim/pull/2028)** | test: make the hover helper dance with two files to reduce flake 👈🏻