### PR TITLE
feat(nvim.yazi): implement change_working_directory

### DIFF
--- a/integration-tests/.oxlintrc.json
+++ b/integration-tests/.oxlintrc.json
@@ -220,7 +220,7 @@
       }
     },
     {
-      "files": ["cypress/e2e/*.cy.ts", "cypress/support/commands.ts"],
+      "files": ["cypress/e2e/**/*.cy.ts", "cypress/support/commands.ts"],
       // cypress knows how to import its own files
       "rules": {
         "import/unambiguous": "allow",

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -99,18 +99,6 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
     })
   })
 
-  it("keymaps are documented in yazi's help view", () => {
-    openNeovimWithNvimYaziPlugin().then((nvim) => {
-      cy.contains("If you see this text, Neovim is ready!")
-      cy.typeIntoTerminal("{upArrow}")
-      assertYaziIsReady(nvim)
-      assertNvimYaziPluginIndicatorIsVisible()
-
-      cy.typeIntoTerminal("~")
-      cy.contains("yazi.nvim: open file in vertical split")
-    })
-  })
-
   it("can open a file in a new tab", () => {
     openNeovimWithNvimYaziPlugin().then((nvim) => {
       cy.contains("If you see this text, Neovim is ready!")

--- a/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
+++ b/integration-tests/cypress/e2e/yazi-plugin/yazi-plugin-keymaps.cy.ts
@@ -1,3 +1,7 @@
+import path from "path"
+
+import { z } from "zod"
+
 import type { MyTestDirectoryFile } from "../../../MyTestDirectory.ts"
 import {
   assertYaziIsHovering,
@@ -324,6 +328,34 @@ describeOnNightlyYazi("yazi-owned keymaps (nvim.yazi plugin, DDS)", () => {
       // items in the quickfix list should now be visible
       cy.contains(`${nvim.dir.contents["file2.txt"].name}|1 col 1|`)
       cy.contains(`${nvim.dir.contents["file3.txt"].name}|1 col 1|`)
+    })
+  })
+
+  it("can change neovim's cwd with the 'change_working_directory' key", () => {
+    openNeovimWithNvimYaziPlugin().then((nvim) => {
+      cy.contains("If you see this text, Neovim is ready!")
+      cy.typeIntoTerminal("{upArrow}")
+
+      // wait for yazi to open
+      assertYaziIsReady(nvim)
+
+      assertKeymapNotOwnedByYaziNvim(nvim, "<c-w>")
+      hoverFileAndVerifyItsHovered(nvim, "subdirectory/subdirectory-file.txt")
+
+      cy.contains("-- TERMINAL --")
+      cy.typeIntoTerminal("{control+w}")
+      cy.typeIntoTerminal("q")
+      cy.contains("-- TERMINAL --").should("not.exist")
+
+      nvim.runExCommand({ command: "pwd" }).then((result) => {
+        const pwd = z.string().parse(result.value)
+        const subdirectoryPath = path.resolve(
+          nvim.dir.rootPathAbsolute,
+          "subdirectory" satisfies MyTestDirectoryFile,
+        )
+
+        expect(pwd).to.eql(subdirectoryPath)
+      })
     })
   })
 })

--- a/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
+++ b/integration-tests/test-environment/config-modifications/yazi_config/enable_yazi_plugin_keymaps.lua
@@ -12,6 +12,7 @@ require("yazi").setup(
         grep_in_directory = "<c-s>",
         replace_in_directory = "<c-g>",
         send_to_quickfix_list = "<c-q>",
+        change_working_directory = "<c-w>",
       },
     },
   }

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -201,11 +201,13 @@ function M.set_keymappings(yazi_buffer, config, context)
     end
   )
 
-  if config.keymaps.change_working_directory ~= false then
-    vim.keymap.set({ "t" }, config.keymaps.change_working_directory, function()
+  maybe_map(
+    config.keymaps.change_working_directory,
+    plugin_keymaps.change_working_directory,
+    function()
       keybinding_helpers.change_working_directory(context)
-    end, { buffer = yazi_buffer })
-  end
+    end
+  )
 
   if config.keymaps.open_and_pick_window ~= false then
     vim.keymap.set({ "t" }, config.keymaps.open_and_pick_window, function()

--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -110,6 +110,7 @@ end
 ---@field yazi_id? string # the id of the yazi instance that sent the event
 ---@field hovered? string # the currently hovered path, if any
 ---@field selected? string[] # the currently selected paths
+---@field cwd? string[] # the current working directory, if present
 ---
 ---@param event YaziCustomDDSEvent
 ---@param expected_yazi_id string # only handle events from our own yazi instance
@@ -185,6 +186,8 @@ function M.process_plugin_keymap_event(event, expected_yazi_id, config, context)
         openers.send_files_to_quickfix_list({ chosen_file })
       end,
     })
+  elseif payload.action == "change_working_directory" then
+    vim.cmd({ cmd = "cd", args = { payload.cwd } })
   else
     Log:debug(
       string.format("Unknown yazi-nvim plugin action: %s", payload.action)

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -55,6 +55,7 @@
 ---@field grep_in_directory? YaziKeymap # Close yazi and open a grep (default: telescope) narrowed to the directory yazi is in
 ---@field replace_in_directory? YaziKeymap # Close yazi and open a replacer (default: grug-far.nvim) narrowed to the directory yazi is in
 ---@field send_to_quickfix_list? YaziKeymap # Send the selected files to the quickfix list for later processing
+---@field change_working_directory? YaziKeymap # Change working directory to the directory opened by yazi
 
 ---@class (exact) YaziActiveContext # context state for a single yazi session
 ---@field api YaziProcessApi

--- a/lua/yazi/utils.lua
+++ b/lua/yazi/utils.lua
@@ -387,7 +387,6 @@ function M.parse_events(event_lines)
       }
       table.insert(events, event)
     else
-      require("yazi.log"):debug(string.format("Unknown event type: %s", type))
       -- Custom user event.
       -- It could look like this (with optional data at the end)
       -- my-message-no-data,0,1731774290298033,

--- a/yazi-plugin/nvim.yazi/publish.lua
+++ b/yazi-plugin/nvim.yazi/publish.lua
@@ -8,23 +8,32 @@ local M = {}
 -- intercept them (e.g. when the user is in an input mode like bulk rename,
 -- filter, or find).
 M.keymap_event = ya.sync(function(_, action)
-  local hovered = cx.active.current.hovered
+  local neovim_id =
+    assert(os.getenv("YAZI_NVIM_ID"), "YAZI_NVIM_ID must be set")
 
-  local selected = {}
-  for _, url in pairs(cx.active.selected) do
-    selected[#selected + 1] = tostring(url)
+  if action == "change_working_directory" then
+    local cwd = cx.active.current.cwd
+    assert(cwd, "expected to find the yazi cwd")
+    ps.pub_to(0, "yazi-nvim", {
+      action = action,
+      yazi_id = neovim_id,
+      cwd = tostring(cwd),
+    })
+  else
+    local hovered = cx.active.current.hovered
+
+    local selected = {}
+    for _, url in pairs(cx.active.selected) do
+      selected[#selected + 1] = tostring(url)
+    end
+
+    ps.pub_to(0, "yazi-nvim", {
+      action = action,
+      yazi_id = neovim_id,
+      hovered = hovered and tostring(hovered.url) or nil,
+      selected = selected,
+    })
   end
-
-  -- Send everything yazi.nvim might need so it can stay stateless (spike
-  -- decision #2). yazi_id lets yazi.nvim ignore events from other yazi
-  -- instances; if the env var is unavailable it stays nil and yazi.nvim simply
-  -- doesn't filter (fine for a single instance).
-  ps.pub_to(0, "yazi-nvim", {
-    action = action,
-    yazi_id = os.getenv("YAZI_NVIM_ID"),
-    hovered = hovered and tostring(hovered.url) or nil,
-    selected = selected,
-  })
 end)
 
 return M


### PR DESCRIPTION
# feat(nvim.yazi): implement change_working_directory

In this one we don't have to track yazi's latest hovered path because the plugin can access yazi's internal state - no separate juggling of state is needed.

Nice!

# test: remove help test from yazi-plugin-keymaps test

I think it was copied in by accident

# chore: remove debug log for unknown event type

Doesn't seem useful - let's remove it

---

# Pull request stack

- 👉🏻 **[#2040](https://github.com/mikavilpas/yazi.nvim/pull/2040)** | feat(nvim.yazi): implement change_working_directory 👈🏻