### PR TITLE
test: miscellaneous improvements

### DIFF
--- a/integration-tests/cypress/e2e/opening-files.cy.ts
+++ b/integration-tests/cypress/e2e/opening-files.cy.ts
@@ -494,10 +494,12 @@ describe("opening files", () => {
   it("can open multiple files in a directory whose name contains a space character", () => {
     cy.startNeovim({
       filename: "dir with (parens ) and spaces/file1.txt",
+      startupScriptModifications: ["add_yazi_context_assertions.lua"],
     }).then(nvim => {
       cy.contains("this is the first file")
 
       cy.typeIntoTerminal("{upArrow}")
+      assertYaziIsReady(nvim)
       cy.contains(nvim.dir.contents["dir with (parens ) and spaces"].contents["file2.txt"].name)
 
       // select all files and open them

--- a/integration-tests/cypress/e2e/utils/yazi-utils.ts
+++ b/integration-tests/cypress/e2e/utils/yazi-utils.ts
@@ -31,6 +31,6 @@ export function findFileInYazi(filename: MyTestDirectoryFile): void {
   isFileFoundInYazi(filename)
 }
 
-export function assertYaziIsReady(nvim: NeovimContext): Cypress.Chainable<RunLuaCodeOutput> {
-  return nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()` })
+export function assertYaziIsReady(nvim: NeovimContext, timeoutMs?: number): Cypress.Chainable<RunLuaCodeOutput> {
+  return nvim.waitForLuaCode({ luaAssertion: `Yazi_is_ready()`, timeoutMs })
 }

--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -9,7 +9,7 @@ function M.reveal_path_and_wait_for_hover(path)
   local Log = require("yazi.log")
 
   ---@type YaziActiveContext | nil
-  local context = yazi.active_contexts:peek()
+  local context = yazi.active_contexts:current()
   if not context then
     error("No active yazi context found. Is yazi running?")
   end

--- a/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
+++ b/integration-tests/test-environment/config-modifications/add_command_to_reveal_a_file.lua
@@ -32,6 +32,27 @@ function M.reveal_path_and_wait_for_hover(path)
   -- retry it differs from `path` (otherwise we'd already be done).
   local attempts = 20
   local interval_ms = 150
+
+  -- `ya emit-to` can fail without yazi ever seeing the command, e.g. when the
+  -- DDS socket is gone ("Connection refused").
+  ---@type string | nil
+  local last_emit_error = nil
+
+  ---@param job vim.SystemObj
+  ---@param what string
+  local function reveal_and_check(job, what)
+    local result = job:wait(1000)
+    if result.code ~= 0 then
+      last_emit_error = string.format(
+        "revealing %s exited with code %s: '%s'",
+        what,
+        result.code,
+        vim.trim(result.stderr or "")
+      )
+      Log:debug("`ya emit-to` failed: " .. last_emit_error)
+    end
+  end
+
   for _ = 1, attempts do
     if context.ya_process.hovered_url == path then
       return
@@ -42,10 +63,13 @@ function M.reveal_path_and_wait_for_hover(path)
       -- Wait for the decoy reveal to be delivered before revealing the target,
       -- so yazi clearly processes them as two distinct moves rather than
       -- coalescing them into a single no-op cursor update.
-      context.api:reveal(decoy):wait(500)
+      reveal_and_check(
+        context.api:reveal(decoy),
+        string.format("the decoy '%s'", decoy)
+      )
     end
 
-    context.api:reveal(path)
+    reveal_and_check(context.api:reveal(path), string.format("'%s'", path))
     local hovered = vim.wait(interval_ms, function()
       return context.ya_process.hovered_url == path
     end, 20)
@@ -54,11 +78,19 @@ function M.reveal_path_and_wait_for_hover(path)
     end
   end
 
+  local reason = last_emit_error ~= nil
+      and string.format(
+        " The last `ya emit-to` failure was: %s",
+        last_emit_error
+      )
+    or " Every `ya emit-to` succeeded, so yazi received the reveals but never reported hovering the path."
+
   error(
     string.format(
-      "Timed out waiting for yazi to hover '%s'. Last hovered url: '%s'",
+      "Timed out waiting for yazi to hover '%s'. Last hovered url: '%s'.%s",
       path,
-      tostring(context.ya_process.hovered_url)
+      tostring(context.ya_process.hovered_url),
+      reason
     )
   )
 end

--- a/integration-tests/test-environment/config-modifications/add_yazi_context_assertions.lua
+++ b/integration-tests/test-environment/config-modifications/add_yazi_context_assertions.lua
@@ -2,14 +2,21 @@
 
 local yazi = require("yazi")
 
+---The yazi that was started most recently. Tests that open yazi more than once
+---must look at that one - an older context describes a yazi that has already
+---exited.
+---@return YaziActiveContext
+local function current_context()
+  return assert(
+    yazi.active_contexts:current(),
+    "No active context found. Is yazi running?."
+  )
+end
+
 -- selene: allow(unused_variable)
 ---@param path string
 function Yazi_is_hovering(path)
-  ---@type YaziActiveContext
-  local current = assert(
-    yazi.active_contexts:peek(),
-    "No active context found. Is yazi running?."
-  )
+  local current = current_context()
 
   local yazi_id = current.ya_process.yazi_id
   local hovered = current.ya_process.hovered_url
@@ -27,11 +34,21 @@ end
 
 -- selene: allow(unused_variable)
 function Yazi_is_ready()
-  ---@type YaziActiveContext
-  local current = assert(
-    yazi.active_contexts:peek(),
-    "No active context found. Is yazi running?."
-  )
-  local ready, details = current.ya_process:is_ready()
-  assert(ready, "Yazi is not ready yet. Details: " .. vim.inspect(details))
+  local current = current_context()
+
+  local ready = current.ya_process:is_ready()
+  if not ready then
+    local all_details = {}
+
+    for _, value in ipairs(yazi.active_contexts:all()) do
+      local _, details = value.ya_process:is_ready()
+      table.insert(all_details, details)
+    end
+
+    assert(
+      ready,
+      "Yazi is not ready yet. Details (newest first): "
+        .. vim.inspect(all_details)
+    )
+  end
 end

--- a/lua/yazi.lua
+++ b/lua/yazi.lua
@@ -1,5 +1,6 @@
 ---@module "plenary"
 
+local ActiveContexts = require("yazi.active_contexts")
 local configModule = require("yazi.config")
 
 local M = {}
@@ -10,7 +11,8 @@ M.version = "13.9.0" -- x-release-please-version
 ---@type YaziPreviousState
 M.previous_state = {}
 
-M.active_contexts = vim.ringbuf(2)
+-- The yazi instances that are currently running, newest first
+M.active_contexts = ActiveContexts.new(2)
 
 ---@alias yazi.Arguments {reveal_path: string}
 
@@ -76,7 +78,18 @@ function M.yazi(config, input_path, args)
         })
       end
     end,
-    on_exit = function(exit_code, selected_files, hovered_url, last_directory)
+    on_exit = function(
+      exit_code,
+      selected_files,
+      hovered_url,
+      last_directory,
+      context
+    )
+      -- this yazi is gone, so its context is no longer active. Remove it before
+      -- anything else, so that an unsuccessful exit cannot leave a dead context
+      -- behind either.
+      M.active_contexts:remove(context)
+
       if exit_code ~= 0 then
         print(
           "yazi.nvim: had trouble opening yazi. Run ':checkhealth yazi' for more information."

--- a/lua/yazi/active_contexts.lua
+++ b/lua/yazi/active_contexts.lua
@@ -1,0 +1,64 @@
+local Log = require("yazi.log")
+
+--- A bounded, newest-first record of the yazi instances that are running.
+---
+--- Holds at most `capacity` contexts. Pushing beyond that drops the oldest, so a
+--- context that is never removed (a missed `on_exit`) cannot accumulate.
+---
+---@class yazi.ActiveContexts
+---@field private items YaziActiveContext[] # newest first
+---@field private capacity integer
+local ActiveContexts = {}
+---@diagnostic disable-next-line: inject-field
+ActiveContexts.__index = ActiveContexts
+
+---@param capacity integer
+---@return yazi.ActiveContexts
+function ActiveContexts.new(capacity)
+  assert(capacity > 0, "capacity must be positive")
+  return setmetatable({ items = {}, capacity = capacity }, ActiveContexts)
+end
+
+---@param context YaziActiveContext
+function ActiveContexts:push(context)
+  table.insert(self.items, 1, context)
+
+  while #self.items > self.capacity do
+    local dropped = table.remove(self.items) -- the oldest
+    Log:debug(
+      string.format(
+        "Dropping the oldest active context (%s) to stay within the capacity of %d. It was never removed - did it fail to report exiting?",
+        dropped and dropped.ya_process:id() or "nil",
+        self.capacity
+      )
+    )
+  end
+end
+
+---The most recently started yazi, if any is running.
+---@return YaziActiveContext?
+function ActiveContexts:current()
+  return self.items[1]
+end
+
+---Every context still known, newest first. A copy, so that mutating the result
+---cannot affect the collection.
+---@return YaziActiveContext[]
+function ActiveContexts:all()
+  return vim.list_slice(self.items)
+end
+
+---@param context YaziActiveContext
+---@return boolean removed # false if the context was not (or no longer) known
+function ActiveContexts:remove(context)
+  for index, value in ipairs(self.items) do
+    if value == context then
+      table.remove(self.items, index)
+      return true
+    end
+  end
+
+  return false
+end
+
+return ActiveContexts

--- a/lua/yazi/log.lua
+++ b/lua/yazi/log.lua
@@ -70,4 +70,11 @@ function Log:debug(message)
   end
 end
 
+---@param message string
+function Log:error(message)
+  if self:active_for_level(log_levels.ERROR) then
+    self:write_message("ERROR", message)
+  end
+end
+
 return Log

--- a/lua/yazi/process/yazi_process_api.lua
+++ b/lua/yazi/process/yazi_process_api.lua
@@ -32,14 +32,29 @@ function YaziProcessApi:emit_to_yazi(args)
     { "ya", "emit-to", self.yazi_id, unpack(args) },
     { timeout = 1000 },
     function(result)
-      Log:debug(
-        string.format(
-          "emit_to_yazi: ya succeeded: 'ya emit-to %s' with args: '%s' and result '%s'",
-          self.yazi_id,
-          vim.inspect(args),
-          vim.inspect(result)
+      if result.code == 0 then
+        Log:debug(
+          string.format(
+            "emit_to_yazi: ya succeeded: 'ya emit-to %s' with args: '%s' and result '%s'",
+            self.yazi_id,
+            vim.inspect(args),
+            vim.inspect(result)
+          )
         )
-      )
+      else
+        -- The command never reached yazi. This happens e.g. when the DDS
+        -- socket is gone ("Connection refused"), so the caller's request was
+        -- silently dropped.
+        Log:error(
+          string.format(
+            "emit_to_yazi: ya failed with exit code %s: 'ya emit-to %s' with args: '%s' and stderr '%s'",
+            result.code,
+            self.yazi_id,
+            vim.inspect(args),
+            vim.trim(result.stderr or "")
+          )
+        )
+      end
     end
   )
 end

--- a/spec/yazi/active_contexts_spec.lua
+++ b/spec/yazi/active_contexts_spec.lua
@@ -1,0 +1,119 @@
+local assert = require("luassert")
+local ActiveContexts = require("yazi.active_contexts")
+
+---A stand-in for a real context. Only identity matters to ActiveContexts, but
+---the eviction logging reads `ya_process:id()`, so provide that much.
+---@param name string
+---@return YaziActiveContext
+local function context(name)
+  ---@diagnostic disable-next-line: missing-fields, return-type-mismatch
+  return {
+    ya_process = {
+      id = function()
+        return name
+      end,
+    },
+  }
+end
+
+describe("ActiveContexts", function()
+  it("has no current context when nothing has been pushed", function()
+    local contexts = ActiveContexts.new(2)
+
+    assert.is_nil(contexts:current())
+    assert.same({}, contexts:all())
+  end)
+
+  it("reports the most recently pushed context as the current one", function()
+    local contexts = ActiveContexts.new(2)
+    local first, second = context("first"), context("second")
+
+    contexts:push(first)
+    assert.equal(first, contexts:current())
+
+    contexts:push(second)
+    assert.equal(second, contexts:current())
+  end)
+
+  it("returns all known contexts, newest first", function()
+    local contexts = ActiveContexts.new(3)
+    local first, second, third =
+      context("first"), context("second"), context("third")
+
+    contexts:push(first)
+    contexts:push(second)
+    contexts:push(third)
+
+    assert.same({ third, second, first }, contexts:all())
+  end)
+
+  it("drops the oldest context when the capacity is exceeded", function()
+    local contexts = ActiveContexts.new(2)
+    local first, second, third =
+      context("first"), context("second"), context("third")
+
+    contexts:push(first)
+    contexts:push(second)
+    contexts:push(third)
+
+    assert.same({ third, second }, contexts:all())
+    assert.equal(third, contexts:current())
+  end)
+
+  it("does not let mutating the result of all() affect it", function()
+    local contexts = ActiveContexts.new(2)
+    local only = context("only")
+    contexts:push(only)
+
+    local items = contexts:all()
+    table.remove(items)
+
+    assert.same({ only }, contexts:all())
+  end)
+
+  describe("remove()", function()
+    it("removes the context, keeping the rest in order", function()
+      local contexts = ActiveContexts.new(3)
+      local first, second, third =
+        context("first"), context("second"), context("third")
+      contexts:push(first)
+      contexts:push(second)
+      contexts:push(third)
+
+      assert.is_true(contexts:remove(second))
+
+      assert.same({ third, first }, contexts:all())
+    end)
+
+    it("makes the previous context current again", function()
+      local contexts = ActiveContexts.new(2)
+      local first, second = context("first"), context("second")
+      contexts:push(first)
+      contexts:push(second)
+
+      assert.is_true(contexts:remove(second))
+
+      assert.equal(first, contexts:current())
+    end)
+
+    it("reports removing an unknown context as a no-op", function()
+      local contexts = ActiveContexts.new(2)
+      local only = context("only")
+      contexts:push(only)
+
+      assert.is_false(contexts:remove(context("never pushed")))
+      assert.same({ only }, contexts:all())
+    end)
+
+    it("is safe to remove the same context twice", function()
+      local contexts = ActiveContexts.new(2)
+      local only = context("only")
+      contexts:push(only)
+
+      assert.is_true(contexts:remove(only))
+      assert.is_false(contexts:remove(only))
+
+      assert.same({}, contexts:all())
+    end)
+  end)
+end)

--- a/spec/yazi/lazy_loading_spec.lua
+++ b/spec/yazi/lazy_loading_spec.lua
@@ -31,6 +31,7 @@ describe("lazy loading", function()
     table.sort(yazi_modules)
     assert.are.same(yazi_modules, {
       "yazi",
+      "yazi.active_contexts",
       "yazi.config",
       "yazi.log",
       "yazi.openers",


### PR DESCRIPTION
# test: reveal_path_and_wait_for_hover() helper fails on dds failures

# test: reduce flakiness a bit

# test: make sure active_contexts are provided in order

**Issue:**

I had previously thought a ringbuffer is basically a stack. I just realized it's a first-in-first-out queue instead, and currently does not report the correct "current" context when a second yazi has been started.

**Solution:**

Create a bounded stack of active contexts, newest first. Use that instead.

# test: allow customizing timeout for assertYaziIsReady()

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2088 👈🏻
  - https://github.com/mikavilpas/yazi.nvim/pull/2084
    - https://github.com/mikavilpas/yazi.nvim/pull/2085