### PR TITLE
ci!: drop support for yazi v26.1.4, add new stable v26.8.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,12 +88,12 @@ jobs:
             method: download
             # renovate: datasource=github-releases depName=sxyazi/yazi
             version: v26.8.15
+          - name: v26.5.6
+            method: download
+            version: v26.5.6
           - name: v26.1.22
             method: download
             version: v26.1.22
-          - name: v26.1.4
-            method: download
-            version: v26.1.4
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# ci!: drop support for yazi v26.1.4, add new stable v26.8.15

This means official support for yazi v26.1.4 is dropped. It might still work for some time, but you are encouraged to upgrade.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2120 👈🏻