### PR TITLE
fix: renaming to the same filename closes the nvim buffer

### DIFF
--- a/lua/yazi/event_handling/yazi_event_handling.lua
+++ b/lua/yazi/event_handling/yazi_event_handling.lua
@@ -41,7 +41,10 @@ function M.get_buffers_that_need_renaming_after_yazi_exited(
 
   local event = rename_or_move_event
   for _, buffer in ipairs(open_buffers) do
-    if buffer:matches_exactly(event.from) then
+    -- selene: allow(empty_if)
+    if buffer:is_same(event.to) then
+      -- do nothing, the buffer is already open with the new name
+    elseif buffer:matches_exactly(event.from) then
       buffer:rename(event.to)
       renamed_buffers[buffer.bufnr] = buffer
     elseif buffer:matches_parent(event.from) then

--- a/lua/yazi/renameable_buffer.lua
+++ b/lua/yazi/renameable_buffer.lua
@@ -43,6 +43,12 @@ end
 
 ---@param path string
 ---@return boolean
+function RenameableBuffer:is_same(path)
+  return self.path.filename == path
+end
+
+---@param path string
+---@return boolean
 function RenameableBuffer:matches_parent(path)
   path = remove_trailing_slash(path)
   for _, parent in ipairs(self.path:parents()) do

--- a/spec/yazi/move_spec.lua
+++ b/spec/yazi/move_spec.lua
@@ -31,6 +31,22 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     assert.is_number(result1.bufnr)
   end)
 
+  it("skips renaming to the same filename", function()
+    local path = "/my-tmp/file1"
+    ---@type YaziEventDataRenameOrMove
+    local move_event = {
+      from = path,
+      to = path,
+    }
+
+    local instructions =
+      yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
+        move_event
+      )
+
+    assert.equal(vim.tbl_count(instructions), 0)
+  end)
+
   it(
     "can detect moves to buffers open in a directory that was moved",
     function()

--- a/spec/yazi/rename_spec.lua
+++ b/spec/yazi/rename_spec.lua
@@ -32,6 +32,22 @@ describe("get_buffers_that_need_renaming_after_yazi_exited", function()
     assert.is_number(result1.bufnr)
   end)
 
+  it("skips renaming to the same filename", function()
+    local path = "/my-tmp/file1"
+    ---@type YaziEventDataRenameOrMove
+    local rename_event = {
+      from = path,
+      to = path,
+    }
+
+    local rename_instructions =
+      yazi_event_handling.get_buffers_that_need_renaming_after_yazi_exited(
+        rename_event
+      )
+
+    assert.equal(vim.tbl_count(rename_instructions), 0)
+  end)
+
   it(
     "can detect renames to buffers open in a directory that was renamed",
     function()


### PR DESCRIPTION
# fix: renaming to the same filename closes the nvim buffer

Fixes: https://github.com/mikavilpas/yazi.nvim/issues/2100

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2117 👈🏻