### PR TITLE
ci(perf): disable installing cypress for lint and style checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,4 +60,6 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
       - run: pnpm run lint

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
-      - run: pnpm install
+      - run: pnpm install --filter @yazi.nvim/plugin
       - run: pnpm oxfmt --check
 
   stylua:


### PR DESCRIPTION
# ci(perf): disable installing cypress for lint and style checks

https://docs.cypress.io/app/references/advanced-installation allows specifying `CYPRESS_INSTALL_BINARY=0` to skip downloading the Cypress binary.

---

# Pull request stack

- 👉🏻 **[#2034](https://github.com/mikavilpas/yazi.nvim/pull/2034)** | ci(perf): disable installing cypress for lint and style checks 👈🏻