### PR TITLE
feat(nvim.yazi): implement send_to_quickfix_list (`<c-q>`)

### DIFF
--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -330,4 +330,37 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       })
     })
   })
+
+  it("can send file names to the quickfix list", () => {
+    openNeovimWithNvimYaziPlugin({
+      filename: "file2.txt",
+      startupScriptModifications: ["add_command_to_reveal_a_file.lua"],
+    }).then((nvim) => {
+      cy.contains("Hello")
+      cy.typeIntoTerminal("{upArrow}")
+
+      // wait for yazi to open
+      assertYaziIsReady(nvim)
+
+      // file2.txt should be selected
+      isFileSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
+
+      // select file2, the cursor moves one line down to the next file
+      cy.typeIntoTerminal(" ")
+      isFileNotSelectedInYazi("file2.txt" satisfies MyTestDirectoryFile)
+
+      // also select the next file because multiple files have to be selected
+      isFileSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+      cy.typeIntoTerminal(" ")
+      isFileNotSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+      cy.typeIntoTerminal("{control+q}")
+
+      // yazi should now be closed
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      // items in the quickfix list should now be visible
+      cy.contains(`${nvim.dir.contents["file2.txt"].name}|1 col 1|`)
+      cy.contains(`${nvim.dir.contents["file3.txt"].name}|1 col 1|`)
+    })
+  })
 })

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -1,3 +1,6 @@
+import type { MyNeovimConfigModification } from "@tui-sandbox/library"
+import type { OverrideProperties } from "type-fest"
+
 import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
 import type {
   MyStartNeovimServerArguments,
@@ -18,8 +21,16 @@ import {
   describeOnNightlyYazi,
 } from "./yazi-plugin-utils.ts"
 
+type NonDefaultStartupModification = Exclude<
+  MyNeovimConfigModification<MyTestDirectoryFile>,
+  | "add_yazi_context_assertions.lua"
+  | "yazi_config/enable_yazi_plugin_keymaps.lua"
+>
 const openNeovimWithNvimYaziPlugin = (
-  args?: MyStartNeovimServerArguments,
+  args?: OverrideProperties<
+    MyStartNeovimServerArguments,
+    { startupScriptModifications?: NonDefaultStartupModification[] }
+  >,
 ): Cypress.Chainable<NeovimContext> =>
   cy.startNeovim({
     ...args,

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -1,11 +1,4 @@
-import type { MyNeovimConfigModification } from "@tui-sandbox/library"
-import type { OverrideProperties } from "type-fest"
-
 import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
-import type {
-  MyStartNeovimServerArguments,
-  NeovimContext,
-} from "../../support/tui-sandbox.ts"
 import {
   assertYaziIsHovering,
   hoverFileAndVerifyItsHovered,
@@ -19,27 +12,8 @@ import {
   assertKeymapNotOwnedByYaziNvim,
   assertNvimYaziPluginIndicatorIsVisible,
   describeOnNightlyYazi,
+  openNeovimWithNvimYaziPlugin,
 } from "./yazi-plugin-utils.ts"
-
-type NonDefaultStartupModification = Exclude<
-  MyNeovimConfigModification<MyTestDirectoryFile>,
-  | "add_yazi_context_assertions.lua"
-  | "yazi_config/enable_yazi_plugin_keymaps.lua"
->
-const openNeovimWithNvimYaziPlugin = (
-  args?: OverrideProperties<
-    MyStartNeovimServerArguments,
-    { startupScriptModifications?: NonDefaultStartupModification[] }
-  >,
-): Cypress.Chainable<NeovimContext> =>
-  cy.startNeovim({
-    ...args,
-    startupScriptModifications: [
-      "add_yazi_context_assertions.lua",
-      "yazi_config/enable_yazi_plugin_keymaps.lua",
-      ...(args?.startupScriptModifications ?? []),
-    ],
-  })
 
 describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
   beforeEach(() => {
@@ -353,6 +327,7 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       isFileSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
       cy.typeIntoTerminal(" ")
       isFileNotSelectedInYazi("file3.txt" satisfies MyTestDirectoryFile)
+      assertKeymapNotOwnedByYaziNvim(nvim, "<c-q>")
       cy.typeIntoTerminal("{control+q}")
 
       // yazi should now be closed

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-utils.ts
@@ -1,7 +1,13 @@
+import type { MyNeovimConfigModification } from "@tui-sandbox/library"
 import type { RunLuaCodeOutput } from "@tui-sandbox/library/server"
+import type { OverrideProperties } from "type-fest"
 import * as z from "zod"
 
-import type { NeovimContext } from "../../support/tui-sandbox.js"
+import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
+import type {
+  MyStartNeovimServerArguments,
+  NeovimContext,
+} from "../../support/tui-sandbox.js"
 
 export const describeOnNightlyYazi = (title: string, fn: () => void): void => {
   const runner: (title: string, fn: () => void) => void =
@@ -58,3 +64,23 @@ export function assertKeymapNotOwnedByYaziNvim(
       ).to.eql(false)
     })
 }
+
+type NonDefaultStartupModification = Exclude<
+  MyNeovimConfigModification<MyTestDirectoryFile>,
+  | "add_yazi_context_assertions.lua"
+  | "yazi_config/enable_yazi_plugin_keymaps.lua"
+>
+export const openNeovimWithNvimYaziPlugin = (
+  args?: OverrideProperties<
+    MyStartNeovimServerArguments,
+    { startupScriptModifications?: NonDefaultStartupModification[] }
+  >,
+): Cypress.Chainable<NeovimContext> =>
+  cy.startNeovim({
+    ...args,
+    startupScriptModifications: [
+      "add_yazi_context_assertions.lua",
+      "yazi_config/enable_yazi_plugin_keymaps.lua",
+      ...(args?.startupScriptModifications ?? []),
+    ],
+  })

--- a/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
@@ -11,6 +11,7 @@ require("yazi").setup(
         cycle_open_buffers = "<tab>",
         grep_in_directory = "<c-s>",
         replace_in_directory = "<c-g>",
+        send_to_quickfix_list = "<c-q>",
       },
     },
   }

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -180,8 +180,10 @@ function M.set_keymappings(yazi_buffer, config, context)
     end
   )
 
-  if config.keymaps.send_to_quickfix_list ~= false then
-    vim.keymap.set({ "t" }, config.keymaps.send_to_quickfix_list, function()
+  maybe_map(
+    config.keymaps.send_to_quickfix_list,
+    plugin_keymaps.send_to_quickfix_list,
+    function()
       local openers = require("yazi.openers")
       keybinding_helpers.select_current_file_and_close_yazi(config, {
         api = context.api,
@@ -190,8 +192,8 @@ function M.set_keymappings(yazi_buffer, config, context)
           openers.send_files_to_quickfix_list({ chosen_file })
         end,
       })
-    end, { buffer = yazi_buffer })
-  end
+    end
+  )
 
   if config.keymaps.change_working_directory ~= false then
     vim.keymap.set({ "t" }, config.keymaps.change_working_directory, function()

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -176,6 +176,15 @@ function M.process_plugin_keymap_event(event, expected_yazi_id, config, context)
         keybinding_helpers.replace_in_selected_files(config, chosen_files)
       end,
     })
+  elseif payload.action == "send_to_quickfix_list" then
+    local openers = require("yazi.openers")
+    keybinding_helpers.select_current_file_and_close_yazi(config, {
+      api = context.api,
+      on_multiple_files_opened = openers.send_files_to_quickfix_list,
+      on_file_opened = function(chosen_file)
+        openers.send_files_to_quickfix_list({ chosen_file })
+      end,
+    })
   else
     Log:debug(
       string.format("Unknown yazi-nvim plugin action: %s", payload.action)

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -54,6 +54,7 @@
 ---@field cycle_open_buffers? YaziKeymap # When Neovim has multiple splits open and visible, make yazi jump to the directory of the next one
 ---@field grep_in_directory? YaziKeymap # Close yazi and open a grep (default: telescope) narrowed to the directory yazi is in
 ---@field replace_in_directory? YaziKeymap # Close yazi and open a replacer (default: grug-far.nvim) narrowed to the directory yazi is in
+---@field send_to_quickfix_list? YaziKeymap # Send the selected files to the quickfix list for later processing
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi


### PR DESCRIPTION
# test: move openNeovimWithNvimYaziPlugin helper to utils file

# feat(nvim.yazi): implement send_to_quickfix_list (`<c-q>`)

# test: plugin tests can't repeat already applied config-modifications

---

# Pull request stack

- 👉🏻 **[#2031](https://github.com/mikavilpas/yazi.nvim/pull/2031)** | feat(nvim.yazi): implement send_to_quickfix_list (`<c-q>`) 👈🏻