### PR TITLE
chore(mise): fix emmylua-analyzer-rust asset_patterns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust"' mise.toml)
+          VERSION=$(yq '.tools."github:EmmyLuaLs/emmylua-analyzer-rust".version' mise.toml)
           ubi --project EmmyLuaLs/emmylua-analyzer-rust --tag "$VERSION" --exe emmylua_ls --matching-regex "^emmylua_ls"
 
           VERSION=$(yq '.tools.ripgrep.version' mise.toml)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,9 @@ jobs:
           fzf --version
           rg --version
           which realpath || { exit 1; }
+          nvim --version
+          yazi --version
+          ya --version
 
       - working-directory: integration-tests
         name: Prepare Neovim for integration tests

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [tools]
-"github:EmmyLuaLs/emmylua-analyzer-rust" = "0.23.2"
 fzf = "0.74.0"
 # fd is a dependency of telescope and fzf-lua
 fd = "10.4.2"
@@ -11,6 +10,14 @@ ripgrep = { version = "15.1.0", exe = "rg" }
 actionlint = "1.7.12"
 zizmor = "1.26.1"
 "aqua:Kampfkarren/selene" = "0.31.0"
+
+[tools."github:EmmyLuaLs/emmylua-analyzer-rust"]
+version = "0.23.2"
+
+[tools."github:EmmyLuaLs/emmylua-analyzer-rust".platforms]
+linux-x64 = { asset_pattern = "*_ls-linux-x64*" }
+macos-x64 = { asset_pattern = "*_ls-darwin-x64*" }
+macos-arm64 = { asset_pattern = "*_ls-darwin-arm64*" }
 
 [env]
 # busted/nlua live in this project's own luarocks tree (`luarocks init` ->


### PR DESCRIPTION
# chore(mise): fix emmylua-analyzer-rust asset_patterns

It does not seem to install the correct version on osx locally, let's see if this works.

---

# Pull request stack

- 👉🏻 **[#2056](https://github.com/mikavilpas/yazi.nvim/pull/2056)** | chore(mise): fix emmylua-analyzer-rust asset_patterns 👈🏻