### PR TITLE
refactor: formalize ya sub as an EventSource abstraction

### DIFF
--- a/integration-tests/cypress/e2e/reading-events.cy.ts
+++ b/integration-tests/cypress/e2e/reading-events.cy.ts
@@ -27,7 +27,6 @@ describe("reading events", () => {
       // indicating that the directory was changed
       cy.contains("other-subdirectory" satisfies MyTestDirectoryFile)
       hoverFileAndVerifyItsHovered(nvim, "other-subdirectory")
-      cy.typeIntoTerminal("{enter}")
       cy.typeIntoTerminal("{rightArrow}")
       cy.typeIntoTerminal("{control+s}")
 

--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -32,6 +32,27 @@ function M.reveal_path_and_wait_for_hover(path)
   -- retry it differs from `path` (otherwise we'd already be done).
   local attempts = 20
   local interval_ms = 150
+
+  -- `ya emit-to` can fail without yazi ever seeing the command, e.g. when the
+  -- DDS socket is gone ("Connection refused").
+  ---@type string | nil
+  local last_emit_error = nil
+
+  ---@param job vim.SystemObj
+  ---@param what string
+  local function reveal_and_check(job, what)
+    local result = job:wait(1000)
+    if result.code ~= 0 then
+      last_emit_error = string.format(
+        "revealing %s exited with code %s: '%s'",
+        what,
+        result.code,
+        vim.trim(result.stderr or "")
+      )
+      Log:debug("`ya emit-to` failed: " .. last_emit_error)
+    end
+  end
+
   for _ = 1, attempts do
     if context.ya_process.hovered_url == path then
       return
@@ -42,10 +63,13 @@ function M.reveal_path_and_wait_for_hover(path)
       -- Wait for the decoy reveal to be delivered before revealing the target,
       -- so yazi clearly processes them as two distinct moves rather than
       -- coalescing them into a single no-op cursor update.
-      context.api:reveal(decoy):wait(500)
+      reveal_and_check(
+        context.api:reveal(decoy),
+        string.format("the decoy '%s'", decoy)
+      )
     end
 
-    context.api:reveal(path)
+    reveal_and_check(context.api:reveal(path), string.format("'%s'", path))
     local hovered = vim.wait(interval_ms, function()
       return context.ya_process.hovered_url == path
     end, 20)
@@ -54,11 +78,19 @@ function M.reveal_path_and_wait_for_hover(path)
     end
   end
 
+  local reason = last_emit_error ~= nil
+      and string.format(
+        " The last `ya emit-to` failure was: %s",
+        last_emit_error
+      )
+    or " Every `ya emit-to` succeeded, so yazi received the reveals but never reported hovering the path."
+
   error(
     string.format(
-      "Timed out waiting for yazi to hover '%s'. Last hovered url: '%s'",
+      "Timed out waiting for yazi to hover '%s'. Last hovered url: '%s'.%s",
       path,
-      tostring(context.ya_process.hovered_url)
+      tostring(context.ya_process.hovered_url),
+      reason
     )
   )
 end

--- a/lua/yazi/log.lua
+++ b/lua/yazi/log.lua
@@ -70,4 +70,11 @@ function Log:debug(message)
   end
 end
 
+---@param message string
+function Log:error(message)
+  if self:active_for_level(log_levels.ERROR) then
+    self:write_message("ERROR", message)
+  end
+end
+
 return Log

--- a/lua/yazi/process/event_source/init.lua
+++ b/lua/yazi/process/event_source/init.lua
@@ -1,0 +1,77 @@
+--- An event source is the transport that carries yazi's
+--- [DDS](https://yazi-rs.github.io/docs/dds) events to yazi.nvim.
+---
+--- Everything downstream of the transport - parsing the lines, tracking the
+--- hovered file, renaming buffers - is the same either way and lives in
+--- `YaProcess`.
+---
+--- The methods are called in this order:
+---
+--- 1. `open()`, before yazi is started, so the source can set up whatever the
+---    yazi command line has to refer to
+--- 2. `yazi_arguments()` and `environment()`, to build that command line
+--- 3. `terminal_command()`, to wrap it in whatever Neovim should actually run
+--- 4. `start()`, once yazi is running
+--- 5. `close()`, once yazi has exited
+---
+---@class yazi.EventSource
+---@field name string # for logging and test assertions
+---@field id fun(self: yazi.EventSource): string # for logging and test assertions
+---@field open fun(self: yazi.EventSource, on_lines: fun(lines: string[])): boolean, string? # acquire the resources the yazi command line refers to. Returns `false` and a message when the source cannot be used.
+---@field yazi_arguments fun(self: yazi.EventSource): string[] # extra arguments yazi itself must be started with
+---@field terminal_command fun(self: yazi.EventSource, yazi_command: string[]): string[] # the command Neovim runs in its terminal, given the yazi command line
+---@field environment fun(self: yazi.EventSource): table<string, string> # extra environment variables for that command
+---@field start fun(self: yazi.EventSource): nil # begin receiving events, now that yazi is running
+---@field close fun(self: yazi.EventSource, timeout: integer): nil
+---@field is_listening fun(self: yazi.EventSource): boolean
+---@field is_ready_signal fun(self: yazi.EventSource, event: YaziEvent): boolean # whether this event proves that yazi is up and reporting
+
+local M = {}
+
+---The DDS event kinds yazi.nvim needs in order to keep Neovim in sync with
+---what happens inside yazi. These are the shared kinds between all sources.
+---@param config YaziConfig
+---@return string[] kinds, table<string, boolean> forwarded_event_kinds
+function M.event_kinds(config)
+  local kinds = {
+    "rename",
+    "delete",
+    "trash",
+    "move",
+    "cd",
+    "hover",
+    "bulk",
+    "bulk-rename",
+  }
+
+  if config.future_features.yazi_plugin_keymaps ~= nil then
+    kinds[#kinds + 1] = "yazi-nvim"
+  end
+
+  ---@type table<string, boolean>
+  local forwarded_event_kinds = {}
+  if config.forwarded_dds_events ~= nil then
+    for _, event_kind in ipairs(config.forwarded_dds_events) do
+      kinds[#kinds + 1] = event_kind
+      forwarded_event_kinds[event_kind] = true
+    end
+  end
+
+  return kinds, forwarded_event_kinds
+end
+
+---@param config YaziConfig
+---@param yazi_id string
+---@return yazi.EventSource
+function M.create(config, yazi_id)
+  return require("yazi.process.event_source.ya_sub").new(config, yazi_id)
+end
+
+---@param config YaziConfig
+---@param yazi_id string
+---@return yazi.EventSource
+function M.create_fallback(config, yazi_id)
+  return require("yazi.process.event_source.ya_sub").new(config, yazi_id)
+end
+
+return M

--- a/lua/yazi/process/event_source/ya_sub.lua
+++ b/lua/yazi/process/event_source/ya_sub.lua
@@ -1,0 +1,173 @@
+local Log = require("yazi.log")
+local event_source = require("yazi.process.event_source")
+local utils = require("yazi.utils")
+
+--- Reads yazi's events from a separate `ya sub` process, which connects to the
+--- running yazi over DDS.
+---
+--- `ya sub` can only connect *after* yazi has started, and it retries once a
+--- second, so events that happen before it connects are never delivered.
+---
+---@class yazi.YaSubEventSource : yazi.EventSource
+---@field private config YaziConfig
+---@field private yazi_id string
+---@field private on_lines fun(lines: string[])
+---@field private ya_process? vim.SystemObj
+---@field private retries integer
+local YaSubEventSource = {}
+YaSubEventSource.__index = YaSubEventSource
+
+---@param config YaziConfig
+---@param yazi_id string
+---@return yazi.YaSubEventSource
+function YaSubEventSource.new(config, yazi_id)
+  local self = setmetatable({}, YaSubEventSource)
+
+  self.name = "ya-sub"
+  self.config = config
+  self.yazi_id = yazi_id
+  self.retries = 0
+
+  return self
+end
+
+---@param on_lines fun(lines: string[])
+---@return boolean, string?
+function YaSubEventSource:open(on_lines)
+  -- nothing to acquire: `ya sub` is started once yazi is running
+  self.on_lines = on_lines
+  return true, nil
+end
+
+---@return string[]
+function YaSubEventSource:yazi_arguments()
+  return {}
+end
+
+---@param yazi_command string[]
+---@return string[]
+function YaSubEventSource:terminal_command(yazi_command)
+  return yazi_command
+end
+
+---@return table<string, string>
+function YaSubEventSource:environment()
+  return {}
+end
+
+---@return boolean
+function YaSubEventSource:is_listening()
+  return self.ya_process ~= nil
+end
+
+---@return string
+function YaSubEventSource:id()
+  return self.yazi_id
+    .. "-"
+    .. (self.ya_process and self.ya_process.pid or "nil")
+end
+
+---When ya starts, it will send a "hi" event to all yazis. They respond with
+---"hey" to acknowledge this. We use this to detect when ya is ready, so that
+---integration-tests can safely start.
+---
+---The `hey` handshake is sent by whichever instance acts as the DDS server (it
+---might be a different yazi than what yazi.nvim starts), so `event.yazi_id`
+---(the sender) is not necessarily our yazi. Instead, detect the readiness of
+---our yazi by looking for its client-id in the peer list. This is robust even
+---when other yazi instances are running on the system.
+---@param event YaziEvent
+---@return boolean
+function YaSubEventSource:is_ready_signal(event)
+  if event.type ~= "hey" then
+    return false
+  end
+
+  ---@cast event YaziRawHeyEvent
+  return utils.parse_hey_peers(event.raw_data)[self.yazi_id] == true
+end
+
+function YaSubEventSource:start()
+  local event_kinds = event_source.event_kinds(self.config)
+  table.insert(event_kinds, "hey")
+
+  local ya_command = {
+    "ya",
+    "sub",
+    table.concat(event_kinds, ","),
+  }
+  Log:debug(
+    string.format(
+      "Opening ya with the command: (%s), attempt %s",
+      table.concat(ya_command, " "),
+      self.retries
+    )
+  )
+
+  self.ya_process = vim.system(ya_command, {
+    -- • text: (boolean) Handle stdout and stderr as text.
+    -- Replaces `\r\n` with `\n`.
+    text = true,
+    stderr = function(err, data)
+      if err then
+        Log:debug(string.format("ya stderr error: '%s'", data))
+      end
+
+      if data == nil then
+        -- weird event, ignore
+        return
+      end
+
+      Log:debug(string.format("ya stderr: '%s'", data))
+
+      if data:find("No running Yazi instance found") then
+        if self.retries < 5 then
+          Log:debug(
+            "Looks like starting ya failed because yazi had not started yet. Retrying to open ya..."
+          )
+          self.retries = self.retries + 1
+          vim.defer_fn(function()
+            self:start()
+          end, 50)
+        else
+          Log:debug("Failed to open ya after 5 retries")
+        end
+      end
+    end,
+
+    stdout = function(err, data)
+      if err then
+        Log:debug(string.format("ya stdout error: '%s'", data))
+      end
+      data = data or ""
+      data = data:gsub("\n+", "\n")
+
+      if not data:match("^hey") then
+        Log:debug(string.format("ya stdout: '%s'", data))
+      end
+
+      self.on_lines(vim.split(data, "\n", { plain = true, trimempty = true }))
+    end,
+
+    ---@param obj vim.SystemCompleted
+    on_exit = function(obj)
+      Log:debug(string.format("ya process exited with code: %s", obj.code))
+    end,
+  })
+end
+
+---@param timeout integer
+function YaSubEventSource:close(timeout)
+  if self.ya_process == nil then
+    return
+  end
+
+  Log:debug("Killing ya process")
+  pcall(self.ya_process.kill, self.ya_process, "sigterm")
+
+  Log:debug("Waiting for ya process to exit")
+  self.ya_process:wait(timeout)
+  self.ya_process = nil
+end
+
+return YaSubEventSource

--- a/lua/yazi/process/ya_process.lua
+++ b/lua/yazi/process/ya_process.lua
@@ -1,20 +1,27 @@
 ---@module "plenary.path"
 
 local Log = require("yazi.log")
+local event_source = require("yazi.process.event_source")
 local utils = require("yazi.utils")
 local YaziSessionHighlighter =
   require("yazi.buffer_highlighting.yazi_session_highlighter")
 
+---Tracks the state of one running yazi (what is hovered, where it is) and
+---turns the events it reports into changes in Neovim.
+---
+---Where those events come from is the business of the `yazi.EventSource` it
+---holds - either a separate `ya sub` process or yazi's own stdout.
+---
 ---@class YaProcess
 ---@field public hovered_url? string "The path that is currently hovered over in this yazi."
 ---@field public cwd? string "The path that the yazi process is currently in."
 ---@field private config YaziConfig
 ---@field public yazi_id string "The YAZI_ID of the yazi process"
----@field private ya_process vim.SystemObj
----@field private retries integer
+---@field public event_source yazi.EventSource
 ---@field private highlighter YaziSessionHighlighter
 ---@field private on_first_output fun()
 ---@field public ready boolean
+---@field private forwarded_event_kinds table<string, boolean>
 local YaProcess = {}
 ---@diagnostic disable-next-line: inject-field
 YaProcess.__index = YaProcess
@@ -29,25 +36,64 @@ function YaProcess.new(config, yazi_id, on_first_output, initial_file)
   self.yazi_id = yazi_id
   self.hovered_url = initial_file
   self.config = config
-  self.retries = 0
   self.highlighter = YaziSessionHighlighter.new()
   self.on_first_output = on_first_output
   self.ready = false
+  self.event_source = event_source.create(config, yazi_id)
+
+  local _, forwarded_event_kinds = event_source.event_kinds(config)
+  self.forwarded_event_kinds = forwarded_event_kinds
 
   return self
 end
 
+function YaProcess:id()
+  return "yazi-"
+    .. self.yazi_id
+    .. "-"
+    .. self.event_source.name
+    .. "-"
+    .. self.event_source:id()
+end
+
 function YaProcess:is_ready()
-  local has_process = self.ya_process ~= nil
+  local is_listening = self.event_source:is_listening()
   local on_first_output_called = self.on_first_output == nil
   local is_ready = self.ready == true
-  local ready = has_process and on_first_output_called and is_ready
+  local ready = is_listening and on_first_output_called and is_ready
   return ready,
     {
-      has_process = has_process,
+      id = self:id(),
+      event_source = self.event_source.name,
+      is_listening = is_listening,
       on_first_output_called = on_first_output_called,
       is_ready = is_ready,
     }
+end
+
+---Set up the transport that will deliver yazi's events. Must be called before
+---the yazi command line is built, because the source may need to put something
+---in it.
+---@param context YaziActiveContext
+function YaProcess:open_event_source(context)
+  local on_lines = function(lines)
+    self:handle_event_lines(lines, context)
+  end
+
+  local ok, error_message = self.event_source:open(on_lines)
+  if ok then
+    return
+  end
+
+  Log:debug(
+    string.format(
+      "Could not use the '%s' event source (%s), falling back to `ya sub`",
+      self.event_source.name,
+      tostring(error_message)
+    )
+  )
+  self.event_source = event_source.create_fallback(self.config, self.yazi_id)
+  assert(self.event_source:open(on_lines))
 end
 
 ---@param items string[]
@@ -89,6 +135,8 @@ function YaProcess:get_yazi_command(paths)
     table.insert(command_words, self.config.cwd_file_path)
   end
 
+  vim.list_extend(command_words, self.event_source:yazi_arguments())
+
   command_words = remove_duplicates(command_words)
 
   return command_words
@@ -96,234 +144,147 @@ end
 
 ---@param timeout integer
 function YaProcess:kill_and_wait(timeout)
-  Log:debug("Killing ya process")
-  pcall(self.ya_process.kill, self.ya_process, "sigterm")
   self.highlighter:clear_highlights()
-
-  Log:debug("Waiting for ya process to exit")
-  self.ya_process:wait(timeout)
+  self.event_source:close(timeout)
 end
 
----@param context YaziActiveContext
-function YaProcess:start(context)
-  local event_kinds = {
-    "rename",
-    "delete",
-    "trash",
-    "move",
-    "cd",
-    "hover",
-    "bulk",
-    "bulk-rename",
-    -- when ya starts, it will send a "hi" event to all yazis. They respond
-    -- with "hey" to acknowledge this. We can use this to detect when ya is
-    -- ready, so that integration-tests can safely start.
-    "hey",
-  }
-
-  -- subscribe to the events published by the `nvim.yazi` plugin if the user
-  -- has enabled it.
-  if self.config.future_features.yazi_plugin_keymaps ~= nil then
-    event_kinds[#event_kinds + 1] = "yazi-nvim"
-  end
-
-  ---@type table<string,boolean>
-  local interesting_events = {}
-  if self.config.forwarded_dds_events ~= nil then
-    for _, event_kind in ipairs(self.config.forwarded_dds_events) do
-      event_kinds[#event_kinds + 1] = event_kind
-      interesting_events[event_kind] = true
-    end
-  end
-
-  local ya_command = {
-    "ya",
-    "sub",
-    table.concat(event_kinds, ","),
-  }
-  Log:debug(
-    string.format(
-      "Opening ya with the command: (%s), attempt %s",
-      table.concat(ya_command, " "),
-      self.retries
-    )
-  )
-
-  self.ya_process = vim.system(ya_command, {
-    -- • text: (boolean) Handle stdout and stderr as text.
-    -- Replaces `\r\n` with `\n`.
-    text = true,
-    stderr = function(err, data)
-      if err then
-        Log:debug(string.format("ya stderr error: '%s'", data))
-      end
-
-      if data == nil then
-        -- weird event, ignore
-        return
-      end
-
-      Log:debug(string.format("ya stderr: '%s'", data))
-
-      if data:find("No running Yazi instance found") then
-        if self.retries < 5 then
-          Log:debug(
-            "Looks like starting ya failed because yazi had not started yet. Retrying to open ya..."
-          )
-          self.retries = self.retries + 1
-          vim.defer_fn(function()
-            self:start(context)
-          end, 50)
-        else
-          Log:debug("Failed to open ya after 5 retries")
-        end
-      end
-    end,
-
-    stdout = function(err, data)
-      if err then
-        Log:debug(string.format("ya stdout error: '%s'", data))
-      end
-      data = data or ""
-      data = data:gsub("\n+", "\n")
-
-      if not data:match("^hey") then
-        Log:debug(string.format("ya stdout: '%s'", data))
-      end
-
-      data = vim.split(data, "\n", { plain = true, trimempty = true })
-
-      local parsed = utils.safe_parse_events(data)
-      -- Log:debug(string.format("Parsed events: %s", vim.inspect(parsed)))
-
-      self:process_events(parsed, interesting_events, context)
-    end,
-
-    ---@param obj vim.SystemCompleted
-    on_exit = function(obj)
-      Log:debug(string.format("ya process exited with code: %s", obj.code))
-    end,
-  })
-
+---Begin receiving events, now that yazi is running.
+function YaProcess:start()
+  self.event_source:start()
   return self
+end
+
+---Feed a batch of raw event lines, as reported by the event source, into the
+---event handling.
+---@param lines string[]
+---@param context YaziActiveContext
+function YaProcess:handle_event_lines(lines, context)
+  local parsed = utils.safe_parse_events(lines)
+  -- Log:debug(string.format("Parsed events: %s", vim.inspect(parsed)))
+
+  self:process_events(parsed, self.forwarded_event_kinds, context)
 end
 
 ---@param events YaziEvent[]
 ---@param forwarded_event_kinds table<string,boolean>
 ---@param context YaziActiveContext
 function YaProcess:process_events(events, forwarded_event_kinds, context)
+  for _, event in ipairs(events) do
+    if self.ready ~= true and self.event_source:is_ready_signal(event) then
+      Log:debug(
+        string.format(
+          "The event source (%s) is ready, yazi_id: %s",
+          self.event_source.name,
+          self.yazi_id
+        )
+      )
+      self.ready = true
+      self.on_first_output()
+      self.on_first_output = nil
+    end
+
+    self:process_event(event, forwarded_event_kinds, context)
+  end
+end
+
+---@private
+---@param event YaziEvent
+---@param forwarded_event_kinds table<string,boolean>
+---@param context YaziActiveContext
+function YaProcess:process_event(event, forwarded_event_kinds, context)
   local nvim_event_handling = require("yazi.event_handling.nvim_event_handling")
   local yazi_event_handling = require("yazi.event_handling.yazi_event_handling")
 
-  for _, event in ipairs(events) do
-    if self.ready ~= true and event.type == "hey" then
-      ---@cast event YaziRawHeyEvent
-      -- The `hey` handshake is sent by whichever instance acts as the DDS
-      -- server, so `event.yazi_id` (the sender) is not necessarily our yazi.
-      -- Instead, detect the readiness of our yazi by looking for its client-id
-      -- in the peer list. This is robust even when other yazi instances are
-      -- running on the system. The peers are parsed lazily here as we only
-      -- need to do this once.
-      local peers = utils.parse_hey_peers(event.raw_data)
-      if peers[self.yazi_id] == true then
-        Log:debug(
-          string.format("ya process is ready, yazi_id: %s", self.yazi_id)
-        )
-        self.ready = true
-        self.on_first_output()
-        self.on_first_output = nil
-      end
-    elseif event.type == "hover" and event.yazi_id == self.yazi_id then
-      -- Only track hovers from our own yazi. The DDS bus is shared across all
-      -- yazi instances on the system, so other instances (e.g. another yazi
-      -- the user has open, or a not-yet-exited one from a previous test) also
-      -- broadcast `hover` events. Honoring them would corrupt our
-      -- `hovered_url`. The `cd` handler below filters by `yazi_id` for the
-      -- same reason.
-      ---@cast event YaziHoverEvent
-      Log:debug(
-        string.format(
-          "Changing the hovered url from %s to %s",
-          self.hovered_url,
-          event.url
-        )
+  if event.type == "hey" then
+    -- a `ya sub` handshake, only interesting for detecting readiness above
+    return
+  elseif event.type == "hover" and event.yazi_id == self.yazi_id then
+    -- Only track hovers from our own yazi. The DDS bus is shared across all
+    -- yazi instances on the system, so other instances (e.g. another yazi
+    -- the user has open, or a not-yet-exited one from a previous test) also
+    -- broadcast `hover` events. Honoring them would corrupt our
+    -- `hovered_url`. The `cd` handler below filters by `yazi_id` for the
+    -- same reason.
+    ---@cast event YaziHoverEvent
+    Log:debug(
+      string.format(
+        "Changing the hovered url from %s to %s",
+        self.hovered_url,
+        event.url
       )
-      self.hovered_url = event.url
+    )
+    self.hovered_url = event.url
+    vim.schedule(function()
+      if self.config.highlight_hovered_buffers_in_same_directory then
+        self.highlighter:highlight_buffers_when_hovered(event.url, self.config)
+      else
+        Log:debug("Skipping buffer highlighting (disabled in config)")
+      end
+
+      nvim_event_handling.emit("YaziDDSHover", event)
+    end)
+  elseif event.type == "cd" and event.yazi_id == self.yazi_id then
+    ---@cast event YaziHoverEvent
+    Log:debug(
+      string.format("Changing the cwd from %s to %s", self.cwd, event.url)
+    )
+    self.cwd = event.url
+  elseif event.type == "cycle-buffer" then
+    vim.schedule(function()
+      ---@cast event YaziNvimCycleBufferEvent
+      yazi_event_handling.process_event_emitted_from_yazi(
+        event,
+        self.config,
+        context
+      )
+    end)
+  elseif event.type == "yazi-nvim" then
+    ---@cast event YaziCustomDDSEvent
+    vim.schedule(function()
+      yazi_event_handling.process_plugin_keymap_event(
+        event,
+        self.yazi_id,
+        self.config,
+        context
+      )
+    end)
+  else
+    if
+      event.type == "rename"
+      or event.type == "move"
+      or event.type == "bulk"
+      or event.type == "bulk-rename"
+    then
       vim.schedule(function()
-        if self.config.highlight_hovered_buffers_in_same_directory then
-          self.highlighter:highlight_buffers_when_hovered(
-            event.url,
-            self.config
-          )
-        else
-          Log:debug("Skipping buffer highlighting (disabled in config)")
+        local success, result = pcall(function()
+          nvim_event_handling.emit_renamed_or_moved_event(event)
+        end)
+        if not success then
+          Log:debug(vim.inspect({
+            "Failed to emit YaziRenamedOrMoved event",
+            event,
+            result,
+          }))
         end
 
-        nvim_event_handling.emit("YaziDDSHover", event)
-      end)
-    elseif event.type == "cd" and event.yazi_id == self.yazi_id then
-      ---@cast event YaziHoverEvent
-      Log:debug(
-        string.format("Changing the cwd from %s to %s", self.cwd, event.url)
-      )
-      self.cwd = event.url
-    elseif event.type == "cycle-buffer" then
-      vim.schedule(function()
-        ---@cast event YaziNvimCycleBufferEvent
         yazi_event_handling.process_event_emitted_from_yazi(
           event,
           self.config,
           context
         )
       end)
-    elseif event.type == "yazi-nvim" then
-      ---@cast event YaziCustomDDSEvent
+    elseif forwarded_event_kinds[event.type] ~= nil then
       vim.schedule(function()
-        yazi_event_handling.process_plugin_keymap_event(
+        nvim_event_handling.emit("YaziDDSCustom", event)
+      end)
+    else
+      vim.schedule(function()
+        yazi_event_handling.process_event_emitted_from_yazi(
           event,
-          self.yazi_id,
           self.config,
           context
         )
       end)
-    else
-      if
-        event.type == "rename"
-        or event.type == "move"
-        or event.type == "bulk"
-        or event.type == "bulk-rename"
-      then
-        vim.schedule(function()
-          local success, result = pcall(function()
-            nvim_event_handling.emit_renamed_or_moved_event(event)
-          end)
-          if not success then
-            Log:debug(vim.inspect({
-              "Failed to emit YaziRenamedOrMoved event",
-              event,
-              result,
-            }))
-          end
-
-          yazi_event_handling.process_event_emitted_from_yazi(
-            event,
-            self.config,
-            context
-          )
-        end)
-      elseif forwarded_event_kinds[event.type] ~= nil then
-        vim.schedule(function()
-          nvim_event_handling.emit("YaziDDSCustom", event)
-        end)
-      else
-        vim.schedule(function()
-          yazi_event_handling.process_event_emitted_from_yazi(
-            event,
-            self.config,
-            context
-          )
-        end)
-      end
     end
   end
 end

--- a/lua/yazi/process/yazi_process.lua
+++ b/lua/yazi/process/yazi_process.lua
@@ -36,11 +36,6 @@ function YaziProcess:start(config, paths, callbacks)
     callbacks.on_ya_first_event(self.api)
   end, assert(paths[1]).filename)
 
-  local yazi_cmd = self.ya_process:get_yazi_command(paths)
-  Log:debug(
-    string.format("Opening yazi with the command: (%s).", vim.inspect(yazi_cmd))
-  )
-
   ---@type YaziActiveContext
   local context = {
     api = self.api,
@@ -49,13 +44,27 @@ function YaziProcess:start(config, paths, callbacks)
     input_path = paths[1],
   }
 
-  local env = {
+  -- the event source may need to put something in the yazi command line, so it
+  -- has to be set up before the command is built
+  self.ya_process:open_event_source(context)
+
+  local yazi_cmd = self.ya_process:get_yazi_command(paths)
+  local terminal_cmd = self.ya_process.event_source:terminal_command(yazi_cmd)
+
+  Log:debug(
+    string.format(
+      "Opening yazi with the command: (%s).",
+      vim.inspect(terminal_cmd)
+    )
+  )
+
+  local env = vim.tbl_extend("error", {
     -- expose NVIM_CWD so that yazi keybindings can use it to offer basic
     -- neovim specific functionality
     NVIM_CWD = vim.uv.cwd(),
     YAZI_CONFIG_HOME = config.config_home,
     YAZI_NVIM_ID = yazi_id,
-  }
+  }, self.ya_process.event_source:environment())
 
   -- hand the user-configured `plugin_keymaps` to the `nvim.yazi` plugin, which
   -- registers them inside yazi at runtime.
@@ -65,7 +74,7 @@ function YaziProcess:start(config, paths, callbacks)
       plugin_keymaps.serialize(config.future_features.yazi_plugin_keymaps)
   end
 
-  self.yazi_job_id = vim.fn.jobstart(yazi_cmd, {
+  self.yazi_job_id = vim.fn.jobstart(terminal_cmd, {
     term = true,
     env = env,
     on_exit = function(_, code)
@@ -106,7 +115,7 @@ function YaziProcess:start(config, paths, callbacks)
     end,
   })
 
-  self.ya_process:start(context)
+  self.ya_process:start()
 
   return self, context
 end

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -32,14 +32,29 @@ function YaziProcessApi:emit_to_yazi(args)
     { "ya", "emit-to", self.yazi_id, unpack(args) },
     { timeout = 1000 },
     function(result)
-      Log:debug(
-        string.format(
-          "emit_to_yazi: ya succeeded: 'ya emit-to %s' with args: '%s' and result '%s'",
-          self.yazi_id,
-          vim.inspect(args),
-          vim.inspect(result)
+      if result.code == 0 then
+        Log:debug(
+          string.format(
+            "emit_to_yazi: ya succeeded: 'ya emit-to %s' with args: '%s' and result '%s'",
+            self.yazi_id,
+            vim.inspect(args),
+            vim.inspect(result)
+          )
         )
-      )
+      else
+        -- The command never reached yazi. This happens e.g. when the DDS
+        -- socket is gone ("Connection refused"), so the caller's request was
+        -- silently dropped.
+        Log:error(
+          string.format(
+            "emit_to_yazi: ya failed with exit code %s: 'ya emit-to %s' with args: '%s' and stderr '%s'",
+            result.code,
+            self.yazi_id,
+            vim.inspect(args),
+            vim.trim(result.stderr or "")
+          )
+        )
+      end
     end
   )
 end


### PR DESCRIPTION
# refactor: formalize ya sub as an EventSource abstraction

In a later commit, I want to add a second EventSource so that two different transports can be used to receive events from yazi. This commit prepares for that.

---

# Pull request stack

- https://github.com/mikavilpas/yazi.nvim/pull/2088
  - 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2084 👈🏻
    - https://github.com/mikavilpas/yazi.nvim/pull/2085