### PR TITLE
fix(opt-in): dropping yazi events when ya is slow to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,12 @@ return {
       -- use a file to store the last directory that yazi was in before it was
       -- closed. Defaults to `true`.
       use_cwd_file = true,
+
+      -- read yazi's events from yazi itself instead of from a separate `ya
+      -- sub` process. See
+      -- [documentation/reading-events-from-yazi.md](./documentation/reading-events-from-yazi.md).
+      -- Defaults to `false`.
+      use_local_events = false,
     },
   },
 }

--- a/documentation/reading-events-from-yazi.md
+++ b/documentation/reading-events-from-yazi.md
@@ -1,0 +1,67 @@
+# Reading events from yazi (`use_local_events`)
+
+> [!NOTE]
+>
+> This is an experimental opt-in feature. Enable it with
+>
+> ```lua
+> require("yazi").setup({
+>   future_features = {
+>     use_local_events = true,
+>   },
+> })
+> ```
+
+## The problem
+
+yazi.nvim keeps Neovim in sync with what happens inside yazi (renames, moves, deletes, the hovered file, …) by
+subscribing to yazi's [DDS](https://yazi-rs.github.io/docs/dds) events.
+
+Until now that was done with a second process, `ya sub`, which connects to the running yazi over DDS. `ya sub` can only
+be started _after_ yazi has started, and it retries the connection once per second. Anything that happens before it
+connects is never delivered.
+
+In practice that means a rename done in the first moment after yazi opens does not propagate to the open buffer. The
+window is usually small enough not to matter, but it grows with anything that makes starting a process slow - Windows in
+general, or a live malware scanner that inspects every new executable.
+
+See [the upstream discussion](https://github.com/sxyazi/yazi/discussions/4139) for the report and the analysis.
+
+## The approach
+
+yazi can report its own events straight to _its own stdout_ with `--local-events`, which makes `ya sub` unnecessary -
+the events are then available from yazi's very first millisecond, and nothing can be dropped.
+
+yazi.nvim could not use that on its own. yazi is interactive, so it has to run in Neovim's `:terminal`, and the embedded
+terminal hands the child a pty for stdin, stdout and stderr alike; it cannot read the stream separately while the
+program is running.
+
+So yazi.nvim starts a small wrapper program in the terminal instead of yazi. The wrapper spawns yazi as its child with a
+real pipe for stdout, while stdin, stderr and the controlling terminal are passed through untouched, and forwards
+everything yazi writes back to yazi.nvim over a loopback TCP socket:
+
+```mermaid
+sequenceDiagram
+
+participant neovim
+participant wrapper as wrapper (nvim -l)
+participant yazi
+
+neovim->>neovim: listen for events on 127.0.0.1, random free port
+neovim->>wrapper: start in :terminal, pass the port and a one-time token
+wrapper->>yazi: spawn with stdout piped, --local-events=…
+wrapper->>neovim: connect over TCP, send the token
+yazi->>wrapper: report events on stdout (from the first millisecond)
+wrapper->>neovim: forward the events over TCP
+neovim->>neovim: rename buffers, highlight, emit autocmds
+yazi->>wrapper: exit
+wrapper->>neovim: exit with yazi's exit code
+```
+
+This does not disturb the UI, because yazi draws to the controlling terminal (`/dev/tty`, or `CONOUT$` on Windows) and
+not to stdout.
+
+The wrapper is
+[`lua/yazi/process/event_source/local_events_wrapper.lua`](../lua/yazi/process/event_source/local_events_wrapper.lua),
+run by `nvim -l` - Neovim as a plain Lua interpreter. That needs no new dependency, costs about 20ms, and does not load
+your Neovim config.

--- a/integration-tests/test-environment/.config/nvim/init.lua
+++ b/integration-tests/test-environment/.config/nvim/init.lua
@@ -57,7 +57,9 @@ vim.list_extend(plugins, {
       clipboard_register = '"',
       -- allows logging debug data, which can be shown in CI when cypress tests fail
       log_level = vim.log.levels.DEBUG,
-      future_features = {},
+      future_features = {
+        use_local_events = true,
+      },
     },
   },
 })

--- a/lua/yazi/config.lua
+++ b/lua/yazi/config.lua
@@ -23,6 +23,7 @@ function M.default()
     future_features = {
       use_cwd_file = true,
       yazi_plugin_keymaps = {},
+      use_local_events = false,
     },
     open_multiple_tabs = false,
     enable_mouse_support = false,

--- a/lua/yazi/process/event_source/init.lua
+++ b/lua/yazi/process/event_source/init.lua
@@ -64,6 +64,13 @@ end
 ---@param yazi_id string
 ---@return yazi.EventSource
 function M.create(config, yazi_id)
+  if config.future_features.use_local_events == true then
+    return require("yazi.process.event_source.local_events").new(
+      config,
+      yazi_id
+    )
+  end
+
   return require("yazi.process.event_source.ya_sub").new(config, yazi_id)
 end
 

--- a/lua/yazi/process/event_source/local_events.lua
+++ b/lua/yazi/process/event_source/local_events.lua
@@ -1,0 +1,123 @@
+local Log = require("yazi.log")
+local event_source = require("yazi.process.event_source")
+
+--- A source that reads events from yazi's stdout directly. Because of nvim
+--- limitations with reading stdout from an interactive terminal application
+--- (yazi), a small wrapper program is used to forward yazi's stdout over a TCP
+--- socket.
+---
+---@class yazi.LocalEventsSource : yazi.EventSource
+---@field private config YaziConfig
+---@field private yazi_id string
+---@field private server? yazi.LocalEventServer
+local LocalEventsSource = {}
+LocalEventsSource.__index = LocalEventsSource
+
+---Path to the wrapper program that `nvim -l` runs.
+---@return string
+local function wrapper_script_path()
+  local this_file = debug.getinfo(1, "S").source:sub(2)
+  return vim.fs.joinpath(
+    vim.fn.fnamemodify(this_file, ":h"),
+    "local_events_wrapper.lua"
+  )
+end
+
+---@param config YaziConfig
+---@param yazi_id string
+---@return yazi.LocalEventsSource
+function LocalEventsSource.new(config, yazi_id)
+  local self = setmetatable({}, LocalEventsSource)
+
+  self.name = "yazi --local-events"
+  self.config = config
+  self.yazi_id = yazi_id
+
+  return self
+end
+
+---@param on_lines fun(lines: string[])
+---@return boolean, string?
+function LocalEventsSource:open(on_lines)
+  local LocalEventServer =
+    require("yazi.process.event_source.local_events_server")
+
+  local server, error_message = LocalEventServer.start(on_lines)
+  if server == nil then
+    return false, error_message
+  end
+
+  self.server = server
+  return true, nil
+end
+
+---@return string[]
+function LocalEventsSource:yazi_arguments()
+  -- ask yazi to report its own events to its stdout, which the wrapper pipes
+  -- back to us. This replaces `ya sub`.
+  local event_kinds = event_source.event_kinds(self.config)
+  return { "--local-events=" .. table.concat(event_kinds, ",") }
+end
+
+--- Run the wrapper in the terminal, with yazi as its child, so that yazi's
+--- stdout can be read while yazi is running.
+---@param yazi_command string[]
+---@return string[]
+function LocalEventsSource:terminal_command(yazi_command)
+  local server = assert(self.server, "the event source has not been opened")
+
+  local command = vim.list_slice(yazi_command)
+  local yazi_executable = table.remove(command, 1)
+
+  return vim.list_extend({
+    vim.v.progpath,
+    "-l",
+    wrapper_script_path(),
+    tostring(server.port),
+    server:get_token(),
+    yazi_executable,
+  }, command)
+end
+
+---@return table<string, string>
+function LocalEventsSource:environment()
+  return {
+    -- tell the `nvim.yazi` plugin to publish its events locally (so they end
+    -- up on yazi's stdout) instead of broadcasting them to remote peers
+    YAZI_NVIM_LOCAL_EVENTS = "1",
+  }
+end
+
+---@return boolean
+function LocalEventsSource:is_listening()
+  return self.server ~= nil
+end
+
+---Receiving anything at all proves yazi is running and reporting events, so it
+---takes the place of the `hey` handshake that `ya sub` relies on.
+---@param _event YaziEvent
+---@return boolean
+---@diagnostic disable-next-line: unused-local
+function LocalEventsSource:is_ready_signal(_event)
+  assert(self.server ~= nil, "the event source has not been opened")
+  return true
+end
+
+function LocalEventsSource:start()
+  -- the server is already listening; yazi's own stdout is the transport, so
+  -- there is no second process to start
+  Log:debug("Reading events from yazi's stdout, not starting `ya sub`")
+end
+
+---@param _timeout integer
+---@diagnostic disable-next-line: unused-local
+function LocalEventsSource:close(_timeout)
+  if self.server == nil then
+    return
+  end
+
+  self.server:close()
+  self.server = nil
+end
+
+return LocalEventsSource

--- a/lua/yazi/process/event_source/local_events_server.lua
+++ b/lua/yazi/process/event_source/local_events_server.lua
@@ -1,0 +1,196 @@
+local Log = require("yazi.log")
+
+--- A loopback TCP server that receives the DDS events yazi reports to its
+--- stdout. The other end is `local_events_wrapper.lua`, which yazi.nvim starts
+--- in the Neovim terminal in place of yazi itself.
+---
+--- Only complete lines are handed to the callback: a TCP read can split a
+--- single event across two chunks, and yazi's event format is line based.
+---@class yazi.LocalEventServer
+---@field private server uv.uv_tcp_t
+---@field private clients uv.uv_tcp_t[]
+---@field private token string
+---@field public port integer
+local LocalEventServer = {}
+LocalEventServer.__index = LocalEventServer
+
+---@return string
+local function generate_token()
+  return string.format("%.0f-%d", vim.uv.hrtime(), math.random(0, 2 ^ 30))
+end
+
+---@param on_lines fun(lines: string[]) # called (on the main loop) with each batch of complete event lines
+---@return yazi.LocalEventServer | nil, string | nil # the server, or nil and an error message
+function LocalEventServer.start(on_lines)
+  local self = setmetatable({}, LocalEventServer)
+  self.clients = {}
+  self.token = generate_token()
+
+  -- libuv reports a failure by returning nil along with a message that already
+  -- contains its symbolic name, such as "EADDRINUSE: address already in use"
+  local server, new_tcp_error = vim.uv.new_tcp()
+  if server == nil then
+    return nil,
+      string.format(
+        "could not create a tcp socket: %s",
+        new_tcp_error or "unknown error"
+      )
+  end
+  self.server = server
+
+  -- port 0 means "any free port". Binding to the loopback interface keeps the
+  -- socket unreachable from outside this machine; the token check in `accept`
+  -- protects against other local processes.
+  local bound, bind_error = server:bind("127.0.0.1", 0)
+  if bound == nil then
+    server:close()
+    return nil,
+      string.format(
+        "could not bind to 127.0.0.1: %s",
+        bind_error or "unknown error"
+      )
+  end
+
+  local listening, listen_error = server:listen(1, function(connection_error)
+    if connection_error ~= nil then
+      Log:debug(
+        string.format(
+          "Could not receive a local event connection: %s",
+          connection_error
+        )
+      )
+      return
+    end
+    ---@diagnostic disable-next-line: invisible
+    self:accept(on_lines)
+  end)
+  if listening == nil then
+    server:close()
+    return nil,
+      string.format(
+        "could not listen for connections: %s",
+        listen_error or "unknown error"
+      )
+  end
+
+  local name, getsockname_error = server:getsockname()
+  if name == nil then
+    server:close()
+    return nil,
+      string.format(
+        "could not resolve the port of the local event server: %s",
+        getsockname_error or "unknown error"
+      )
+  end
+  if name.port == nil then
+    server:close()
+    return nil, "the local event server was not given a port"
+  end
+
+  self.port = name.port
+  Log:debug(
+    string.format("Started the local event server on port %s", self.port)
+  )
+
+  return self, nil
+end
+
+---@return string
+function LocalEventServer:get_token()
+  return self.token
+end
+
+---@private
+---@param on_lines fun(lines: string[])
+function LocalEventServer:accept(on_lines)
+  local client, new_tcp_error = vim.uv.new_tcp()
+  if client == nil then
+    Log:debug(
+      string.format(
+        "Could not create a socket for an incoming local event connection: %s",
+        new_tcp_error or "unknown error"
+      )
+    )
+    return
+  end
+
+  -- note that `accept` reports a failure by returning nil rather than by
+  -- raising, so its return value has to be checked
+  local accepted, accept_error = self.server:accept(client)
+  if accepted == nil then
+    Log:debug(
+      string.format(
+        "Could not accept a local event connection: %s",
+        accept_error or "unknown error"
+      )
+    )
+    client:close()
+    return
+  end
+
+  self.clients[#self.clients + 1] = client
+
+  -- everything received before the token line has been verified
+  local buffer = ""
+  local authenticated = false
+
+  client:read_start(function(err, chunk)
+    if err ~= nil or chunk == nil then
+      if not client:is_closing() then
+        client:close()
+      end
+      return
+    end
+
+    buffer = buffer .. chunk
+
+    ---@type string[]
+    local lines = {}
+    while true do
+      local newline = buffer:find("\n", 1, true)
+      if newline == nil then
+        break
+      end
+      lines[#lines + 1] = buffer:sub(1, newline - 1)
+      buffer = buffer:sub(newline + 1)
+    end
+
+    if #lines == 0 then
+      return
+    end
+
+    if not authenticated then
+      local presented = table.remove(lines, 1)
+      if presented ~= self.token then
+        Log:debug(
+          "A client connected to the local event server with a bad token, dropping it"
+        )
+        client:close()
+        return
+      end
+      authenticated = true
+      if #lines == 0 then
+        return
+      end
+    end
+
+    vim.schedule(function()
+      on_lines(lines)
+    end)
+  end)
+end
+
+function LocalEventServer:close()
+  for _, client in ipairs(self.clients) do
+    if not client:is_closing() then
+      pcall(client.close, client)
+    end
+  end
+  self.clients = {}
+
+  if self.server ~= nil and not self.server:is_closing() then
+    pcall(self.server.close, self.server)
+  end
+end
+
+return LocalEventServer

--- a/lua/yazi/process/event_source/local_events_wrapper.lua
+++ b/lua/yazi/process/event_source/local_events_wrapper.lua
@@ -1,0 +1,177 @@
+-- A tiny wrapper program that is executed with `nvim -l` (Neovim as a plain
+-- Lua interpreter, ~20ms of startup and no user config loaded).
+--
+-- Why does this exist? Read documentation/reading-events-from-yazi.md
+--
+-- Usage: nvim -l local_events_wrapper.lua <port> <token> <yazi> [args...]
+
+local uv = vim.uv or vim.loop
+
+-- `arg` is only set when Neovim is run as `nvim -l`.
+-- selene: allow(global_usage)
+local argv = _G.arg
+
+-- When this file is `require()`d as an ordinary module (a stray require,
+-- :checkhealth, a documentation generator) there is nothing to do.
+if argv == nil or argv[1] == nil then
+  return {}
+end
+
+---The terminal belongs to yazi, and stdout is the event stream, so problems
+---can only be reported on stderr.
+---@param message string
+local function warn(message)
+  -- selene: allow(incorrect_standard_library_use)
+  io.stderr:write(message)
+end
+
+local port = tonumber(argv[1])
+local token = argv[2]
+local yazi_executable = argv[3]
+
+local yazi_args = {}
+for i = 4, #argv do
+  yazi_args[#yazi_args + 1] = argv[i]
+end
+
+if port == nil or token == nil or yazi_executable == nil then
+  warn("yazi.nvim: local_events_wrapper.lua called with bad args\n")
+  os.exit(1)
+end
+
+---Bytes yazi produced before the socket finished connecting. Buffering them
+---means the events yazi reports during its own startup are not lost, which is
+---the entire point of this program.
+---@type string[]
+local pending = {}
+local connected = false
+
+local socket = uv.new_tcp()
+
+---Give up on reporting events. yazi itself keeps running - the user gets a
+---working file manager, just without the Neovim integration, which is far
+---better than killing their editor's terminal.
+local function abandon_socket()
+  pending = {}
+  connected = false
+  if socket ~= nil and not socket:is_closing() then
+    socket:close()
+  end
+  socket = nil
+end
+
+---@param data string
+local function forward(data)
+  local connection = socket
+  if connection == nil then
+    return
+  elseif not connected then
+    pending[#pending + 1] = data
+    return
+  end
+
+  local ok = pcall(connection.write, connection, data)
+  if not ok then
+    abandon_socket()
+  end
+end
+
+if socket == nil then
+  -- yazi will still run, just without telling Neovim what happens in it
+  warn("yazi.nvim: could not create the event socket\n")
+else
+  socket:connect("127.0.0.1", port, function(err)
+    local connection = socket
+    if err ~= nil or connection == nil then
+      abandon_socket()
+      return
+    end
+
+    connected = true
+    -- The first line proves to yazi.nvim that we are the wrapper it started,
+    -- and not some other local process that guessed the port.
+    local buffered = table.concat(pending)
+    pending = {}
+    local ok = pcall(connection.write, connection, token .. "\n" .. buffered)
+    if not ok then
+      abandon_socket()
+    end
+  end)
+end
+
+local stdout = assert(uv.new_pipe(false), "could not create a stdout pipe")
+
+local yazi_exited = false
+local stdout_closed = false
+local exit_code = 0
+
+local function finish()
+  if not (yazi_exited and stdout_closed) then
+    return
+  end
+
+  if socket ~= nil and not socket:is_closing() then
+    socket:shutdown(function()
+      abandon_socket()
+      uv.stop()
+    end)
+  else
+    uv.stop()
+  end
+end
+
+-- Start yazi immediately rather than waiting for the socket to connect, so the
+-- wrapper adds no perceptible delay to how fast yazi appears.
+local handle, spawn_error = uv.spawn(yazi_executable, {
+  args = yazi_args,
+  -- stdin and stderr are inherited from the terminal Neovim gave us. yazi
+  -- opens the controlling terminal itself for drawing, so it is unaffected by
+  -- stdout being a pipe.
+  stdio = { 0, stdout, 2 },
+}, function(code)
+  exit_code = code or 0
+  yazi_exited = true
+  finish()
+end)
+
+if handle == nil then
+  warn(
+    string.format(
+      "yazi.nvim: failed to start '%s': %s\n",
+      yazi_executable,
+      tostring(spawn_error)
+    )
+  )
+  os.exit(1)
+end
+
+stdout:read_start(function(err, data)
+  if err ~= nil or data == nil then
+    -- read error, or end of stream because yazi closed its stdout
+    if not stdout:is_closing() then
+      stdout:close()
+    end
+    stdout_closed = true
+    finish()
+    return
+  end
+
+  forward(data)
+end)
+
+-- Neovim terminates the terminal job by signalling this process. Pass that on
+-- to yazi so it can restore the terminal and write its chooser/cwd files,
+-- instead of being orphaned.
+for _, name in ipairs({ "sigterm", "sighup", "sigint" }) do
+  local signal = uv.new_signal()
+  if signal ~= nil then
+    signal:start(name, function()
+      pcall(handle.kill, handle, name)
+    end)
+    -- do not let a pending signal handle keep the event loop alive
+    signal:unref()
+  end
+end
+
+uv.run()
+os.exit(exit_code)

--- a/lua/yazi/types.lua
+++ b/lua/yazi/types.lua
@@ -31,6 +31,7 @@
 ---@class(exact) yazi.OptInFeatures
 ---@field public use_cwd_file? boolean # use a file to store the last directory that yazi was in before it was closed. Defaults to `true`.
 ---@field public yazi_plugin_keymaps? YaziPluginKeymaps # keymaps that are registered *inside yazi* by the `nvim.yazi` plugin instead of as Neovim terminal-mode maps. yazi owns these keys, so they are automatically disabled while yazi is in an input mode (bulk rename, filter, find).
+---@field public use_local_events? boolean # read yazi's events from yazi itself (`yazi --local-events`) instead of from a separate `ya sub` process. `ya sub` can only connect to yazi *after* yazi has started, so events that happen in the first moments (a quick rename, for example) are lost. Defaults to `false`.
 
 ---@alias YaziKeymap string | false # `string` is a keybinding such as "<c-tab>", false means the keybinding is disabled
 

--- a/spec/yazi/local_events_server_spec.lua
+++ b/spec/yazi/local_events_server_spec.lua
@@ -1,0 +1,140 @@
+local assert = require("luassert")
+local stub = require("luassert.stub")
+local LocalEventServer =
+  require("yazi.process.event_source.local_events_server")
+
+---Connect to the server the way `local_events_wrapper.lua` does, and wait
+---until the connection is established.
+---@param port integer
+---@return uv.uv_tcp_t
+local function connect(port)
+  local client = assert(vim.uv.new_tcp())
+  local connected = false
+  client:connect("127.0.0.1", port, function(err)
+    assert(err == nil, tostring(err))
+    connected = true
+  end)
+  assert(
+    vim.wait(2000, function()
+      return connected
+    end),
+    "timed out connecting to the local event server"
+  )
+  return client
+end
+
+---@param received string[][]
+---@param count integer
+---@param timeout? integer # keep it short when asserting that nothing arrives
+local function wait_for_batches(received, count, timeout)
+  return vim.wait(timeout or 2000, function()
+    return #received >= count
+  end)
+end
+
+describe("the local event server", function()
+  ---@type yazi.LocalEventServer | nil
+  local server = nil
+
+  after_each(function()
+    if server ~= nil then
+      server:close()
+      server = nil
+    end
+  end)
+
+  it("reports why it could not be started", function()
+    -- libuv reports failures by returning nil plus a message. Make sure the
+    -- message is not swallowed, so that the fallback to `ya sub` can say why it
+    -- happened.
+    stub(vim.uv, "new_tcp", nil, "EMFILE: too many open files", "EMFILE")
+
+    local created, reason = LocalEventServer.start(function() end)
+
+    ---@diagnostic disable-next-line: undefined-field
+    vim.uv.new_tcp:revert()
+
+    assert.is_nil(created)
+    assert.is_not_nil(reason)
+    assert.is_truthy(
+      reason and reason:find("EMFILE: too many open files", 1, true),
+      string.format("expected the libuv reason in '%s'", tostring(reason))
+    )
+  end)
+
+  it("listens on a port on the loopback interface", function()
+    local created, reason = LocalEventServer.start(function() end)
+    server = created
+
+    assert.is_nil(reason)
+    assert.is_not_nil(server)
+    assert.is_true(server ~= nil and server.port > 0)
+  end)
+
+  it("hands over complete lines from a client that knows the token", function()
+    ---@type string[][]
+    local received = {}
+    local created = assert(LocalEventServer.start(function(lines)
+      received[#received + 1] = lines
+    end))
+    server = created
+
+    local client = connect(created.port)
+    client:write(created:get_token() .. "\n")
+    client:write('cd,1,1,{"tab":1}\nhover,1,1,{"tab":1}\n')
+
+    assert.is_true(wait_for_batches(received, 1))
+    assert.are.same({
+      { 'cd,1,1,{"tab":1}', 'hover,1,1,{"tab":1}' },
+    }, received)
+
+    client:close()
+  end)
+
+  it("waits for the rest of a line that arrived in pieces", function()
+    -- a TCP read can split an event anywhere, so a partial line must be held
+    -- back until its newline arrives
+    ---@type string[][]
+    local received = {}
+    local created = assert(LocalEventServer.start(function(lines)
+      received[#received + 1] = lines
+    end))
+    server = created
+
+    local client = connect(created.port)
+    client:write(created:get_token() .. "\n")
+    client:write('cd,1,1,{"tab"')
+
+    -- nothing is complete yet, so nothing may be handed over
+    assert.is_false(wait_for_batches(received, 1, 200))
+
+    client:write(':1}\ntrash,1,1,{"urls":[]}\n')
+
+    assert.is_true(wait_for_batches(received, 1))
+    assert.are.same({
+      { 'cd,1,1,{"tab":1}', 'trash,1,1,{"urls":[]}' },
+    }, received)
+
+    client:close()
+  end)
+
+  it("drops a client that presents the wrong token", function()
+    ---@type string[][]
+    local received = {}
+    local created = assert(LocalEventServer.start(function(lines)
+      received[#received + 1] = lines
+    end))
+    server = created
+
+    local client = connect(created.port)
+    client:write("not-the-token\n")
+    client:write('cd,1,1,{"tab":1}\n')
+
+    assert.is_false(wait_for_batches(received, 1, 200))
+    assert.are.same({}, received)
+
+    if not client:is_closing() then
+      client:close()
+    end
+  end)
+end)

--- a/spec/yazi/ya_process_spec.lua
+++ b/spec/yazi/ya_process_spec.lua
@@ -64,6 +64,48 @@ describe("the get_yazi_command() function", function()
     end
   )
 
+  it(
+    "asks yazi to report its own events when `use_local_events` is enabled",
+    function()
+      local config = require("yazi.config").default()
+      config.chosen_file_path = "/tmp/chosen_file_path"
+      config.cwd_file_path = "/tmp/cwd_file_path"
+      config.future_features.use_local_events = true
+
+      local ya = ya_process.new(config, yazi_id)
+
+      local command = ya:get_yazi_command({ { filename = "file1" } })
+
+      assert.are.same({
+        "yazi",
+        "file1",
+        "--chooser-file",
+        "/tmp/chosen_file_path",
+        "--client-id",
+        "yazi_id_123",
+        "--cwd-file",
+        "/tmp/cwd_file_path",
+        -- note that `hey` is missing: it is part of the `ya sub` handshake,
+        -- and yazi does not publish it as a local event
+        "--local-events=rename,delete,trash,move,cd,hover,bulk,bulk-rename,yazi-nvim,nvim-cycle-buffer",
+      }, command)
+    end
+  )
+
+  it("does not use `--local-events` by default", function()
+    local config = require("yazi.config").default()
+    config.chosen_file_path = "/tmp/chosen_file_path"
+    config.cwd_file_path = "/tmp/cwd_file_path"
+
+    local ya = ya_process.new(config, yazi_id)
+
+    local command = ya:get_yazi_command({ { filename = "file1" } })
+
+    for _, word in ipairs(command) do
+      assert.is_nil(word:match("^%-%-local%-events"))
+    end
+  end)
+
   it("doesn't open duplicate tabs", function()
     local config = require("yazi.config").default()
     config.open_multiple_tabs = true

--- a/yazi-plugin/nvim.yazi/publish.lua
+++ b/yazi-plugin/nvim.yazi/publish.lua
@@ -2,9 +2,24 @@
 
 local M = {}
 
--- Publish the DDS event for a keymap action, so yazi.nvim's `ya sub` receives
--- it. Then yazi.nvim can react to the action. This kind of design allows yazi
--- to own the keymaps, so that yazi.nvim doesn't have to guess when it should
+-- Send the event to yazi.nvim.
+--
+-- `ps.pub` publishes locally, which makes yazi report the event on its own
+-- stdout when it was started with `--local-events=yazi-nvim`. `ps.pub_to(0,
+-- ...)` instead broadcasts to *remote* peers only, which is what the separate
+-- `ya sub` process listens to.
+---@param payload table
+local function publish(payload)
+  if os.getenv("YAZI_NVIM_LOCAL_EVENTS") ~= nil then
+    ps.pub("yazi-nvim", payload)
+  else
+    ps.pub_to(0, "yazi-nvim", payload)
+  end
+end
+
+-- Publish the DDS event for a keymap action, so yazi.nvim receives it. Then
+-- yazi.nvim can react to the action. This kind of design allows yazi to own
+-- the keymaps, so that yazi.nvim doesn't have to guess when it should
 -- intercept them (e.g. when the user is in an input mode like bulk rename,
 -- filter, or find).
 M.keymap_event = ya.sync(function(_, action)
@@ -14,7 +29,7 @@ M.keymap_event = ya.sync(function(_, action)
   if action == "change_working_directory" then
     local cwd = cx.active.current.cwd
     assert(cwd, "expected to find the yazi cwd")
-    ps.pub_to(0, "yazi-nvim", {
+    publish({
       action = action,
       yazi_id = neovim_id,
       cwd = tostring(cwd),
@@ -27,7 +42,7 @@ M.keymap_event = ya.sync(function(_, action)
       selected[#selected + 1] = tostring(url)
     end
 
-    ps.pub_to(0, "yazi-nvim", {
+    publish({
       action = action,
       yazi_id = neovim_id,
       hovered = hovered and tostring(hovered.url) or nil,


### PR DESCRIPTION
# test: run all tests using `use_local_events=true`

# fix: dropping yazi events when ya is slow to start (opt-in)

Supersedes https://github.com/mikavilpas/yazi.nvim/pull/2057

Co-authored-by: Universal.Invariant <Invariant@mail.com>

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2085 👈🏻