### PR TITLE
chore: update yazi stable and nightly versions in their own groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,18 @@
     {
       "matchDepNames": ["lua"],
       "allowedVersions": "<=5.1"
+    },
+    {
+      "description": ["Update yazi stable versions in their own group."],
+      "matchPackageNames": ["sxyazi/yazi"],
+      "matchDatasources": ["github-releases"],
+      "groupName": "yazi-stable"
+    },
+    {
+      "description": ["Update yazi nightly versions in their own group."],
+      "matchPackageNames": ["https://github.com/sxyazi/yazi"],
+      "matchDatasources": ["git-refs"],
+      "groupName": "yazi-nightly"
     }
   ]
 }


### PR DESCRIPTION
# chore: update yazi stable and nightly versions in their own groups

**Issue:**

https://github.com/mikavilpas/yazi.nvim/pull/2148 has been pending for a week due to some inconsistency in the recently released yazi v26.9.1 and yazi.nvim.

The update needs more looking into to make it compatible. However, in the meantime we should not be blocking all other updates.

**Solution:**

Add a separate renovate update group for yazi stable and nightly versions so they stop blocking other updates.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/yazi.nvim/pull/2157 👈🏻